### PR TITLE
#16 follow-up: test consolidation, flaky backoff fix, pipeline cleanup

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,9 +66,7 @@ jobs:
     # Tests can only run on native targets, not cross-compilation targets like aarch64-apple-darwin
     - name: Run tests
       if: matrix.sys.target != 'aarch64-apple-darwin'
-      # Skip wall-clock timing tests — flaky under CI CPU contention.
-      # See docs/backoff-timing-test-flakiness.md
-      run: cargo test --target ${{ matrix.sys.target }} -- --skip test_exponential_backoff_timing
+      run: cargo test --target ${{ matrix.sys.target }}
 
   publish-dry-run:
     if: github.event_name == 'push' || startsWith(github.head_ref, 'release/')

--- a/src/mirror_operation.rs
+++ b/src/mirror_operation.rs
@@ -520,7 +520,7 @@ impl Operation for MirrorOperation {
         Ok(())
     }
 
-    fn checkpoint_complete(&self, checkpoint: u32) {
+    fn finalize_checkpoint(&self, checkpoint: u32) {
         if let Some(ref manager) = self.verification_manager {
             manager.verify_and_release(checkpoint);
         }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -216,6 +216,34 @@ impl<Op: Operation> Pipeline<Op> {
         self.operation.finalize_checkpoint(checkpoint);
     }
 
+    /// Run an async operation with retries and exponential backoff.
+    ///
+    /// Creates a per-call `RetryState`, retries on transient errors, and returns
+    /// `Ok(T)` on success or the final `Err` when retries are exhausted.
+    async fn with_retries<T>(
+        &self,
+        path: &str,
+        action: &str,
+        mut f: impl AsyncFnMut() -> Result<T, crate::storage::Error>,
+    ) -> Result<T, crate::storage::Error> {
+        let mut retry = RetryState::new(
+            self.config.storage_config.max_retries as u32,
+            self.config.storage_config.retry_min_delay.as_millis() as u64,
+        );
+        loop {
+            match f().await {
+                Ok(val) => return Ok(val),
+                Err(e) => {
+                    if retry.should_retry(&e, action, path) {
+                        retry.backoff().await;
+                        continue;
+                    }
+                    return Err(e);
+                }
+            }
+        }
+    }
+
     /// Process a history file for a checkpoint.
     /// Downloads and parses the history JSON, then processes buckets.
     /// Retries are handled at this level to avoid file corruption from partial streams.
@@ -224,18 +252,10 @@ impl<Op: Operation> Pipeline<Op> {
 
         let history_path = checkpoint_path("history", checkpoint);
 
-        // Retry state for downloading the history file
-        let mut retry_state = RetryState::new(
-            self.config.storage_config.max_retries as u32,
-            self.config.storage_config.retry_min_delay.as_millis() as u64,
-        );
-
-        // Download the history file with retries at this level
-        // Use into_stream to handle chunked transfer encoding properly
-        let buffer = loop {
-            let download_result: Result<Buffer, crate::storage::Error> = async {
+        // Download the history file with retries
+        let buffer = match self
+            .with_retries(&history_path, "download history", async || {
                 let reader = self.src_store.open_reader(&history_path).await?;
-                // Convert to stream and collect all chunks into a single buffer
                 let stream = reader
                     .into_stream(..)
                     .await
@@ -244,22 +264,15 @@ impl<Op: Operation> Pipeline<Op> {
                     .try_collect()
                     .await
                     .map_err(|e| crate::storage::from_opendal_error(e, "Read error"))?;
-                // Merge chunks into a single buffer
                 let buffer: Buffer = chunks.into_iter().flatten().collect();
                 Ok(buffer)
-            }
-            .await;
-
-            match download_result {
-                Ok(buf) => break buf,
-                Err(e) => {
-                    if retry_state.should_retry(&e, "download history file", &history_path) {
-                        retry_state.backoff().await;
-                        continue;
-                    }
-                    self.operation.record_failure(&history_path).await;
-                    return;
-                }
+            })
+            .await
+        {
+            Ok(buf) => buf,
+            Err(_) => {
+                self.operation.record_failure(&history_path).await;
+                return;
             }
         };
 
@@ -328,75 +341,39 @@ impl<Op: Operation> Pipeline<Op> {
                 Ok(()) => {
                     debug!("Skipping: {}", path);
                     self.operation.record_skipped(&path);
-                    return;
                 }
                 Err(e) => {
                     error!("Pre-check failed for {}: {}", path, e);
                     self.operation.record_failure(&path).await;
-                    return;
                 }
             }
+            return;
         }
 
-        let mut retry_state = RetryState::new(
-            self.config.storage_config.max_retries as u32,
-            self.config.storage_config.retry_min_delay.as_millis() as u64,
-        );
-
-        // For existence-only checks, we don't need to open a reader or call process_object
-        if self.operation.existence_check_only() {
-            loop {
-                match self.src_store.exists(&path).await {
-                    Ok(true) => {
-                        debug!("Exists: {}", path);
-                        self.operation.record_success(&path);
-                        return;
-                    }
-                    Ok(false) => {
-                        error!("File not found: {}", path);
-                        self.operation.record_failure(&path).await;
-                        return;
-                    }
-                    Err(e) => {
-                        if retry_state.should_retry(&e, "check existence of", &path) {
-                            retry_state.backoff().await;
-                            continue;
-                        }
-                        self.operation.record_failure(&path).await;
-                        return;
-                    }
+        let result = if self.operation.existence_check_only() {
+            self.with_retries(&path, "check existence of", async || {
+                if self.src_store.exists(&path).await? {
+                    Ok(())
+                } else {
+                    Err(crate::storage::Error::not_found())
                 }
+            })
+            .await
+        } else {
+            self.with_retries(&path, "process", async || {
+                let reader = self.src_store.open_reader(&path).await?;
+                self.operation.process_object(&path, reader).await
+            })
+            .await
+        };
+
+        match result {
+            Ok(()) => {
+                debug!("Processed: {}", path);
+                self.operation.record_success(&path);
             }
-        }
-
-        loop {
-            let reader = match self.src_store.open_reader(&path).await {
-                Ok(reader) => reader,
-                Err(e) => {
-                    if retry_state.should_retry(&e, "open reader for", &path) {
-                        retry_state.backoff().await;
-                        continue;
-                    }
-                    self.operation.record_failure(&path).await;
-                    return;
-                }
-            };
-
-            // Process the file - process_object cleans up partial files on error
-            match self.operation.process_object(&path, reader).await {
-                Ok(()) => {
-                    debug!("Processed: {}", path);
-                    self.operation.record_success(&path);
-                    return;
-                }
-                Err(e) => {
-                    if retry_state.should_retry(&e, "process", &path) {
-                        retry_state.backoff().await;
-                        continue;
-                    }
-                    self.operation.record_failure(&path).await;
-                    return;
-                }
+            Err(_) => {
+                self.operation.record_failure(&path).await;
             }
         }
     }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -253,7 +253,7 @@ impl<Op: Operation> Pipeline<Op> {
         let history_path = checkpoint_path("history", checkpoint);
 
         // Download the history file with retries
-        let buffer = match self
+        let Ok(buffer) = self
             .with_retries(&history_path, "download history", async || {
                 let reader = self.src_store.open_reader(&history_path).await?;
                 let stream = reader
@@ -268,12 +268,9 @@ impl<Op: Operation> Pipeline<Op> {
                 Ok(buffer)
             })
             .await
-        {
-            Ok(buf) => buf,
-            Err(_) => {
-                self.operation.record_failure(&history_path).await;
-                return;
-            }
+        else {
+            self.operation.record_failure(&history_path).await;
+            return;
         };
 
         // Parse and validate

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -102,7 +102,7 @@ pub trait Operation: Send + Sync + 'static {
     /// Called when all files for a checkpoint have been processed.
     /// This is the hook for per-checkpoint verification to trigger
     /// and release memory for the completed checkpoint.
-    fn checkpoint_complete(&self, _checkpoint: u32) {
+    fn finalize_checkpoint(&self, _checkpoint: u32) {
         // No-op by default
     }
 }
@@ -213,7 +213,7 @@ impl<Op: Operation> Pipeline<Op> {
         }
 
         // Notify operation that all files for this checkpoint are processed
-        self.operation.checkpoint_complete(checkpoint);
+        self.operation.finalize_checkpoint(checkpoint);
     }
 
     /// Process a history file for a checkpoint.

--- a/src/scan_operation.rs
+++ b/src/scan_operation.rs
@@ -181,7 +181,7 @@ impl Operation for ScanOperation {
         self.verification_manager.is_none()
     }
 
-    fn checkpoint_complete(&self, checkpoint: u32) {
+    fn finalize_checkpoint(&self, checkpoint: u32) {
         if let Some(ref manager) = self.verification_manager {
             manager.verify_and_release(checkpoint);
         }

--- a/src/tests/http_retry_test.rs
+++ b/src/tests/http_retry_test.rs
@@ -230,16 +230,20 @@ async fn test_retries_on_connection_drops(
     );
 }
 
-/// Tests that retry delays follow exponential backoff pattern.
-/// Skipped in CI — wall-clock timing assertions are flaky under CPU contention.
-/// See docs/backoff-timing-test-flakiness.md for details.
+/// Tests that retry delays follow the exponential backoff pattern.
+///
+/// Uses a virtual clock (task-local override) to record intended sleep durations
+/// deterministically, avoiding the wall-clock flakiness caused by OS scheduler
+/// latency under CI CPU contention. See docs/backoff-timing-test-flakiness.md.
 #[rstest]
 #[case::one_failure(1)]
 #[case::two_failures(2)]
 #[case::three_failures(3)]
 #[tokio::test]
 async fn test_exponential_backoff_timing(#[case] fail_count: usize) {
+    use super::utils::{VirtualClock, CLOCK_OVERRIDE};
     use crate::storage::StorageConfig;
+    use std::sync::Arc;
     use std::time::Duration;
 
     let archive_path = test_archive_path();
@@ -248,9 +252,11 @@ async fn test_exponential_backoff_timing(#[case] fail_count: usize) {
     let config = FlakyServerConfig::archive_status_error(archive_path, 503, fail_count, "bucket/");
     let (server_url, tracker, handle) = start_flaky_server(config).await;
 
+    let virtual_clock = Arc::new(VirtualClock::new());
+
     let storage_config = StorageConfig::new(
         3,
-        Duration::from_secs(1), // Use large timeout values so jitter doesn't affect unit tests.
+        Duration::from_secs(1), // initial backoff = 1000ms
         Duration::from_secs(30),
         64,
         Duration::from_secs(30),
@@ -260,15 +266,18 @@ async fn test_exponential_backoff_timing(#[case] fail_count: usize) {
     );
 
     let dest_dir = TempDir::new().unwrap();
-    let result = run_mirror(
-        MirrorConfig::new(&server_url, file_url_from_path(dest_dir.path()))
-            .skip_optional()
-            .concurrency(1)
-            .low(PUBNET_CHECKPOINT_LOW)
-            .high(PUBNET_CHECKPOINT_HIGH)
-            .storage_config(storage_config),
-    )
-    .await;
+    let mirror_config = MirrorConfig::new(&server_url, file_url_from_path(dest_dir.path()))
+        .skip_optional()
+        .concurrency(1)
+        .low(PUBNET_CHECKPOINT_LOW)
+        .high(PUBNET_CHECKPOINT_HIGH)
+        .storage_config(storage_config);
+
+    // Run mirror inside a virtual clock scope — RetryState::backoff() will
+    // record intended durations instead of sleeping.
+    let result = CLOCK_OVERRIDE
+        .scope(virtual_clock.clone(), run_mirror(mirror_config))
+        .await;
     handle.abort();
 
     assert!(
@@ -278,14 +287,15 @@ async fn test_exponential_backoff_timing(#[case] fail_count: usize) {
         result.err()
     );
 
+    // Verify retries occurred at the server level
     let counts = tracker.get_counts();
-    let retried_paths: Vec<_> = counts
+    let num_retried_paths = counts
         .iter()
         .filter(|(path, count)| path.starts_with("bucket/") && **count == fail_count + 1)
-        .collect();
+        .count();
 
     assert!(
-        !retried_paths.is_empty(),
+        num_retried_paths > 0,
         "Expected at least one bucket file to be retried {} times, got counts: {:?}",
         fail_count,
         counts
@@ -294,11 +304,20 @@ async fn test_exponential_backoff_timing(#[case] fail_count: usize) {
             .collect::<Vec<_>>()
     );
 
-    for (path, _) in &retried_paths {
-        if let Err(e) = tracker.verify_backoff_timing(path, 1000, 200, 700) {
-            panic!("Exponential backoff failed for {path} with {fail_count} failures: {e}");
-        }
+    // Verify backoff durations recorded by the virtual clock.
+    // Each retried path independently sleeps [1s, 2s, 4s, ...] (capped at 5s).
+    // Sorted, that's num_retried_paths copies of each level in ascending order.
+    let mut sorted_sleeps = virtual_clock.recorded_sleeps();
+    sorted_sleeps.sort();
+
+    let mut expected = vec![];
+    let mut ms = 1000u64;
+    for _ in 0..fail_count {
+        expected.extend(std::iter::repeat_n(Duration::from_millis(ms), num_retried_paths));
+        ms = (ms * 2).min(5000);
     }
+
+    assert_eq!(sorted_sleeps, expected, "backoff sleeps should follow exponential pattern");
 }
 
 //=============================================================================

--- a/src/tests/http_retry_test.rs
+++ b/src/tests/http_retry_test.rs
@@ -313,11 +313,17 @@ async fn test_exponential_backoff_timing(#[case] fail_count: usize) {
     let mut expected = vec![];
     let mut ms = 1000u64;
     for _ in 0..fail_count {
-        expected.extend(std::iter::repeat_n(Duration::from_millis(ms), num_retried_paths));
+        expected.extend(std::iter::repeat_n(
+            Duration::from_millis(ms),
+            num_retried_paths,
+        ));
         ms = (ms * 2).min(5000);
     }
 
-    assert_eq!(sorted_sleeps, expected, "backoff sleeps should follow exponential pattern");
+    assert_eq!(
+        sorted_sleeps, expected,
+        "backoff sleeps should follow exponential pattern"
+    );
 }
 
 //=============================================================================

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -11,7 +11,7 @@ mod path_normalization_test;
 #[cfg(test)]
 mod scan_op_test;
 #[cfg(test)]
-mod utils;
+pub(crate) mod utils;
 #[cfg(test)]
 mod verify_test;
 #[cfg(test)]

--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -245,72 +245,6 @@ impl RequestTracker {
         self.counts.lock().unwrap().clone()
     }
 
-    pub fn get_timestamps(&self, path: &str) -> Vec<Instant> {
-        self.timestamps
-            .lock()
-            .unwrap()
-            .get(path)
-            .cloned()
-            .unwrap_or_default()
-    }
-
-    /// Verify that retry delays follow exponential backoff pattern.
-    /// Returns Ok if delays are within tolerance, Err with details otherwise.
-    ///
-    /// Expected backoff starts at `initial_backoff_ms`, doubles after each retry, and caps at
-    /// 5000ms. Separate lower and upper tolerances let tests keep a strict minimum delay while
-    /// tolerating scheduler and request overhead on busy machines.
-    pub fn verify_backoff_timing(
-        &self,
-        path: &str,
-        initial_backoff_ms: u64,
-        lower_tolerance_ms: u64,
-        upper_tolerance_ms: u64,
-    ) -> Result<(), String> {
-        let timestamps = self.get_timestamps(path);
-        if timestamps.len() < 2 {
-            return Ok(()); // No retries, nothing to verify
-        }
-
-        let mut expected_backoff_ms = initial_backoff_ms;
-        for i in 1..timestamps.len() {
-            let actual_delay = timestamps[i].duration_since(timestamps[i - 1]);
-            let actual_ms = actual_delay.as_millis() as u64;
-            let min_expected = expected_backoff_ms.saturating_sub(lower_tolerance_ms);
-            let max_expected = expected_backoff_ms + upper_tolerance_ms;
-
-            if actual_ms < min_expected {
-                return Err(format!(
-                    "Retry {} -> {}: delay {}ms is below minimum {}ms (expected ~{}ms -{}ms/+{}ms)",
-                    i,
-                    i + 1,
-                    actual_ms,
-                    min_expected,
-                    expected_backoff_ms,
-                    lower_tolerance_ms,
-                    upper_tolerance_ms
-                ));
-            }
-
-            if actual_ms > max_expected {
-                return Err(format!(
-                    "Retry {} -> {}: delay {}ms exceeds maximum {}ms (expected ~{}ms -{}ms/+{}ms)",
-                    i,
-                    i + 1,
-                    actual_ms,
-                    max_expected,
-                    expected_backoff_ms,
-                    lower_tolerance_ms,
-                    upper_tolerance_ms
-                ));
-            }
-
-            // Advance expected backoff (doubles, capped at 5000ms)
-            expected_backoff_ms = (expected_backoff_ms * 2).min(5000);
-        }
-
-        Ok(())
-    }
 }
 
 impl Default for RequestTracker {
@@ -318,6 +252,44 @@ impl Default for RequestTracker {
         Self::new()
     }
 }
+
+//=============================================================================
+// Virtual Clock
+//=============================================================================
+
+/// Records intended sleep durations without real delays.
+/// Used with the `CLOCK_OVERRIDE` task-local to make backoff timing tests
+/// deterministic regardless of CPU contention.
+pub struct VirtualClock {
+    sleeps: Mutex<Vec<std::time::Duration>>,
+}
+
+impl VirtualClock {
+    pub fn new() -> Self {
+        Self {
+            sleeps: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub fn recorded_sleeps(&self) -> Vec<std::time::Duration> {
+        self.sleeps.lock().unwrap().clone()
+    }
+
+    pub async fn sleep(&self, duration: std::time::Duration) {
+        self.sleeps.lock().unwrap().push(duration);
+        tokio::task::yield_now().await;
+    }
+}
+
+tokio::task_local! {
+    /// Task-local virtual clock override for `RetryState::backoff()`.
+    /// Set via `CLOCK_OVERRIDE.scope(virtual_clock, future)` in tests.
+    pub static CLOCK_OVERRIDE: Arc<VirtualClock>;
+}
+
+//=============================================================================
+// Flaky Server
+//=============================================================================
 
 /// Start a flaky HTTP server with configurable failure modes
 pub async fn start_flaky_server(

--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -244,7 +244,6 @@ impl RequestTracker {
     pub fn get_counts(&self) -> HashMap<String, usize> {
         self.counts.lock().unwrap().clone()
     }
-
 }
 
 impl Default for RequestTracker {

--- a/src/tests/xdr_verification_e2e_test.rs
+++ b/src/tests/xdr_verification_e2e_test.rs
@@ -434,116 +434,49 @@ async fn test_mirror_verify_valid_archive(#[case] archive_type: ArchiveType) {
 }
 
 //=============================================================================
-// Ledger File Corruption Tests
+// XDR File Corruption Tests (Scan)
 //
-// Ledger files (ledger-*.xdr.gz) are the foundation of archive verification:
-//   - Contain LedgerHeaderHistoryEntry records with hash chain
-//   - Store expected hashes for transaction and result files
-//   - Must be parseable for any verification to proceed
-//
-// Corruption methods tested:
-//   - InvalidGzip: File isn't valid gzip (download truncation, storage error)
-//   - WrongContent: Valid gzip but wrong XDR content (file swap, mismatch)
-//   - FlippedBytes: Valid structure but corrupted bytes (bit rot, tampering)
+// Tests that --verify detects corruption across all XDR file types (ledger,
+// transactions, results) and all corruption methods (InvalidGzip, WrongContent,
+// FlippedBytes) for both archive formats.
 //=============================================================================
 
-// Verifies --verify detects various types of ledger file corruption.
 #[rstest]
-#[case::pubnet_invalid_gzip(ArchiveType::PubnetOldTxset, CorruptionMethod::InvalidGzip)]
-#[case::pubnet_wrong_content(ArchiveType::PubnetOldTxset, CorruptionMethod::WrongContent)]
-#[case::pubnet_flipped_bytes(ArchiveType::PubnetOldTxset, CorruptionMethod::FlippedBytes)]
-#[case::testnet_invalid_gzip(ArchiveType::TestnetSmall, CorruptionMethod::InvalidGzip)]
-#[case::testnet_wrong_content(ArchiveType::TestnetSmall, CorruptionMethod::WrongContent)]
-#[case::testnet_flipped_bytes(ArchiveType::TestnetSmall, CorruptionMethod::FlippedBytes)]
+#[case::pubnet_ledger_invalid_gzip(ArchiveType::PubnetOldTxset, XdrFileType::Ledger, CorruptionMethod::InvalidGzip)]
+#[case::pubnet_ledger_wrong_content(ArchiveType::PubnetOldTxset, XdrFileType::Ledger, CorruptionMethod::WrongContent)]
+#[case::pubnet_ledger_flipped_bytes(ArchiveType::PubnetOldTxset, XdrFileType::Ledger, CorruptionMethod::FlippedBytes)]
+#[case::pubnet_transactions_invalid_gzip(ArchiveType::PubnetOldTxset, XdrFileType::Transactions, CorruptionMethod::InvalidGzip)]
+#[case::pubnet_transactions_wrong_content(ArchiveType::PubnetOldTxset, XdrFileType::Transactions, CorruptionMethod::WrongContent)]
+#[case::pubnet_transactions_flipped_bytes(ArchiveType::PubnetOldTxset, XdrFileType::Transactions, CorruptionMethod::FlippedBytes)]
+#[case::pubnet_results_invalid_gzip(ArchiveType::PubnetOldTxset, XdrFileType::Results, CorruptionMethod::InvalidGzip)]
+#[case::pubnet_results_wrong_content(ArchiveType::PubnetOldTxset, XdrFileType::Results, CorruptionMethod::WrongContent)]
+#[case::pubnet_results_flipped_bytes(ArchiveType::PubnetOldTxset, XdrFileType::Results, CorruptionMethod::FlippedBytes)]
+#[case::testnet_ledger_invalid_gzip(ArchiveType::TestnetSmall, XdrFileType::Ledger, CorruptionMethod::InvalidGzip)]
+#[case::testnet_ledger_wrong_content(ArchiveType::TestnetSmall, XdrFileType::Ledger, CorruptionMethod::WrongContent)]
+#[case::testnet_ledger_flipped_bytes(ArchiveType::TestnetSmall, XdrFileType::Ledger, CorruptionMethod::FlippedBytes)]
+#[case::testnet_transactions_invalid_gzip(ArchiveType::TestnetSmall, XdrFileType::Transactions, CorruptionMethod::InvalidGzip)]
+#[case::testnet_transactions_wrong_content(ArchiveType::TestnetSmall, XdrFileType::Transactions, CorruptionMethod::WrongContent)]
+#[case::testnet_transactions_flipped_bytes(ArchiveType::TestnetSmall, XdrFileType::Transactions, CorruptionMethod::FlippedBytes)]
+#[case::testnet_results_invalid_gzip(ArchiveType::TestnetSmall, XdrFileType::Results, CorruptionMethod::InvalidGzip)]
+#[case::testnet_results_wrong_content(ArchiveType::TestnetSmall, XdrFileType::Results, CorruptionMethod::WrongContent)]
+#[case::testnet_results_flipped_bytes(ArchiveType::TestnetSmall, XdrFileType::Results, CorruptionMethod::FlippedBytes)]
 #[tokio::test]
-async fn test_scan_verify_detects_corrupt_ledger(
+async fn test_scan_verify_detects_corrupt_xdr(
     #[case] archive_type: ArchiveType,
+    #[case] file_type: XdrFileType,
     #[case] corruption: CorruptionMethod,
 ) {
     let (_temp_dir, archive_path) =
-        setup_corrupted_xdr_archive(archive_type, XdrFileType::Ledger, corruption);
+        setup_corrupted_xdr_archive(archive_type, file_type, corruption);
     let archive_url = format!("file://{}", archive_path.display());
 
     let result = run_scan(configure_scan(&archive_url, archive_type, true, true)).await;
 
     assert!(
         result.is_err(),
-        "Scan --verify should fail on {} ledger corruption ({}) but succeeded",
+        "Scan --verify should fail on {} {} corruption ({}) but succeeded",
         archive_type.name(),
-        corruption.name()
-    );
-}
-
-//=============================================================================
-// Transactions File Corruption Tests
-//
-// Transaction files (transactions-*.xdr.gz) contain TransactionHistoryEntry records.
-// Each entry has a transaction set whose hash must match the ledger header's tx_set_hash.
-// Corruption here is detected via:
-//   - Parse failure (InvalidGzip, WrongContent)
-//   - Hash mismatch (FlippedBytes changes computed hash, won't match ledger header)
-//=============================================================================
-
-// Verifies --verify detects various types of transaction file corruption.
-#[rstest]
-#[case::pubnet_invalid_gzip(ArchiveType::PubnetOldTxset, CorruptionMethod::InvalidGzip)]
-#[case::pubnet_wrong_content(ArchiveType::PubnetOldTxset, CorruptionMethod::WrongContent)]
-#[case::pubnet_flipped_bytes(ArchiveType::PubnetOldTxset, CorruptionMethod::FlippedBytes)]
-#[case::testnet_invalid_gzip(ArchiveType::TestnetSmall, CorruptionMethod::InvalidGzip)]
-#[case::testnet_wrong_content(ArchiveType::TestnetSmall, CorruptionMethod::WrongContent)]
-#[case::testnet_flipped_bytes(ArchiveType::TestnetSmall, CorruptionMethod::FlippedBytes)]
-#[tokio::test]
-async fn test_scan_verify_detects_corrupt_transactions(
-    #[case] archive_type: ArchiveType,
-    #[case] corruption: CorruptionMethod,
-) {
-    let (_temp_dir, archive_path) =
-        setup_corrupted_xdr_archive(archive_type, XdrFileType::Transactions, corruption);
-    let archive_url = format!("file://{}", archive_path.display());
-
-    let result = run_scan(configure_scan(&archive_url, archive_type, true, true)).await;
-
-    assert!(
-        result.is_err(),
-        "Scan --verify should fail on {} transactions corruption ({}) but succeeded",
-        archive_type.name(),
-        corruption.name()
-    );
-}
-
-//=============================================================================
-// Results File Corruption Tests
-//
-// Result files (results-*.xdr.gz) contain TransactionHistoryResultEntry records.
-// Each entry has a result set whose hash must match the ledger header's tx_set_result_hash.
-// Same corruption detection mechanisms as transaction files:
-//   - Parse failure catches structural corruption
-//   - Hash mismatch catches content corruption
-//=============================================================================
-
-// Verifies --verify detects various types of result file corruption.
-#[rstest]
-#[case::pubnet_invalid_gzip(ArchiveType::PubnetOldTxset, CorruptionMethod::InvalidGzip)]
-#[case::pubnet_wrong_content(ArchiveType::PubnetOldTxset, CorruptionMethod::WrongContent)]
-#[case::pubnet_flipped_bytes(ArchiveType::PubnetOldTxset, CorruptionMethod::FlippedBytes)]
-#[case::testnet_invalid_gzip(ArchiveType::TestnetSmall, CorruptionMethod::InvalidGzip)]
-#[case::testnet_wrong_content(ArchiveType::TestnetSmall, CorruptionMethod::WrongContent)]
-#[case::testnet_flipped_bytes(ArchiveType::TestnetSmall, CorruptionMethod::FlippedBytes)]
-#[tokio::test]
-async fn test_scan_verify_detects_corrupt_results(
-    #[case] archive_type: ArchiveType,
-    #[case] corruption: CorruptionMethod,
-) {
-    let (_temp_dir, archive_path) =
-        setup_corrupted_xdr_archive(archive_type, XdrFileType::Results, corruption);
-    let archive_url = format!("file://{}", archive_path.display());
-
-    let result = run_scan(configure_scan(&archive_url, archive_type, true, true)).await;
-
-    assert!(
-        result.is_err(),
-        "Scan --verify should fail on {} results corruption ({}) but succeeded",
-        archive_type.name(),
+        file_type.name(),
         corruption.name()
     );
 }

--- a/src/tests/xdr_verification_e2e_test.rs
+++ b/src/tests/xdr_verification_e2e_test.rs
@@ -442,24 +442,96 @@ async fn test_mirror_verify_valid_archive(#[case] archive_type: ArchiveType) {
 //=============================================================================
 
 #[rstest]
-#[case::pubnet_ledger_invalid_gzip(ArchiveType::PubnetOldTxset, XdrFileType::Ledger, CorruptionMethod::InvalidGzip)]
-#[case::pubnet_ledger_wrong_content(ArchiveType::PubnetOldTxset, XdrFileType::Ledger, CorruptionMethod::WrongContent)]
-#[case::pubnet_ledger_flipped_bytes(ArchiveType::PubnetOldTxset, XdrFileType::Ledger, CorruptionMethod::FlippedBytes)]
-#[case::pubnet_transactions_invalid_gzip(ArchiveType::PubnetOldTxset, XdrFileType::Transactions, CorruptionMethod::InvalidGzip)]
-#[case::pubnet_transactions_wrong_content(ArchiveType::PubnetOldTxset, XdrFileType::Transactions, CorruptionMethod::WrongContent)]
-#[case::pubnet_transactions_flipped_bytes(ArchiveType::PubnetOldTxset, XdrFileType::Transactions, CorruptionMethod::FlippedBytes)]
-#[case::pubnet_results_invalid_gzip(ArchiveType::PubnetOldTxset, XdrFileType::Results, CorruptionMethod::InvalidGzip)]
-#[case::pubnet_results_wrong_content(ArchiveType::PubnetOldTxset, XdrFileType::Results, CorruptionMethod::WrongContent)]
-#[case::pubnet_results_flipped_bytes(ArchiveType::PubnetOldTxset, XdrFileType::Results, CorruptionMethod::FlippedBytes)]
-#[case::testnet_ledger_invalid_gzip(ArchiveType::TestnetSmall, XdrFileType::Ledger, CorruptionMethod::InvalidGzip)]
-#[case::testnet_ledger_wrong_content(ArchiveType::TestnetSmall, XdrFileType::Ledger, CorruptionMethod::WrongContent)]
-#[case::testnet_ledger_flipped_bytes(ArchiveType::TestnetSmall, XdrFileType::Ledger, CorruptionMethod::FlippedBytes)]
-#[case::testnet_transactions_invalid_gzip(ArchiveType::TestnetSmall, XdrFileType::Transactions, CorruptionMethod::InvalidGzip)]
-#[case::testnet_transactions_wrong_content(ArchiveType::TestnetSmall, XdrFileType::Transactions, CorruptionMethod::WrongContent)]
-#[case::testnet_transactions_flipped_bytes(ArchiveType::TestnetSmall, XdrFileType::Transactions, CorruptionMethod::FlippedBytes)]
-#[case::testnet_results_invalid_gzip(ArchiveType::TestnetSmall, XdrFileType::Results, CorruptionMethod::InvalidGzip)]
-#[case::testnet_results_wrong_content(ArchiveType::TestnetSmall, XdrFileType::Results, CorruptionMethod::WrongContent)]
-#[case::testnet_results_flipped_bytes(ArchiveType::TestnetSmall, XdrFileType::Results, CorruptionMethod::FlippedBytes)]
+#[case::pubnet_ledger_invalid_gzip(
+    ArchiveType::PubnetOldTxset,
+    XdrFileType::Ledger,
+    CorruptionMethod::InvalidGzip
+)]
+#[case::pubnet_ledger_wrong_content(
+    ArchiveType::PubnetOldTxset,
+    XdrFileType::Ledger,
+    CorruptionMethod::WrongContent
+)]
+#[case::pubnet_ledger_flipped_bytes(
+    ArchiveType::PubnetOldTxset,
+    XdrFileType::Ledger,
+    CorruptionMethod::FlippedBytes
+)]
+#[case::pubnet_transactions_invalid_gzip(
+    ArchiveType::PubnetOldTxset,
+    XdrFileType::Transactions,
+    CorruptionMethod::InvalidGzip
+)]
+#[case::pubnet_transactions_wrong_content(
+    ArchiveType::PubnetOldTxset,
+    XdrFileType::Transactions,
+    CorruptionMethod::WrongContent
+)]
+#[case::pubnet_transactions_flipped_bytes(
+    ArchiveType::PubnetOldTxset,
+    XdrFileType::Transactions,
+    CorruptionMethod::FlippedBytes
+)]
+#[case::pubnet_results_invalid_gzip(
+    ArchiveType::PubnetOldTxset,
+    XdrFileType::Results,
+    CorruptionMethod::InvalidGzip
+)]
+#[case::pubnet_results_wrong_content(
+    ArchiveType::PubnetOldTxset,
+    XdrFileType::Results,
+    CorruptionMethod::WrongContent
+)]
+#[case::pubnet_results_flipped_bytes(
+    ArchiveType::PubnetOldTxset,
+    XdrFileType::Results,
+    CorruptionMethod::FlippedBytes
+)]
+#[case::testnet_ledger_invalid_gzip(
+    ArchiveType::TestnetSmall,
+    XdrFileType::Ledger,
+    CorruptionMethod::InvalidGzip
+)]
+#[case::testnet_ledger_wrong_content(
+    ArchiveType::TestnetSmall,
+    XdrFileType::Ledger,
+    CorruptionMethod::WrongContent
+)]
+#[case::testnet_ledger_flipped_bytes(
+    ArchiveType::TestnetSmall,
+    XdrFileType::Ledger,
+    CorruptionMethod::FlippedBytes
+)]
+#[case::testnet_transactions_invalid_gzip(
+    ArchiveType::TestnetSmall,
+    XdrFileType::Transactions,
+    CorruptionMethod::InvalidGzip
+)]
+#[case::testnet_transactions_wrong_content(
+    ArchiveType::TestnetSmall,
+    XdrFileType::Transactions,
+    CorruptionMethod::WrongContent
+)]
+#[case::testnet_transactions_flipped_bytes(
+    ArchiveType::TestnetSmall,
+    XdrFileType::Transactions,
+    CorruptionMethod::FlippedBytes
+)]
+#[case::testnet_results_invalid_gzip(
+    ArchiveType::TestnetSmall,
+    XdrFileType::Results,
+    CorruptionMethod::InvalidGzip
+)]
+#[case::testnet_results_wrong_content(
+    ArchiveType::TestnetSmall,
+    XdrFileType::Results,
+    CorruptionMethod::WrongContent
+)]
+#[case::testnet_results_flipped_bytes(
+    ArchiveType::TestnetSmall,
+    XdrFileType::Results,
+    CorruptionMethod::FlippedBytes
+)]
 #[tokio::test]
 async fn test_scan_verify_detects_corrupt_xdr(
     #[case] archive_type: ArchiveType,
@@ -957,9 +1029,11 @@ async fn test_verify_detects_true_cross_file_mismatch(
 ) {
     let (_temp_dir, archive_path) = setup_archive(archive_type);
     match corruption_type {
-        "tx_set" | "result" => {
-            corrupt_ledger_hash_field_preserving_entry_hash(&archive_path, archive_type, corruption_type)
-        }
+        "tx_set" | "result" => corrupt_ledger_hash_field_preserving_entry_hash(
+            &archive_path,
+            archive_type,
+            corruption_type,
+        ),
         "chain" => corrupt_cross_checkpoint_boundary(&archive_path, archive_type),
         _ => unreachable!(),
     }

--- a/src/tests/xdr_verification_e2e_test.rs
+++ b/src/tests/xdr_verification_e2e_test.rs
@@ -790,44 +790,6 @@ async fn test_verify_detects_result_hash_mismatch_in_scan_and_mirror(
 }
 
 #[tokio::test]
-async fn test_mirror_verify_removes_corrupt_written_xdr_file() {
-    let (_temp_src, archive_path) = setup_corrupted_xdr_archive(
-        ArchiveType::PubnetOldTxset,
-        XdrFileType::Transactions,
-        CorruptionMethod::WrongContent,
-    );
-    let corrupt_file = get_first_file_in_range(
-        &archive_path,
-        ArchiveType::PubnetOldTxset,
-        XdrFileType::Transactions.pattern(),
-    );
-
-    let temp_dest = TempDir::new().expect("Failed to create temp dir");
-    let src_url = format!("file://{}", archive_path.display());
-    let dest_url = format!("file://{}", temp_dest.path().display());
-
-    let result = run_mirror(configure_mirror(
-        &src_url,
-        &dest_url,
-        ArchiveType::PubnetOldTxset,
-        true,
-        true,
-    ))
-    .await;
-
-    assert!(
-        result.is_err(),
-        "Mirror should fail on corrupt transactions file"
-    );
-
-    let relative = corrupt_file.strip_prefix(&archive_path).unwrap();
-    assert!(
-        !temp_dest.path().join(relative).exists(),
-        "corrupt xdr file should be cleaned up after mirror verification failure"
-    );
-}
-
-#[tokio::test]
 async fn test_scan_verify_fails_with_multiple_corrupt_files_same_checkpoint() {
     let (_temp_dir, archive_path) = setup_archive(ArchiveType::PubnetOldTxset);
     let ledger_file = get_first_file_in_range(

--- a/src/tests/xdr_verification_e2e_test.rs
+++ b/src/tests/xdr_verification_e2e_test.rs
@@ -555,26 +555,6 @@ fn corrupt_result_hash_in_ledger(archive_path: &Path, archive_type: ArchiveType)
     std::fs::write(&ledger_file, compressed).expect("Failed to write corrupted file");
 }
 
-// Verifies --verify detects when ledger header's expected result hash doesn't match
-// the actual hash computed from the result file.
-#[rstest]
-#[case::pubnet_old_txset(ArchiveType::PubnetOldTxset)]
-#[case::testnet_small(ArchiveType::TestnetSmall)]
-#[tokio::test]
-async fn test_scan_verify_detects_result_hash_mismatch(#[case] archive_type: ArchiveType) {
-    let (_temp_dir, archive_path) = setup_archive(archive_type);
-    corrupt_result_hash_in_ledger(&archive_path, archive_type);
-    let archive_url = format!("file://{}", archive_path.display());
-
-    let result = run_scan(configure_scan(&archive_url, archive_type, true, true)).await;
-
-    assert!(
-        result.is_err(),
-        "Scan --verify should fail on {} result hash mismatch but succeeded",
-        archive_type.name()
-    );
-}
-
 //=============================================================================
 // Hash Chain Verification Tests
 //
@@ -622,25 +602,6 @@ fn corrupt_prev_ledger_hash(archive_path: &Path, archive_type: ArchiveType) {
         .expect("Failed to write corrupted data");
     let compressed = encoder.finish().expect("Failed to finish compression");
     std::fs::write(second_file, compressed).expect("Failed to write corrupted file");
-}
-
-// Verifies --verify detects when the hash chain between ledgers is broken.
-#[rstest]
-#[case::pubnet_old_txset(ArchiveType::PubnetOldTxset)]
-#[case::testnet_small(ArchiveType::TestnetSmall)]
-#[tokio::test]
-async fn test_scan_verify_detects_hash_chain_break(#[case] archive_type: ArchiveType) {
-    let (_temp_dir, archive_path) = setup_archive(archive_type);
-    corrupt_prev_ledger_hash(&archive_path, archive_type);
-    let archive_url = format!("file://{}", archive_path.display());
-
-    let result = run_scan(configure_scan(&archive_url, archive_type, true, true)).await;
-
-    assert!(
-        result.is_err(),
-        "Scan --verify should fail on {} hash chain break but succeeded",
-        archive_type.name()
-    );
 }
 
 //=============================================================================

--- a/src/tests/xdr_verification_e2e_test.rs
+++ b/src/tests/xdr_verification_e2e_test.rs
@@ -945,69 +945,37 @@ fn corrupt_cross_checkpoint_boundary(archive_path: &Path, archive_type: ArchiveT
 //=============================================================================
 
 #[rstest]
-#[case::scan_v0(VerifyOperation::Scan, ArchiveType::PubnetOldTxset)]
-#[case::scan_v1(VerifyOperation::Scan, ArchiveType::TestnetSmall)]
-#[case::mirror_v0(VerifyOperation::Mirror, ArchiveType::PubnetOldTxset)]
-#[case::mirror_v1(VerifyOperation::Mirror, ArchiveType::TestnetSmall)]
+#[case::tx_set_scan_v0(VerifyOperation::Scan, ArchiveType::PubnetOldTxset, "tx_set")]
+#[case::tx_set_scan_v1(VerifyOperation::Scan, ArchiveType::TestnetSmall, "tx_set")]
+#[case::tx_set_mirror_v0(VerifyOperation::Mirror, ArchiveType::PubnetOldTxset, "tx_set")]
+#[case::tx_set_mirror_v1(VerifyOperation::Mirror, ArchiveType::TestnetSmall, "tx_set")]
+#[case::result_scan_v0(VerifyOperation::Scan, ArchiveType::PubnetOldTxset, "result")]
+#[case::result_scan_v1(VerifyOperation::Scan, ArchiveType::TestnetSmall, "result")]
+#[case::result_mirror_v0(VerifyOperation::Mirror, ArchiveType::PubnetOldTxset, "result")]
+#[case::result_mirror_v1(VerifyOperation::Mirror, ArchiveType::TestnetSmall, "result")]
+#[case::chain_scan_v0(VerifyOperation::Scan, ArchiveType::PubnetOldTxset, "chain")]
+#[case::chain_scan_v1(VerifyOperation::Scan, ArchiveType::TestnetSmall, "chain")]
+#[case::chain_mirror_v0(VerifyOperation::Mirror, ArchiveType::PubnetOldTxset, "chain")]
+#[case::chain_mirror_v1(VerifyOperation::Mirror, ArchiveType::TestnetSmall, "chain")]
 #[tokio::test]
-async fn test_verify_detects_true_tx_set_hash_mismatch_in_scan_and_mirror(
+async fn test_verify_detects_true_cross_file_mismatch(
     #[case] op: VerifyOperation,
     #[case] archive_type: ArchiveType,
+    #[case] corruption_type: &str,
 ) {
     let (_temp_dir, archive_path) = setup_archive(archive_type);
-    corrupt_tx_set_hash_preserving_entry_hash(&archive_path, archive_type);
+    match corruption_type {
+        "tx_set" => corrupt_tx_set_hash_preserving_entry_hash(&archive_path, archive_type),
+        "result" => corrupt_result_hash_preserving_entry_hash(&archive_path, archive_type),
+        "chain" => corrupt_cross_checkpoint_boundary(&archive_path, archive_type),
+        _ => unreachable!(),
+    }
     let archive_url = format!("file://{}", archive_path.display());
 
     let result = op.run_with_verify(&archive_url, archive_type, true).await;
     assert!(
         result.is_err(),
-        "{:?} --verify should fail on {} true tx set hash mismatch",
-        op,
-        archive_type.name()
-    );
-}
-
-#[rstest]
-#[case::scan_v0(VerifyOperation::Scan, ArchiveType::PubnetOldTxset)]
-#[case::scan_v1(VerifyOperation::Scan, ArchiveType::TestnetSmall)]
-#[case::mirror_v0(VerifyOperation::Mirror, ArchiveType::PubnetOldTxset)]
-#[case::mirror_v1(VerifyOperation::Mirror, ArchiveType::TestnetSmall)]
-#[tokio::test]
-async fn test_verify_detects_true_result_hash_mismatch_in_scan_and_mirror(
-    #[case] op: VerifyOperation,
-    #[case] archive_type: ArchiveType,
-) {
-    let (_temp_dir, archive_path) = setup_archive(archive_type);
-    corrupt_result_hash_preserving_entry_hash(&archive_path, archive_type);
-    let archive_url = format!("file://{}", archive_path.display());
-
-    let result = op.run_with_verify(&archive_url, archive_type, true).await;
-    assert!(
-        result.is_err(),
-        "{:?} --verify should fail on {} true result hash mismatch",
-        op,
-        archive_type.name()
-    );
-}
-
-#[rstest]
-#[case::scan_v0(VerifyOperation::Scan, ArchiveType::PubnetOldTxset)]
-#[case::scan_v1(VerifyOperation::Scan, ArchiveType::TestnetSmall)]
-#[case::mirror_v0(VerifyOperation::Mirror, ArchiveType::PubnetOldTxset)]
-#[case::mirror_v1(VerifyOperation::Mirror, ArchiveType::TestnetSmall)]
-#[tokio::test]
-async fn test_verify_detects_true_cross_checkpoint_chain_break_in_scan_and_mirror(
-    #[case] op: VerifyOperation,
-    #[case] archive_type: ArchiveType,
-) {
-    let (_temp_dir, archive_path) = setup_archive(archive_type);
-    corrupt_cross_checkpoint_boundary(&archive_path, archive_type);
-    let archive_url = format!("file://{}", archive_path.display());
-
-    let result = op.run_with_verify(&archive_url, archive_type, true).await;
-    assert!(
-        result.is_err(),
-        "{:?} --verify should fail on {} cross-checkpoint chain break",
+        "{:?} --verify should fail on {} true {corruption_type} mismatch",
         op,
         archive_type.name()
     );

--- a/src/tests/xdr_verification_e2e_test.rs
+++ b/src/tests/xdr_verification_e2e_test.rs
@@ -874,32 +874,24 @@ fn write_ledger_entries_to_file(path: &Path, entries: &[LedgerHeaderHistoryEntry
     std::fs::write(path, compressed).expect("Failed to write file");
 }
 
-/// Modify all entries in a ledger file: set tx_set_hash to a wrong value,
-/// recompute each entry's hash, and fix the internal prev-hash chain so
+/// Modify all entries in a ledger file: set the specified hash field to a wrong
+/// value, recompute each entry's hash, and fix the internal prev-hash chain so
 /// the file passes per-entry and intra-checkpoint validation. The mismatch
-/// surfaces only when cross-checking against the transactions file.
-fn corrupt_tx_set_hash_preserving_entry_hash(archive_path: &Path, archive_type: ArchiveType) {
+/// surfaces only during cross-file verification.
+fn corrupt_ledger_hash_field_preserving_entry_hash(
+    archive_path: &Path,
+    archive_type: ArchiveType,
+    field: &str,
+) {
     let ledger_file = get_first_file_in_range(archive_path, archive_type, "/ledger-");
     let mut entries = read_and_parse_ledger_file(&ledger_file);
 
     for i in 0..entries.len() {
-        entries[i].header.scp_value.tx_set_hash = Hash([0xDE; 32]);
-        if i > 0 {
-            entries[i].header.previous_ledger_hash = entries[i - 1].hash.clone();
+        match field {
+            "tx_set" => entries[i].header.scp_value.tx_set_hash = Hash([0xDE; 32]),
+            "result" => entries[i].header.tx_set_result_hash = Hash([0xDE; 32]),
+            _ => unreachable!(),
         }
-        recompute_entry_hash(&mut entries[i]);
-    }
-
-    write_ledger_entries_to_file(&ledger_file, &entries);
-}
-
-/// Same as above but for tx_set_result_hash.
-fn corrupt_result_hash_preserving_entry_hash(archive_path: &Path, archive_type: ArchiveType) {
-    let ledger_file = get_first_file_in_range(archive_path, archive_type, "/ledger-");
-    let mut entries = read_and_parse_ledger_file(&ledger_file);
-
-    for i in 0..entries.len() {
-        entries[i].header.tx_set_result_hash = Hash([0xDE; 32]);
         if i > 0 {
             entries[i].header.previous_ledger_hash = entries[i - 1].hash.clone();
         }
@@ -965,8 +957,9 @@ async fn test_verify_detects_true_cross_file_mismatch(
 ) {
     let (_temp_dir, archive_path) = setup_archive(archive_type);
     match corruption_type {
-        "tx_set" => corrupt_tx_set_hash_preserving_entry_hash(&archive_path, archive_type),
-        "result" => corrupt_result_hash_preserving_entry_hash(&archive_path, archive_type),
+        "tx_set" | "result" => {
+            corrupt_ledger_hash_field_preserving_entry_hash(&archive_path, archive_type, corruption_type)
+        }
         "chain" => corrupt_cross_checkpoint_boundary(&archive_path, archive_type),
         _ => unreachable!(),
     }

--- a/src/tests/xdr_verify_test.rs
+++ b/src/tests/xdr_verify_test.rs
@@ -779,54 +779,39 @@ fn test_expected_ledger_range_large_checkpoint() {
     assert_eq!(last - first, 63);
 }
 
-#[test]
-fn test_manager_detects_tx_set_hash_mismatch() {
+#[rstest]
+#[case::tx_set("tx set")]
+#[case::result_set("result set")]
+fn test_manager_detects_hash_mismatch(#[case] hash_type: &str) {
     let manager = XdrVerificationManager::new();
     let checkpoint = 127;
-    let expected_tx = hash_of("expected_tx");
-    let wrong_tx = hash_of("wrong_tx");
+    let expected = hash_of("expected");
+    let wrong = hash_of("wrong");
 
     let mut ledger_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
     for data in ledger_data.values_mut() {
-        data.expected_tx_set_hash = expected_tx;
+        match hash_type {
+            "tx set" => data.expected_tx_set_hash = expected,
+            "result set" => data.expected_result_hash = expected,
+            _ => unreachable!(),
+        }
     }
 
-    let tx_set_hashes: HashMap<u32, [u8; 32]> =
-        ledger_data.keys().map(|&seq| (seq, wrong_tx)).collect();
+    let wrong_hashes: HashMap<u32, [u8; 32]> =
+        ledger_data.keys().map(|&seq| (seq, wrong)).collect();
 
     manager.record_ledger_data(checkpoint, ledger_data);
-    manager.record_tx_set_hashes(checkpoint, tx_set_hashes);
+    match hash_type {
+        "tx set" => manager.record_tx_set_hashes(checkpoint, wrong_hashes),
+        "result set" => manager.record_result_hashes(checkpoint, wrong_hashes),
+        _ => unreachable!(),
+    }
     manager.verify_and_release(checkpoint);
 
     assert!(manager
         .get_errors()
         .iter()
-        .any(|e| e.message.contains("tx set hash mismatch")));
-}
-
-#[test]
-fn test_manager_detects_result_set_hash_mismatch() {
-    let manager = XdrVerificationManager::new();
-    let checkpoint = 127;
-    let expected_result = hash_of("expected_result");
-    let wrong_result = hash_of("wrong_result");
-
-    let mut ledger_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
-    for data in ledger_data.values_mut() {
-        data.expected_result_hash = expected_result;
-    }
-
-    let result_hashes: HashMap<u32, [u8; 32]> =
-        ledger_data.keys().map(|&seq| (seq, wrong_result)).collect();
-
-    manager.record_ledger_data(checkpoint, ledger_data);
-    manager.record_result_hashes(checkpoint, result_hashes);
-    manager.verify_and_release(checkpoint);
-
-    assert!(manager
-        .get_errors()
-        .iter()
-        .any(|e| e.message.contains("result set hash mismatch")));
+        .any(|e| e.message.contains(&format!("{hash_type} hash mismatch"))));
 }
 
 #[test]

--- a/src/tests/xdr_verify_test.rs
+++ b/src/tests/xdr_verify_test.rs
@@ -299,10 +299,24 @@ fn test_parse_ledger_entries_duplicate_sequence() {
     assert!(err.message.contains("duplicate ledger entry"));
 }
 
-#[test]
-fn test_parse_ledger_entries_malformed_frame() {
-    let valid = frame_xdr(&create_valid_ledger_entry(100, [0; 32], [0; 32], [0; 32]));
-    let err = parse_ledger_entries(&valid[..valid.len() / 2]).unwrap_err();
+#[rstest]
+#[case::ledger("ledger")]
+#[case::transaction("transaction")]
+#[case::result("result")]
+fn test_parse_rejects_malformed_frame(#[case] file_type: &str) {
+    let valid = match file_type {
+        "ledger" => frame_xdr(&create_valid_ledger_entry(100, [0; 32], [0; 32], [0; 32])),
+        "transaction" => frame_xdr(&v0_history_entry(100, [0; 32], vec![tx_v0_envelope(1)])),
+        "result" => frame_xdr(&result_entry(100, &[1])),
+        _ => unreachable!(),
+    };
+    let truncated = &valid[..valid.len() / 2];
+    let err = match file_type {
+        "ledger" => parse_ledger_entries(truncated).unwrap_err(),
+        "transaction" => parse_transaction_entries(truncated).unwrap_err(),
+        "result" => parse_result_entries(truncated).unwrap_err(),
+        _ => unreachable!(),
+    };
     assert!(err.message.contains("failed to parse"));
 }
 
@@ -1018,21 +1032,6 @@ fn test_manager_still_flags_missing_tx_set_when_result_hash_is_empty_array_hash(
     );
 }
 
-#[test]
-fn test_parse_transaction_entries_malformed_frame() {
-    let entry = v0_history_entry(100, [0; 32], vec![tx_v0_envelope(1)]);
-    let valid = frame_xdr(&entry);
-    let err = parse_transaction_entries(&valid[..valid.len() / 2]).unwrap_err();
-    assert!(err.message.contains("failed to parse"));
-}
-
-#[test]
-fn test_parse_result_entries_malformed_frame() {
-    let entry = result_entry(100, &[1]);
-    let valid = frame_xdr(&entry);
-    let err = parse_result_entries(&valid[..valid.len() / 2]).unwrap_err();
-    assert!(err.message.contains("failed to parse"));
-}
 
 #[test]
 fn test_parse_transaction_entries_rejects_ledger_outside_checkpoint_range() {

--- a/src/tests/xdr_verify_test.rs
+++ b/src/tests/xdr_verify_test.rs
@@ -7,7 +7,7 @@ use crate::xdr_verify::{
 };
 use rstest::rstest;
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use stellar_xdr::curr::{
     AccountId, CreateAccountOp, GeneralizedTransactionSet, Hash, LedgerHeader, LedgerHeaderExt,
     LedgerHeaderHistoryEntry, LedgerHeaderHistoryEntryExt, LedgerScpMessages, Limits, Memo,
@@ -206,9 +206,9 @@ fn create_valid_ledger_entry(
 fn create_complete_checkpoint_data(
     checkpoint: u32,
     initial_prev_hash: [u8; 32],
-) -> HashMap<u32, LedgerVerificationData> {
+) -> BTreeMap<u32, LedgerVerificationData> {
     let (first_ledger, last_ledger) = expected_ledger_range(checkpoint);
-    let mut ledger_data = HashMap::new();
+    let mut ledger_data = BTreeMap::new();
     let mut prev_hash = initial_prev_hash;
 
     for seq in first_ledger..=last_ledger {
@@ -231,7 +231,7 @@ fn create_complete_checkpoint_data(
 fn create_checkpoint_data_missing(
     checkpoint: u32,
     missing: &[u32],
-) -> HashMap<u32, LedgerVerificationData> {
+) -> BTreeMap<u32, LedgerVerificationData> {
     let mut data = create_complete_checkpoint_data(checkpoint, [0; 32]);
     for seq in missing {
         data.remove(seq);
@@ -243,8 +243,8 @@ fn single_ledger_data(
     seq: u32,
     computed_hash: [u8; 32],
     prev_hash: [u8; 32],
-) -> HashMap<u32, LedgerVerificationData> {
-    HashMap::from([(
+) -> BTreeMap<u32, LedgerVerificationData> {
+    BTreeMap::from([(
         seq,
         LedgerVerificationData {
             computed_hash,
@@ -574,7 +574,7 @@ fn test_missing_ledger_entries(#[case] checkpoint: u32, #[case] missing: Vec<u32
 #[test]
 fn test_manager_empty_checkpoint_data() {
     let manager = XdrVerificationManager::new();
-    manager.record_ledger_data(127, HashMap::new());
+    manager.record_ledger_data(127, BTreeMap::new());
     manager.verify_and_release(127);
     assert!(!manager.get_errors().is_empty());
 }
@@ -635,7 +635,7 @@ fn test_consecutive_checkpoints_full(#[case] break_chain: bool) {
     let ledger_data_63 = create_complete_checkpoint_data(63, [0; 32]);
     let last_hash_of_63 = ledger_data_63.get(&63).unwrap().computed_hash;
 
-    let mut ledger_data_127 = HashMap::new();
+    let mut ledger_data_127 = BTreeMap::new();
     let mut prev_hash = if break_chain {
         [0xff; 32]
     } else {

--- a/src/tests/xdr_verify_test.rs
+++ b/src/tests/xdr_verify_test.rs
@@ -844,121 +844,60 @@ fn test_manager_detects_missing_entry_for_non_empty_hash(#[case] hash_type: &str
         .any(|e| e.message.contains(&format!("missing {hash_type} entry"))));
 }
 
-#[test]
-fn test_manager_allows_missing_tx_set_entry_for_empty_v0_tx_set() {
+/// Missing entries should not be flagged when the expected hash indicates an empty
+/// or zero-valued set. Each case sets a different "empty" hash variant and verifies
+/// no spurious errors are produced.
+#[rstest]
+#[case::tx_set_empty_v0("tx set", "empty_v0")]
+#[case::tx_set_empty_v1("tx set", "empty_v1")]
+#[case::tx_set_zero("tx set", "zero")]
+#[case::result_empty_xdr_array("result", "empty_xdr_array")]
+#[case::result_zero("result", "zero")]
+fn test_manager_allows_missing_entry_for_empty_hash(
+    #[case] hash_type: &str,
+    #[case] empty_variant: &str,
+) {
     let manager = XdrVerificationManager::new();
     let checkpoint = 127;
 
     let mut ledger_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
     for data in ledger_data.values_mut() {
-        data.expected_tx_set_hash = compute_empty_v0_tx_set_hash(&data.prev_hash);
-        data.expected_result_hash = hash_of("some_result");
+        match (hash_type, empty_variant) {
+            ("tx set", "empty_v0") => {
+                data.expected_tx_set_hash = compute_empty_v0_tx_set_hash(&data.prev_hash);
+                data.expected_result_hash = hash_of("some_result");
+            }
+            ("tx set", "empty_v1") => {
+                data.expected_tx_set_hash = compute_empty_v1_tx_set_hash(&data.prev_hash);
+                data.expected_result_hash = hash_of("some_result");
+            }
+            ("tx set", "zero") => {} // defaults are already [0; 32]
+            ("result", "empty_xdr_array") => {
+                data.expected_result_hash = EMPTY_XDR_ARRAY_HASH;
+            }
+            ("result", "zero") => {} // defaults are already [0; 32]
+            _ => unreachable!(),
+        }
     }
 
     manager.record_ledger_data(checkpoint, ledger_data);
-    manager.record_tx_set_hashes(checkpoint, HashMap::new());
+    match hash_type {
+        "tx set" => manager.record_tx_set_hashes(checkpoint, HashMap::new()),
+        "result" => manager.record_result_hashes(checkpoint, HashMap::new()),
+        _ => unreachable!(),
+    }
     manager.verify_and_release(checkpoint);
 
-    let tx_errors: Vec<_> = manager
+    let errors: Vec<_> = manager
         .get_errors()
         .iter()
-        .filter(|e| e.message.contains("tx set"))
+        .filter(|e| e.message.contains(hash_type))
         .cloned()
         .collect();
     assert!(
-        tx_errors.is_empty(),
-        "Should allow missing tx set for empty v0 hash, got: {:?}",
-        tx_errors
+        errors.is_empty(),
+        "Should allow missing {hash_type} entry for {empty_variant} hash, got: {errors:?}",
     );
-}
-
-#[test]
-fn test_manager_allows_missing_tx_set_entry_for_empty_v1_tx_set() {
-    let manager = XdrVerificationManager::new();
-    let checkpoint = 127;
-
-    let mut ledger_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
-    for data in ledger_data.values_mut() {
-        data.expected_tx_set_hash = compute_empty_v1_tx_set_hash(&data.prev_hash);
-        data.expected_result_hash = hash_of("some_result");
-    }
-
-    manager.record_ledger_data(checkpoint, ledger_data);
-    manager.record_tx_set_hashes(checkpoint, HashMap::new());
-    manager.verify_and_release(checkpoint);
-
-    let tx_errors: Vec<_> = manager
-        .get_errors()
-        .iter()
-        .filter(|e| e.message.contains("tx set"))
-        .cloned()
-        .collect();
-    assert!(
-        tx_errors.is_empty(),
-        "Should allow missing tx set for empty v1 hash, got: {:?}",
-        tx_errors
-    );
-}
-
-#[test]
-fn test_manager_allows_missing_tx_set_entry_for_zero_tx_hash() {
-    let manager = XdrVerificationManager::new();
-    let checkpoint = 127;
-    let ledger_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
-
-    manager.record_ledger_data(checkpoint, ledger_data);
-    manager.record_tx_set_hashes(checkpoint, HashMap::new());
-    manager.verify_and_release(checkpoint);
-
-    let tx_errors: Vec<_> = manager
-        .get_errors()
-        .iter()
-        .filter(|e| e.message.contains("tx set"))
-        .cloned()
-        .collect();
-    assert!(tx_errors.is_empty());
-}
-
-#[test]
-fn test_manager_allows_missing_result_entry_for_empty_result_hash() {
-    let manager = XdrVerificationManager::new();
-    let checkpoint = 127;
-
-    let mut ledger_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
-    for data in ledger_data.values_mut() {
-        data.expected_result_hash = EMPTY_XDR_ARRAY_HASH;
-    }
-
-    manager.record_ledger_data(checkpoint, ledger_data);
-    manager.record_result_hashes(checkpoint, HashMap::new());
-    manager.verify_and_release(checkpoint);
-
-    let result_errors: Vec<_> = manager
-        .get_errors()
-        .iter()
-        .filter(|e| e.message.contains("result"))
-        .cloned()
-        .collect();
-    assert!(result_errors.is_empty());
-}
-
-#[test]
-fn test_manager_allows_missing_result_entry_for_zero_result_hash() {
-    let manager = XdrVerificationManager::new();
-    let checkpoint = 127;
-    let ledger_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
-
-    manager.record_ledger_data(checkpoint, ledger_data);
-    manager.record_result_hashes(checkpoint, HashMap::new());
-    manager.verify_and_release(checkpoint);
-
-    let result_errors: Vec<_> = manager
-        .get_errors()
-        .iter()
-        .filter(|e| e.message.contains("result"))
-        .cloned()
-        .collect();
-    assert!(result_errors.is_empty());
 }
 
 #[test]

--- a/src/tests/xdr_verify_test.rs
+++ b/src/tests/xdr_verify_test.rs
@@ -814,48 +814,34 @@ fn test_manager_detects_hash_mismatch(#[case] hash_type: &str) {
         .any(|e| e.message.contains(&format!("{hash_type} hash mismatch"))));
 }
 
-#[test]
-fn test_manager_detects_missing_tx_set_entry_for_non_empty_tx_set() {
+#[rstest]
+#[case::tx_set("tx set")]
+#[case::result("result")]
+fn test_manager_detects_missing_entry_for_non_empty_hash(#[case] hash_type: &str) {
     let manager = XdrVerificationManager::new();
     let checkpoint = 127;
-    let non_empty_tx_hash = hash_of("non_empty_tx_set");
-    let non_empty_result_hash = hash_of("non_empty_result");
+    let non_empty_hash = hash_of("non_empty");
 
     let mut ledger_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
     for data in ledger_data.values_mut() {
-        data.expected_tx_set_hash = non_empty_tx_hash;
-        data.expected_result_hash = non_empty_result_hash;
+        // tx set missing-entry detection requires expected_result_hash != EMPTY_XDR_ARRAY_HASH,
+        // so both cases set non-empty hashes for both fields.
+        data.expected_tx_set_hash = non_empty_hash;
+        data.expected_result_hash = non_empty_hash;
     }
 
     manager.record_ledger_data(checkpoint, ledger_data);
-    manager.record_tx_set_hashes(checkpoint, HashMap::new());
+    match hash_type {
+        "tx set" => manager.record_tx_set_hashes(checkpoint, HashMap::new()),
+        "result" => manager.record_result_hashes(checkpoint, HashMap::new()),
+        _ => unreachable!(),
+    }
     manager.verify_and_release(checkpoint);
 
     assert!(manager
         .get_errors()
         .iter()
-        .any(|e| e.message.contains("missing tx set entry")));
-}
-
-#[test]
-fn test_manager_detects_missing_result_entry_for_non_empty_result_set() {
-    let manager = XdrVerificationManager::new();
-    let checkpoint = 127;
-    let non_empty_result_hash = hash_of("non_empty_result");
-
-    let mut ledger_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
-    for data in ledger_data.values_mut() {
-        data.expected_result_hash = non_empty_result_hash;
-    }
-
-    manager.record_ledger_data(checkpoint, ledger_data);
-    manager.record_result_hashes(checkpoint, HashMap::new());
-    manager.verify_and_release(checkpoint);
-
-    assert!(manager
-        .get_errors()
-        .iter()
-        .any(|e| e.message.contains("missing result entry")));
+        .any(|e| e.message.contains(&format!("missing {hash_type} entry"))));
 }
 
 #[test]

--- a/src/tests/xdr_verify_test.rs
+++ b/src/tests/xdr_verify_test.rs
@@ -261,9 +261,16 @@ fn hash_of(value: &str) -> [u8; 32] {
 
 fn assert_has_error(manager: &XdrVerificationManager, substring: &str) {
     assert!(
-        manager.get_errors().iter().any(|e| e.message.contains(substring)),
+        manager
+            .get_errors()
+            .iter()
+            .any(|e| e.message.contains(substring)),
         "expected an error containing {substring:?}, got: {:?}",
-        manager.get_errors().iter().map(|e| &e.message).collect::<Vec<_>>(),
+        manager
+            .get_errors()
+            .iter()
+            .map(|e| &e.message)
+            .collect::<Vec<_>>(),
     );
 }
 
@@ -370,7 +377,6 @@ fn test_parse_result_entries_single_entry() {
     assert_eq!(parsed, HashMap::from([(100, expected)]));
 }
 
-
 #[test]
 fn test_parse_transaction_entries_v0_non_empty() {
     let prev_hash = [0x42; 32];
@@ -396,7 +402,6 @@ fn test_parse_transaction_entries_v1_non_empty() {
     assert_eq!(parsed[&100], compute_v1_tx_set_hash(generalized).unwrap());
     assert!(!is_empty_tx_set_hash(&parsed[&100], &prev_hash));
 }
-
 
 #[test]
 fn test_compute_v0_tx_set_hash_matches_manual_hash() {
@@ -545,8 +550,7 @@ fn test_chain_break_within_ledger_file(#[case] checkpoint: u32, #[case] corrupte
     assert!(manager
         .get_errors()
         .iter()
-        .any(|e| e.ledger_seq == Some(corrupted_ledger) && e.message.contains("hash chain break")),
-    );
+        .any(|e| e.ledger_seq == Some(corrupted_ledger) && e.message.contains("hash chain break")),);
 }
 
 #[rstest]
@@ -897,7 +901,6 @@ fn test_manager_still_flags_missing_tx_set_when_result_hash_is_empty_array_hash(
     // because no results implies no transactions, regardless of tx_set_hash format
     assert_no_errors_matching(&manager, "missing tx set entry");
 }
-
 
 #[rstest]
 #[case::ledger("ledger")]

--- a/src/tests/xdr_verify_test.rs
+++ b/src/tests/xdr_verify_test.rs
@@ -508,14 +508,12 @@ fn test_manager_records_and_verifies_checkpoint() {
 }
 
 #[rstest]
-#[case::beginning(1)]
-#[case::middle(31)]
-#[case::end(63)]
-fn test_chain_break_within_ledger_file(#[case] offset_from_first: u32) {
+#[case::beginning(127, 65)]
+#[case::middle(127, 95)]
+#[case::end(127, 127)]
+#[case::genesis(63, 2)]
+fn test_chain_break_within_ledger_file(#[case] checkpoint: u32, #[case] corrupted_ledger: u32) {
     let manager = XdrVerificationManager::new();
-    let checkpoint = 127;
-    let first_ledger = 64;
-    let corrupted_ledger = first_ledger + offset_from_first;
 
     let mut ledger_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
     ledger_data.get_mut(&corrupted_ledger).unwrap().prev_hash = [0xff; 32];
@@ -527,19 +525,6 @@ fn test_chain_break_within_ledger_file(#[case] offset_from_first: u32) {
         .get_errors()
         .iter()
         .any(|e| e.ledger_seq == Some(corrupted_ledger) && e.message.contains("hash chain break")));
-}
-
-#[test]
-fn test_manager_detects_internal_genesis_chain_break() {
-    let manager = XdrVerificationManager::new();
-    let mut ledger_data = create_complete_checkpoint_data(63, [0; 32]);
-    ledger_data.get_mut(&2).unwrap().prev_hash = [0xff; 32];
-
-    manager.record_ledger_data(63, ledger_data);
-    manager.verify_and_release(63);
-
-    assert_eq!(manager.get_errors().len(), 1);
-    assert!(manager.get_errors()[0].message.contains("hash chain break"));
 }
 
 #[rstest]

--- a/src/tests/xdr_verify_test.rs
+++ b/src/tests/xdr_verify_test.rs
@@ -1033,26 +1033,22 @@ fn test_manager_still_flags_missing_tx_set_when_result_hash_is_empty_array_hash(
 }
 
 
-#[test]
-fn test_parse_transaction_entries_rejects_ledger_outside_checkpoint_range() {
-    let entry = v0_history_entry(200, [0; 32], vec![tx_v0_envelope(1)]);
-    let data = frame_xdr(&entry);
-    let err = parse_transaction_entries_for_checkpoint(&data, Some(127)).unwrap_err();
-    assert!(err.message.contains("outside expected checkpoint range"));
-}
-
-#[test]
-fn test_parse_result_entries_rejects_ledger_outside_checkpoint_range() {
-    let entry = result_entry(200, &[1]);
-    let data = frame_xdr(&entry);
-    let err = parse_result_entries_for_checkpoint(&data, Some(127)).unwrap_err();
-    assert!(err.message.contains("outside expected checkpoint range"));
-}
-
-#[test]
-fn test_parse_ledger_entries_rejects_ledger_outside_checkpoint_range() {
-    let entry = create_valid_ledger_entry(200, [0; 32], [0; 32], [0; 32]);
-    let data = frame_xdr(&entry);
-    let err = parse_ledger_entries_for_checkpoint(&data, Some(127)).unwrap_err();
+#[rstest]
+#[case::ledger("ledger")]
+#[case::transaction("transaction")]
+#[case::result("result")]
+fn test_parse_rejects_ledger_outside_checkpoint_range(#[case] file_type: &str) {
+    let data = match file_type {
+        "ledger" => frame_xdr(&create_valid_ledger_entry(200, [0; 32], [0; 32], [0; 32])),
+        "transaction" => frame_xdr(&v0_history_entry(200, [0; 32], vec![tx_v0_envelope(1)])),
+        "result" => frame_xdr(&result_entry(200, &[1])),
+        _ => unreachable!(),
+    };
+    let err = match file_type {
+        "ledger" => parse_ledger_entries_for_checkpoint(&data, Some(127)).unwrap_err(),
+        "transaction" => parse_transaction_entries_for_checkpoint(&data, Some(127)).unwrap_err(),
+        "result" => parse_result_entries_for_checkpoint(&data, Some(127)).unwrap_err(),
+        _ => unreachable!(),
+    };
     assert!(err.message.contains("outside expected checkpoint range"));
 }

--- a/src/tests/xdr_verify_test.rs
+++ b/src/tests/xdr_verify_test.rs
@@ -289,14 +289,26 @@ fn test_parse_ledger_entries_hash_mismatch() {
     assert!(err.message.contains("hash mismatch"));
 }
 
-#[test]
-fn test_parse_ledger_entries_duplicate_sequence() {
-    let entry = create_valid_ledger_entry(100, [0; 32], [0; 32], [0; 32]);
-    let mut data = frame_xdr(&entry);
-    data.extend(frame_xdr(&entry));
-
-    let err = parse_ledger_entries(&data).unwrap_err();
-    assert!(err.message.contains("duplicate ledger entry"));
+#[rstest]
+#[case::ledger("ledger")]
+#[case::transaction("transaction")]
+#[case::result("result")]
+fn test_parse_rejects_duplicate_sequence(#[case] file_type: &str) {
+    let frame = match file_type {
+        "ledger" => frame_xdr(&create_valid_ledger_entry(100, [0; 32], [0; 32], [0; 32])),
+        "transaction" => frame_xdr(&v0_history_entry(100, [0; 32], vec![tx_v0_envelope(1)])),
+        "result" => frame_xdr(&result_entry(100, &[1])),
+        _ => unreachable!(),
+    };
+    let mut data = frame.clone();
+    data.extend(frame);
+    let err = match file_type {
+        "ledger" => parse_ledger_entries(&data).unwrap_err(),
+        "transaction" => parse_transaction_entries(&data).unwrap_err(),
+        "result" => parse_result_entries(&data).unwrap_err(),
+        _ => unreachable!(),
+    };
+    assert!(err.message.contains("duplicate"));
 }
 
 #[rstest]
@@ -337,15 +349,6 @@ fn test_parse_result_entries_single_entry() {
     assert_eq!(parsed, HashMap::from([(100, expected)]));
 }
 
-#[test]
-fn test_parse_result_entries_duplicate_sequence() {
-    let entry = result_entry(100, &[1]);
-    let mut data = frame_xdr(&entry);
-    data.extend(frame_xdr(&entry));
-
-    let err = parse_result_entries(&data).unwrap_err();
-    assert!(err.message.contains("duplicate result entry"));
-}
 
 #[test]
 fn test_parse_transaction_entries_v0_non_empty() {
@@ -373,15 +376,6 @@ fn test_parse_transaction_entries_v1_non_empty() {
     assert!(!is_empty_tx_set_hash(&parsed[&100], &prev_hash));
 }
 
-#[test]
-fn test_parse_transaction_entries_duplicate_sequence() {
-    let entry = v0_history_entry(100, [0; 32], vec![tx_v0_envelope(1)]);
-    let mut data = frame_xdr(&entry);
-    data.extend(frame_xdr(&entry));
-
-    let err = parse_transaction_entries(&data).unwrap_err();
-    assert!(err.message.contains("duplicate transaction entry"));
-}
 
 #[test]
 fn test_compute_v0_tx_set_hash_matches_manual_hash() {

--- a/src/tests/xdr_verify_test.rs
+++ b/src/tests/xdr_verify_test.rs
@@ -547,6 +547,7 @@ fn test_complete_checkpoint_passes(#[case] checkpoint: u32, #[case] expected_cou
 #[case::middle_ledger(127, vec![100])]
 #[case::multiple_ledgers(127, vec![66, 67])]
 #[case::genesis_first(63, vec![1])]
+#[case::all_missing(127, (64..=127).collect())]
 fn test_missing_ledger_entries(#[case] checkpoint: u32, #[case] missing: Vec<u32>) {
     let manager = XdrVerificationManager::new();
     manager.record_ledger_data(
@@ -562,14 +563,6 @@ fn test_missing_ledger_entries(#[case] checkpoint: u32, #[case] missing: Vec<u32
         .collect::<Vec<_>>()
         .join(" ");
     assert!(combined.contains("missing"));
-}
-
-#[test]
-fn test_manager_empty_checkpoint_data() {
-    let manager = XdrVerificationManager::new();
-    manager.record_ledger_data(127, BTreeMap::new());
-    manager.verify_and_release(127);
-    assert!(!manager.get_errors().is_empty());
 }
 
 #[test]

--- a/src/tests/xdr_verify_test.rs
+++ b/src/tests/xdr_verify_test.rs
@@ -259,6 +259,27 @@ fn hash_of(value: &str) -> [u8; 32] {
     Sha256::digest(value.as_bytes()).into()
 }
 
+fn assert_has_error(manager: &XdrVerificationManager, substring: &str) {
+    assert!(
+        manager.get_errors().iter().any(|e| e.message.contains(substring)),
+        "expected an error containing {substring:?}, got: {:?}",
+        manager.get_errors().iter().map(|e| &e.message).collect::<Vec<_>>(),
+    );
+}
+
+fn assert_no_errors_matching(manager: &XdrVerificationManager, substring: &str) {
+    let matching: Vec<_> = manager
+        .get_errors()
+        .iter()
+        .filter(|e| e.message.contains(substring))
+        .cloned()
+        .collect();
+    assert!(
+        matching.is_empty(),
+        "expected no errors containing {substring:?}, got: {matching:?}",
+    );
+}
+
 #[test]
 fn test_parse_ledger_entries_empty_input() {
     let parsed = parse_ledger_entries(&[]).unwrap();
@@ -524,7 +545,8 @@ fn test_chain_break_within_ledger_file(#[case] checkpoint: u32, #[case] corrupte
     assert!(manager
         .get_errors()
         .iter()
-        .any(|e| e.ledger_seq == Some(corrupted_ledger) && e.message.contains("hash chain break")));
+        .any(|e| e.ledger_seq == Some(corrupted_ledger) && e.message.contains("hash chain break")),
+    );
 }
 
 #[rstest]
@@ -556,13 +578,7 @@ fn test_missing_ledger_entries(#[case] checkpoint: u32, #[case] missing: Vec<u32
     );
     manager.verify_and_release(checkpoint);
 
-    let combined = manager
-        .get_errors()
-        .iter()
-        .map(|e| e.message.clone())
-        .collect::<Vec<_>>()
-        .join(" ");
-    assert!(combined.contains("missing"));
+    assert_has_error(&manager, "missing");
 }
 
 #[test]
@@ -582,9 +598,7 @@ fn test_ledger_outside_expected_checkpoint_range() {
     manager.record_ledger_data(127, ledger_data);
     manager.verify_and_release(127);
 
-    assert!(manager.get_errors().iter().any(|e| e
-        .message
-        .contains("unexpected ledger entries outside range")));
+    assert_has_error(&manager, "unexpected ledger entries outside range");
 }
 
 #[rstest]
@@ -707,9 +721,7 @@ fn test_verify_and_release_with_only_tx_hashes_records_error_and_is_idempotent()
 
     assert_eq!(first_errors.len(), 1);
     assert_eq!(second_errors.len(), 1);
-    assert!(first_errors[0]
-        .message
-        .contains("missing ledger verification data"));
+    assert_has_error(&manager, "missing ledger verification data");
 }
 
 #[test]
@@ -718,10 +730,7 @@ fn test_verify_and_release_with_only_result_hashes_records_error() {
     manager.record_result_hashes(127, HashMap::from([(100, [1; 32])]));
     manager.verify_and_release(127);
 
-    assert_eq!(manager.get_errors().len(), 1);
-    assert!(manager.get_errors()[0]
-        .message
-        .contains("missing ledger verification data"));
+    assert_has_error(&manager, "missing ledger verification data");
 }
 
 #[test]
@@ -786,10 +795,7 @@ fn test_manager_detects_hash_mismatch(#[case] hash_type: &str) {
     }
     manager.verify_and_release(checkpoint);
 
-    assert!(manager
-        .get_errors()
-        .iter()
-        .any(|e| e.message.contains(&format!("{hash_type} hash mismatch"))));
+    assert_has_error(&manager, &format!("{hash_type} hash mismatch"));
 }
 
 #[rstest]
@@ -816,10 +822,7 @@ fn test_manager_detects_missing_entry_for_non_empty_hash(#[case] hash_type: &str
     }
     manager.verify_and_release(checkpoint);
 
-    assert!(manager
-        .get_errors()
-        .iter()
-        .any(|e| e.message.contains(&format!("missing {hash_type} entry"))));
+    assert_has_error(&manager, &format!("missing {hash_type} entry"));
 }
 
 /// Missing entries should not be flagged when the expected hash indicates an empty
@@ -866,16 +869,7 @@ fn test_manager_allows_missing_entry_for_empty_hash(
     }
     manager.verify_and_release(checkpoint);
 
-    let errors: Vec<_> = manager
-        .get_errors()
-        .iter()
-        .filter(|e| e.message.contains(hash_type))
-        .cloned()
-        .collect();
-    assert!(
-        errors.is_empty(),
-        "Should allow missing {hash_type} entry for {empty_variant} hash, got: {errors:?}",
-    );
+    assert_no_errors_matching(&manager, hash_type);
 }
 
 #[test]
@@ -901,17 +895,7 @@ fn test_manager_still_flags_missing_tx_set_when_result_hash_is_empty_array_hash(
 
     // The EMPTY_XDR_ARRAY_HASH result hash suppresses the missing tx set error
     // because no results implies no transactions, regardless of tx_set_hash format
-    let tx_errors: Vec<_> = manager
-        .get_errors()
-        .iter()
-        .filter(|e| e.message.contains("missing tx set entry"))
-        .cloned()
-        .collect();
-    assert!(
-        tx_errors.is_empty(),
-        "EMPTY_XDR_ARRAY_HASH result hash should suppress missing tx set error, got: {:?}",
-        tx_errors
-    );
+    assert_no_errors_matching(&manager, "missing tx set entry");
 }
 
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -286,7 +286,16 @@ impl RetryState {
 
     /// Wait for the backoff period and increase it for next time
     pub async fn backoff(&mut self) {
-        tokio::time::sleep(tokio::time::Duration::from_millis(self.backoff_ms)).await;
+        let duration = tokio::time::Duration::from_millis(self.backoff_ms);
+
+        #[cfg(test)]
+        if let Ok(vc) = crate::tests::utils::CLOCK_OVERRIDE.try_with(|c| c.clone()) {
+            vc.sleep(duration).await;
+            self.backoff_ms = (self.backoff_ms * 2).min(5000);
+            return;
+        }
+
+        tokio::time::sleep(duration).await;
         self.backoff_ms = (self.backoff_ms * 2).min(5000); // Cap at 5 seconds
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -278,9 +278,13 @@ impl RetryState {
                 );
                 return true;
             }
+            error!(
+                "Exceeded {} retry attempts to {} {}: {}",
+                self.max_retries, action, path, error
+            );
+        } else {
+            error!("Failed to {} {}: {}", action, path, error);
         }
-
-        error!("Failed to {} {}: {}", action, path, error);
         false
     }
 

--- a/src/xdr_verify.rs
+++ b/src/xdr_verify.rs
@@ -225,15 +225,17 @@ impl XdrVerificationManager {
             });
         }
 
-        let missing: Vec<u32> = range
-            .filter(|seq| !ledger_data.contains_key(seq))
-            .collect();
+        let missing: Vec<u32> = range.filter(|seq| !ledger_data.contains_key(seq)).collect();
 
         if !missing.is_empty() {
             let list_str = if missing.len() <= 10 {
                 fmt_list(&missing)
             } else {
-                format!("{}, ... ({} more)", fmt_list(&missing[..5]), missing.len() - 5)
+                format!(
+                    "{}, ... ({} more)",
+                    fmt_list(&missing[..5]),
+                    missing.len() - 5
+                )
             };
             let err_msg = format!(
                 "missing {} of {} ledger entries (ledgers {first_ledger}-{last_ledger}): {list_str}",
@@ -672,7 +674,10 @@ pub(crate) fn parse_result_entries_for_checkpoint(
 }
 
 /// Decompress gzip data from a reader into an in-memory buffer.
-pub(crate) async fn decompress_to_buffer(path: &str, reader: Reader) -> Result<Vec<u8>, StorageError> {
+pub(crate) async fn decompress_to_buffer(
+    path: &str,
+    reader: Reader,
+) -> Result<Vec<u8>, StorageError> {
     // the writer is None, thus the return sink is also None, which is safe to
     // be discarded
     let (decompressed, _) = decompress_and_write_internal(path, reader, None).await?;

--- a/src/xdr_verify.rs
+++ b/src/xdr_verify.rs
@@ -56,7 +56,7 @@ pub struct LedgerVerificationData {
 
 #[derive(Default)]
 struct PendingCheckpoint {
-    ledger_data: Option<HashMap<u32, LedgerVerificationData>>,
+    ledger_data: Option<BTreeMap<u32, LedgerVerificationData>>,
     tx_set_hashes: Option<HashMap<u32, [u8; 32]>>,
     result_hashes: Option<HashMap<u32, [u8; 32]>>,
 }
@@ -89,7 +89,7 @@ impl XdrVerificationManager {
         }
     }
 
-    pub fn record_ledger_data(&self, checkpoint: u32, data: HashMap<u32, LedgerVerificationData>) {
+    pub fn record_ledger_data(&self, checkpoint: u32, data: BTreeMap<u32, LedgerVerificationData>) {
         let mut pending = self.pending.lock().unwrap();
         let entry = pending.entry(checkpoint).or_default();
         entry.ledger_data = Some(data);
@@ -147,7 +147,7 @@ impl XdrVerificationManager {
     fn verify_checkpoint_completeness(
         &self,
         checkpoint: u32,
-        ledger_data: &HashMap<u32, LedgerVerificationData>,
+        ledger_data: &BTreeMap<u32, LedgerVerificationData>,
     ) {
         let (first_ledger, last_ledger) = expected_ledger_range(checkpoint);
         let range = first_ledger..=last_ledger;
@@ -204,7 +204,7 @@ impl XdrVerificationManager {
     fn verify_tx_set_hashes_internal(
         &self,
         checkpoint: u32,
-        ledger_data: &HashMap<u32, LedgerVerificationData>,
+        ledger_data: &BTreeMap<u32, LedgerVerificationData>,
         tx_set_hashes: &HashMap<u32, [u8; 32]>,
     ) {
         for (&seq, data) in ledger_data {
@@ -245,7 +245,7 @@ impl XdrVerificationManager {
     fn verify_result_hashes_internal(
         &self,
         checkpoint: u32,
-        ledger_data: &HashMap<u32, LedgerVerificationData>,
+        ledger_data: &BTreeMap<u32, LedgerVerificationData>,
         result_hashes: &HashMap<u32, [u8; 32]>,
     ) {
         for (&seq, data) in ledger_data {
@@ -284,57 +284,53 @@ impl XdrVerificationManager {
     fn verify_internal_chain(
         &self,
         checkpoint: u32,
-        ledger_data: &HashMap<u32, LedgerVerificationData>,
+        ledger_data: &BTreeMap<u32, LedgerVerificationData>,
     ) {
-        if ledger_data.is_empty() {
-            return;
-        }
+        let entries: Vec<_> = ledger_data.iter().collect();
 
-        let (first_expected, _) = expected_ledger_range(checkpoint);
+        for pair in entries.windows(2) {
+            let mut err_msg: Option<String> = None;
+            let mut ledger_seq: Option<u32> = None;
 
-        for (&seq, data) in ledger_data {
-            let prev_seq = seq.saturating_sub(1);
-
-            if prev_seq < first_expected {
-                continue;
-            }
-
-            let err_msg = if let Some(prev_data) = ledger_data.get(&prev_seq) {
-                if prev_data.computed_hash != data.prev_hash {
-                    Some(format!(
+            if let [(&prev_seq, prev_data), (&seq, data)] = pair {
+                if prev_seq.saturating_add(1) != seq {
+                    err_msg = Some(format!(
+                        "missing predecessor ledger {}",
+                        seq.saturating_sub(1),
+                    ));
+                    ledger_seq = Some(seq);
+                } else if prev_data.computed_hash != data.prev_hash {
+                    err_msg = Some(format!(
                         "hash chain break: previous_ledger_hash {} != computed hash of ledger {} ({})",
                         hex::encode(data.prev_hash),
                         prev_seq,
                         hex::encode(prev_data.computed_hash),
-                    ))
-                } else {
-                    None
+                    ));
+                    ledger_seq = Some(seq);
                 }
             } else {
-                Some(format!("missing predecessor ledger {prev_seq}"))
-            };
+                err_msg = Some(
+                    "internal error: unexpected window size in chain verification".to_string(),
+                );
+            }
 
             if let Some(err_msg) = err_msg {
-                error!("Ledger {seq}: {err_msg}");
+                error!("Checkpoint {checkpoint}: {err_msg}");
                 self.errors.lock().unwrap().push(VerificationError {
                     checkpoint,
-                    ledger_seq: Some(seq),
+                    ledger_seq,
                     message: err_msg,
                 });
             }
         }
     }
 
-    fn store_boundary(&self, checkpoint: u32, ledger_data: &HashMap<u32, LedgerVerificationData>) {
-        if ledger_data.is_empty() {
+    fn store_boundary(&self, checkpoint: u32, ledger_data: &BTreeMap<u32, LedgerVerificationData>) {
+        let (Some((_, first_data)), Some((_, last_data))) =
+            (ledger_data.first_key_value(), ledger_data.last_key_value())
+        else {
             return;
-        }
-
-        let min_seq = *ledger_data.keys().min().unwrap();
-        let max_seq = *ledger_data.keys().max().unwrap();
-
-        let first_data = &ledger_data[&min_seq];
-        let last_data = &ledger_data[&max_seq];
+        };
 
         self.boundaries.lock().unwrap().insert(
             checkpoint,
@@ -396,17 +392,17 @@ impl Default for XdrVerificationManager {
 
 pub fn parse_ledger_entries(
     decompressed_data: &[u8],
-) -> Result<HashMap<u32, LedgerVerificationData>, StorageError> {
+) -> Result<BTreeMap<u32, LedgerVerificationData>, StorageError> {
     parse_ledger_entries_for_checkpoint(decompressed_data, None)
 }
 
 pub(crate) fn parse_ledger_entries_for_checkpoint(
     decompressed_data: &[u8],
     checkpoint: Option<u32>,
-) -> Result<HashMap<u32, LedgerVerificationData>, StorageError> {
+) -> Result<BTreeMap<u32, LedgerVerificationData>, StorageError> {
     let cursor = Cursor::new(decompressed_data);
     let mut limited = Limited::new(cursor, Limits::none());
-    let mut data = HashMap::new();
+    let mut data = BTreeMap::new();
 
     let expected_range = checkpoint.map(expected_ledger_range);
 
@@ -627,7 +623,7 @@ pub async fn decompress_to_buffer(path: &str, reader: Reader) -> Result<Vec<u8>,
 pub async fn parse_ledger_stream(
     path: &str,
     reader: Reader,
-) -> Result<HashMap<u32, LedgerVerificationData>, StorageError> {
+) -> Result<BTreeMap<u32, LedgerVerificationData>, StorageError> {
     let decompressed = decompress_to_buffer(path, reader).await?;
     parse_ledger_entries_for_checkpoint(&decompressed, history_format::checkpoint_from_path(path))
 }
@@ -727,7 +723,7 @@ pub async fn parse_scp_stream(path: &str, reader: Reader) -> Result<(), StorageE
 }
 
 pub enum XdrParseResult {
-    Ledger(HashMap<u32, LedgerVerificationData>),
+    Ledger(BTreeMap<u32, LedgerVerificationData>),
     Transactions(HashMap<u32, [u8; 32]>),
     Results(HashMap<u32, [u8; 32]>),
     None,

--- a/src/xdr_verify.rs
+++ b/src/xdr_verify.rs
@@ -261,14 +261,14 @@ impl XdrVerificationManager {
             let expected = data.expected_tx_set_hash;
 
             let err_msg = if let Some(&actual) = tx_set_hashes.get(&seq) {
-                if actual != expected {
+                if actual == expected {
+                    None
+                } else {
                     Some(format!(
                         "tx set hash mismatch: expected {}, got {}",
                         hex::encode(expected),
                         hex::encode(actual),
                     ))
-                } else {
-                    None
                 }
             } else if data.expected_result_hash != EMPTY_XDR_ARRAY_HASH
                 && !is_empty_tx_set_hash(&expected, &data.prev_hash)
@@ -302,14 +302,14 @@ impl XdrVerificationManager {
             let expected = data.expected_result_hash;
 
             let err_msg = if let Some(&actual) = result_hashes.get(&seq) {
-                if actual != expected {
+                if actual == expected {
+                    None
+                } else {
                     Some(format!(
                         "result set hash mismatch: expected {}, got {}",
                         hex::encode(expected),
                         hex::encode(actual),
                     ))
-                } else {
-                    None
                 }
             } else if expected != EMPTY_XDR_ARRAY_HASH && expected != [0; 32] {
                 Some(format!(

--- a/src/xdr_verify.rs
+++ b/src/xdr_verify.rs
@@ -118,14 +118,12 @@ impl XdrVerificationManager {
         };
 
         let Some(ledger_data) = data.ledger_data else {
-            warn!(
-                "Checkpoint {}: skipping cross-verification because ledger verification data is missing",
-                checkpoint
-            );
+            let err_msg = "missing ledger verification data for checkpoint";
+            warn!("Checkpoint {checkpoint}: skipping cross-verification because {err_msg}");
             self.errors.lock().unwrap().push(VerificationError {
                 checkpoint,
                 ledger_seq: None,
-                message: "missing ledger verification data for checkpoint".to_string(),
+                message: err_msg.to_string(),
             });
             return;
         };
@@ -144,95 +142,61 @@ impl XdrVerificationManager {
         self.store_boundary(checkpoint, &ledger_data);
     }
 
+    // verifies entries in the `ledger_data` matches exactly to the ledgers in
+    // this `checkpoint`
     fn verify_checkpoint_completeness(
         &self,
         checkpoint: u32,
         ledger_data: &HashMap<u32, LedgerVerificationData>,
     ) {
         let (first_ledger, last_ledger) = expected_ledger_range(checkpoint);
-        let expected_count = (last_ledger - first_ledger + 1) as usize;
+        let range = first_ledger..=last_ledger;
+        let fmt_list = |seqs: &[u32]| {
+            seqs.iter()
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
 
         let unexpected: Vec<u32> = ledger_data
             .keys()
             .copied()
-            .filter(|seq| !(first_ledger..=last_ledger).contains(seq))
+            .filter(|seq| !range.contains(seq))
             .collect();
 
         if !unexpected.is_empty() {
-            error!(
-                "Checkpoint {}: found ledger entries outside expected range {}-{}: {}",
-                checkpoint,
-                first_ledger,
-                last_ledger,
-                unexpected
-                    .iter()
-                    .map(|s| s.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ")
+            let err_msg = format!(
+                "unexpected ledger entries outside range {first_ledger}-{last_ledger}: {}",
+                fmt_list(&unexpected),
             );
-
+            error!("Checkpoint {checkpoint}: {err_msg}");
             self.errors.lock().unwrap().push(VerificationError {
                 checkpoint,
                 ledger_seq: unexpected.first().copied(),
-                message: format!(
-                    "unexpected ledger entries outside range {}-{}: {}",
-                    first_ledger,
-                    last_ledger,
-                    unexpected
-                        .iter()
-                        .map(|s| s.to_string())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                ),
+                message: err_msg,
             });
         }
 
-        let mut missing: Vec<u32> = Vec::new();
-        for seq in first_ledger..=last_ledger {
-            if !ledger_data.contains_key(&seq) {
-                missing.push(seq);
-            }
-        }
+        let missing: Vec<u32> = range
+            .filter(|seq| !ledger_data.contains_key(seq))
+            .collect();
 
         if !missing.is_empty() {
-            let missing_str = if missing.len() <= 10 {
-                missing
-                    .iter()
-                    .map(|s| s.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ")
+            let list_str = if missing.len() <= 10 {
+                fmt_list(&missing)
             } else {
-                format!(
-                    "{}, ... ({} more)",
-                    missing[..5]
-                        .iter()
-                        .map(|s| s.to_string())
-                        .collect::<Vec<_>>()
-                        .join(", "),
-                    missing.len() - 5
-                )
+                format!("{}, ... ({} more)", fmt_list(&missing[..5]), missing.len() - 5)
             };
-
-            error!(
-                "Checkpoint {}: missing {} ledger entries (expected {} entries for ledgers {}-{}): {}",
-                checkpoint,
+            let err_msg = format!(
+                "missing {} of {} ledger entries (ledgers {first_ledger}-{last_ledger}): {list_str}",
                 missing.len(),
-                expected_count,
-                first_ledger,
-                last_ledger,
-                missing_str
+                last_ledger - first_ledger + 1,
             );
-
+            error!("Checkpoint {checkpoint}: {err_msg}");
             self.errors.lock().unwrap().push(VerificationError {
                 checkpoint,
                 ledger_seq: missing.first().copied(),
-                message: format!(
-                    "missing {} ledger entries (expected ledgers {}-{}): {}",
-                    missing.len(),
-                    first_ledger,
-                    last_ledger,
-                    missing_str
-                ),
+                message: err_msg,
             });
         }
     }
@@ -246,39 +210,33 @@ impl XdrVerificationManager {
         for (&seq, data) in ledger_data {
             let expected = data.expected_tx_set_hash;
 
-            if let Some(&actual) = tx_set_hashes.get(&seq) {
+            let err_msg = if let Some(&actual) = tx_set_hashes.get(&seq) {
                 if actual != expected {
-                    error!(
-                        "Ledger {}: tx set hash mismatch: expected {}, got {}",
-                        seq,
+                    Some(format!(
+                        "tx set hash mismatch: expected {}, got {}",
                         hex::encode(expected),
-                        hex::encode(actual)
-                    );
-                    self.errors.lock().unwrap().push(VerificationError {
-                        checkpoint,
-                        ledger_seq: Some(seq),
-                        message: format!(
-                            "tx set hash mismatch: expected {}, got {}",
-                            hex::encode(expected),
-                            hex::encode(actual)
-                        ),
-                    });
+                        hex::encode(actual),
+                    ))
+                } else {
+                    None
                 }
             } else if data.expected_result_hash != EMPTY_XDR_ARRAY_HASH
                 && !is_empty_tx_set_hash(&expected, &data.prev_hash)
             {
-                error!(
-                    "Ledger {}: missing tx set entry, expected hash {}",
-                    seq,
-                    hex::encode(expected)
-                );
+                Some(format!(
+                    "missing tx set entry, expected hash {}",
+                    hex::encode(expected),
+                ))
+            } else {
+                None
+            };
+
+            if let Some(err_msg) = err_msg {
+                error!("Ledger {seq}: {err_msg}");
                 self.errors.lock().unwrap().push(VerificationError {
                     checkpoint,
                     ledger_seq: Some(seq),
-                    message: format!(
-                        "missing tx set entry, expected hash {}",
-                        hex::encode(expected)
-                    ),
+                    message: err_msg,
                 });
             }
         }
@@ -293,37 +251,31 @@ impl XdrVerificationManager {
         for (&seq, data) in ledger_data {
             let expected = data.expected_result_hash;
 
-            if let Some(&actual) = result_hashes.get(&seq) {
+            let err_msg = if let Some(&actual) = result_hashes.get(&seq) {
                 if actual != expected {
-                    error!(
-                        "Ledger {}: result set hash mismatch: expected {}, got {}",
-                        seq,
+                    Some(format!(
+                        "result set hash mismatch: expected {}, got {}",
                         hex::encode(expected),
-                        hex::encode(actual)
-                    );
-                    self.errors.lock().unwrap().push(VerificationError {
-                        checkpoint,
-                        ledger_seq: Some(seq),
-                        message: format!(
-                            "result set hash mismatch: expected {}, got {}",
-                            hex::encode(expected),
-                            hex::encode(actual)
-                        ),
-                    });
+                        hex::encode(actual),
+                    ))
+                } else {
+                    None
                 }
             } else if expected != EMPTY_XDR_ARRAY_HASH && expected != [0; 32] {
-                error!(
-                    "Ledger {}: missing result entry, expected hash {}",
-                    seq,
-                    hex::encode(expected)
-                );
+                Some(format!(
+                    "missing result entry, expected hash {}",
+                    hex::encode(expected),
+                ))
+            } else {
+                None
+            };
+
+            if let Some(err_msg) = err_msg {
+                error!("Ledger {seq}: {err_msg}");
                 self.errors.lock().unwrap().push(VerificationError {
                     checkpoint,
                     ledger_seq: Some(seq),
-                    message: format!(
-                        "missing result entry, expected hash {}",
-                        hex::encode(expected)
-                    ),
+                    message: err_msg,
                 });
             }
         }
@@ -347,35 +299,27 @@ impl XdrVerificationManager {
                 continue;
             }
 
-            if let Some(prev_data) = ledger_data.get(&prev_seq) {
+            let err_msg = if let Some(prev_data) = ledger_data.get(&prev_seq) {
                 if prev_data.computed_hash != data.prev_hash {
-                    error!(
-                        "Ledger {}: hash chain break: previous_ledger_hash {} != computed hash of ledger {} ({})",
-                        seq,
+                    Some(format!(
+                        "hash chain break: previous_ledger_hash {} != computed hash of ledger {} ({})",
                         hex::encode(data.prev_hash),
                         prev_seq,
-                        hex::encode(prev_data.computed_hash)
-                    );
-                    self.errors.lock().unwrap().push(VerificationError {
-                        checkpoint,
-                        ledger_seq: Some(seq),
-                        message: format!(
-                            "hash chain break: previous_ledger_hash {} != computed hash of ledger {} ({})",
-                            hex::encode(data.prev_hash),
-                            prev_seq,
-                            hex::encode(prev_data.computed_hash)
-                        ),
-                    });
+                        hex::encode(prev_data.computed_hash),
+                    ))
+                } else {
+                    None
                 }
             } else {
-                error!(
-                    "Ledger {}: missing predecessor ledger {} in checkpoint file",
-                    seq, prev_seq
-                );
+                Some(format!("missing predecessor ledger {prev_seq}"))
+            };
+
+            if let Some(err_msg) = err_msg {
+                error!("Ledger {seq}: {err_msg}");
                 self.errors.lock().unwrap().push(VerificationError {
                     checkpoint,
                     ledger_seq: Some(seq),
-                    message: format!("missing predecessor ledger {}", prev_seq),
+                    message: err_msg,
                 });
             }
         }
@@ -421,22 +365,17 @@ impl XdrVerificationManager {
 
             if curr_boundary.first_prev_hash != prev_boundary.last_computed_hash {
                 let first_ledger = curr_checkpoint.saturating_sub(63);
-                error!(
-                    "Hash chain break between checkpoints {} and {}: ledger {} prev_hash {} != checkpoint {} last hash {}",
-                    prev_checkpoint,
-                    curr_checkpoint,
-                    first_ledger,
+                let err_msg = format!(
+                    "hash chain break between checkpoints {prev_checkpoint} and {curr_checkpoint}: \
+                     ledger {first_ledger} prev_hash {} != checkpoint {prev_checkpoint} last hash {}",
                     hex::encode(curr_boundary.first_prev_hash),
-                    prev_checkpoint,
-                    hex::encode(prev_boundary.last_computed_hash)
+                    hex::encode(prev_boundary.last_computed_hash),
                 );
+                error!("{err_msg}");
                 chain_errors.push(VerificationError {
                     checkpoint: curr_checkpoint,
                     ledger_seq: Some(first_ledger),
-                    message: format!(
-                        "hash chain break between checkpoints {} and {}",
-                        prev_checkpoint, curr_checkpoint
-                    ),
+                    message: err_msg,
                 });
             }
         }

--- a/src/xdr_verify.rs
+++ b/src/xdr_verify.rs
@@ -1,11 +1,20 @@
 //! XDR verification module.
 //!
-//! Provides hash verification for ledger, transaction, and result files.
-//! Cross-file verification validates that:
-//! - Ledger entry.hash == SHA256(entry.header.to_xdr())
-//! - Transaction set hash matches ledger header's scp_value.tx_set_hash
-//! - Result set hash matches ledger header's tx_set_result_hash
-//! - Ledger hash chain: ledger[N].previous_ledger_hash == hash(ledger[N-1])
+//! Parses and validates XDR-encoded archive files (ledger, transaction, result, SCP).
+//!
+//! Per-file verification:
+//! - Ledger header hash: `entry.hash == SHA256(entry.header.to_xdr())`
+//! - Transaction set hash: V0 = `SHA256(prev_hash || tx1 || ... || txN)`,
+//!   V1 = `SHA256(GeneralizedTransactionSet.to_xdr())`
+//! - Result set hash: `SHA256(tx_result_set.to_xdr())`
+//! - SCP entry: validates XDR frame structure
+//!
+//! Cross-file verification (via [`XdrVerificationManager`]):
+//! - Checkpoint completeness: all expected ledger sequences are present
+//! - Transaction set hash matches ledger header's `scp_value.tx_set_hash`
+//! - Result set hash matches ledger header's `tx_set_result_hash`
+//! - Intra-checkpoint hash chain: `ledger[N].previous_ledger_hash == hash(ledger[N-1])`
+//! - Cross-checkpoint hash chain: first ledger's `prev_hash` matches prior checkpoint's last hash
 
 use crate::history_format::{self, CHECKPOINT_FREQUENCY, GENESIS_CHECKPOINT_LEDGER};
 use crate::storage::{from_opendal_error, Error as StorageError, StorageRef};
@@ -46,11 +55,21 @@ pub(crate) fn expected_ledger_range(checkpoint: u32) -> (u32, u32) {
     }
 }
 
+/// Hashes extracted from a single ledger header entry, keyed by ledger sequence.
+/// Produced by [`parse_ledger_entries`], consumed by [`XdrVerificationManager`] for
+/// cross-file and hash-chain verification.
 #[derive(Debug, Clone)]
 pub struct LedgerVerificationData {
+    /// `SHA256(entry.header.to_xdr())` — verified to equal `entry.hash` at parse time.
     pub computed_hash: [u8; 32],
+    /// `entry.header.previous_ledger_hash` — checked against prior ledger's `computed_hash`
+    /// during intra-checkpoint and cross-checkpoint chain verification.
     pub prev_hash: [u8; 32],
+    /// `entry.header.scp_value.tx_set_hash` — cross-verified against the hash computed
+    /// from the transaction file for the same ledger sequence.
     pub expected_tx_set_hash: [u8; 32],
+    /// `entry.header.tx_set_result_hash` — cross-verified against the hash computed
+    /// from the result file for the same ledger sequence.
     pub expected_result_hash: [u8; 32],
 }
 
@@ -67,13 +86,33 @@ struct CheckpointBoundary {
     last_computed_hash: [u8; 32],
 }
 
+/// A verification failure detected during cross-file or chain validation.
+/// Accumulated by [`XdrVerificationManager`] and retrieved via
+/// [`get_errors`](XdrVerificationManager::get_errors).
 #[derive(Debug, Clone)]
 pub struct VerificationError {
     pub checkpoint: u32,
+    /// The specific ledger sequence that failed, or `None` for checkpoint-level errors
+    /// (e.g. missing ledger data, internal errors).
     pub ledger_seq: Option<u32>,
     pub message: String,
 }
 
+/// Coordinates cross-file XDR verification across concurrent checkpoint processing.
+///
+/// **Usage flow:**
+/// 1. For each checkpoint, record parsed data via `record_ledger_data`,
+///    `record_tx_set_hashes`, and `record_result_hashes` (order doesn't matter,
+///    can be called from different tasks concurrently).
+/// 2. Call [`verify_and_release`](Self::verify_and_release) once all three files
+///    for a checkpoint are recorded. This runs completeness, hash-match, and
+///    intra-checkpoint chain checks, then frees the checkpoint's pending data.
+/// 3. After all checkpoints are processed, call [`verify_checkpoint_chain`](Self::verify_checkpoint_chain)
+///    to verify hash continuity across consecutive checkpoint boundaries.
+///    Only checks adjacent checkpoints (skips non-consecutive ones from partial scans).
+/// 4. Retrieve all accumulated errors via [`get_errors`](Self::get_errors).
+///
+/// All state is `Mutex`-protected for concurrent access from the pipeline.
 pub struct XdrVerificationManager {
     pending: Mutex<HashMap<u32, PendingCheckpoint>>,
     boundaries: Mutex<BTreeMap<u32, CheckpointBoundary>>,
@@ -107,6 +146,15 @@ impl XdrVerificationManager {
         entry.result_hashes = Some(hashes);
     }
 
+    /// Run all intra-checkpoint verifications and free the pending data.
+    ///
+    /// Runs (in order): completeness check, tx set hash cross-check, result hash
+    /// cross-check, internal hash chain, then stores the first/last boundary hashes
+    /// for later cross-checkpoint verification. Errors are accumulated, not returned —
+    /// retrieve via [`get_errors`](Self::get_errors).
+    ///
+    /// No-op if no data was recorded for this checkpoint. If ledger data is missing
+    /// but tx/result data exists, records a warning and skips all checks.
     pub fn verify_and_release(&self, checkpoint: u32) {
         let data = {
             let mut pending = self.pending.lock().unwrap();
@@ -341,6 +389,12 @@ impl XdrVerificationManager {
         );
     }
 
+    /// Verify hash chain continuity across consecutive checkpoint boundaries.
+    /// Returns errors directly (not accumulated in `get_errors`) since this runs
+    /// after all per-checkpoint verification is complete.
+    ///
+    /// Only checks adjacent checkpoints separated by exactly `CHECKPOINT_FREQUENCY` —
+    /// non-consecutive checkpoints (from partial or bounded scans) are skipped.
     pub fn verify_checkpoint_chain(&self) -> Vec<VerificationError> {
         let boundaries = self.boundaries.lock().unwrap();
         let mut chain_errors = Vec::new();
@@ -390,6 +444,13 @@ impl Default for XdrVerificationManager {
     }
 }
 
+/// Parse decompressed ledger XDR data into per-ledger verification data.
+///
+/// For each frame, verifies `SHA256(header.to_xdr()) == entry.hash` and extracts
+/// the `prev_hash`, `tx_set_hash`, and `result_hash` fields for cross-file checks.
+///
+/// Returns a fatal error on hash mismatch, duplicate sequence, or malformed XDR.
+/// Empty input returns an empty map (valid for checkpoints with no ledger file).
 pub fn parse_ledger_entries(
     decompressed_data: &[u8],
 ) -> Result<BTreeMap<u32, LedgerVerificationData>, StorageError> {
@@ -542,13 +603,11 @@ pub(crate) fn compute_v1_tx_set_hash(
     Ok(Sha256::digest(&xdr).into())
 }
 
-/// Parse and validate transaction file XDR structure with hash verification.
+/// Parse decompressed result XDR data, computing `SHA256(tx_result_set.to_xdr())`
+/// per ledger. These hashes are cross-verified against `expected_result_hash` from
+/// the ledger headers.
 ///
-/// For each TransactionHistoryEntry:
-/// - V0 (ext == V0): Hash = SHA256(previous_ledger_hash || tx1_xdr || ... || txN_xdr)
-/// - V1 (ext == V1): Hash = SHA256(GeneralizedTransactionSet.to_xdr())
-///
-/// Records computed hashes for cross-verification against ledger headers.
+/// Returns a fatal error on duplicate sequence, out-of-range sequence, or malformed XDR.
 pub fn parse_result_entries(
     decompressed_data: &[u8],
 ) -> Result<HashMap<u32, [u8; 32]>, StorageError> {
@@ -613,13 +672,15 @@ pub(crate) fn parse_result_entries_for_checkpoint(
 }
 
 /// Decompress gzip data from a reader into an in-memory buffer.
-pub async fn decompress_to_buffer(path: &str, reader: Reader) -> Result<Vec<u8>, StorageError> {
+pub(crate) async fn decompress_to_buffer(path: &str, reader: Reader) -> Result<Vec<u8>, StorageError> {
     // the writer is None, thus the return sink is also None, which is safe to
     // be discarded
     let (decompressed, _) = decompress_and_write_internal(path, reader, None).await?;
     Ok(decompressed)
 }
 
+/// Decompress a gzipped ledger file from a reader and parse it.
+/// Infers the checkpoint number from the file path for range validation.
 pub async fn parse_ledger_stream(
     path: &str,
     reader: Reader,
@@ -628,6 +689,8 @@ pub async fn parse_ledger_stream(
     parse_ledger_entries_for_checkpoint(&decompressed, history_format::checkpoint_from_path(path))
 }
 
+/// Decompress a gzipped result file from a reader and parse it.
+/// Infers the checkpoint number from the file path for range validation.
 pub async fn parse_results_stream(
     path: &str,
     reader: Reader,
@@ -636,6 +699,13 @@ pub async fn parse_results_stream(
     parse_result_entries_for_checkpoint(&decompressed, history_format::checkpoint_from_path(path))
 }
 
+/// Parse decompressed transaction XDR data, computing content hashes per ledger.
+/// V0 entries: `SHA256(prev_hash || tx1_xdr || ... || txN_xdr)`.
+/// V1 entries: `SHA256(GeneralizedTransactionSet.to_xdr())`.
+/// These hashes are cross-verified against `expected_tx_set_hash` from the ledger headers.
+///
+/// Returns a fatal error on duplicate sequence, out-of-range sequence, malformed XDR,
+/// or V0 transactions not in hash-sorted order.
 pub fn parse_transaction_entries(
     decompressed_data: &[u8],
 ) -> Result<HashMap<u32, [u8; 32]>, StorageError> {
@@ -694,6 +764,8 @@ pub(crate) fn parse_transaction_entries_for_checkpoint(
     Ok(hashes)
 }
 
+/// Validate SCP history XDR frame structure. Only checks that frames deserialize
+/// correctly — no hashes are computed or returned. Fatal error on malformed XDR.
 pub fn parse_scp_entries(decompressed_data: &[u8]) -> Result<(), StorageError> {
     let cursor = Cursor::new(decompressed_data);
     let mut limited = Limited::new(cursor, Limits::none());
@@ -706,6 +778,8 @@ pub fn parse_scp_entries(decompressed_data: &[u8]) -> Result<(), StorageError> {
     Ok(())
 }
 
+/// Decompress a gzipped transaction file from a reader and parse it.
+/// Infers the checkpoint number from the file path for range validation.
 pub async fn parse_transactions_stream(
     path: &str,
     reader: Reader,
@@ -717,11 +791,15 @@ pub async fn parse_transactions_stream(
     )
 }
 
+/// Decompress a gzipped SCP file from a reader and validate its frame structure.
 pub async fn parse_scp_stream(path: &str, reader: Reader) -> Result<(), StorageError> {
     let decompressed = decompress_to_buffer(path, reader).await?;
     parse_scp_entries(&decompressed)
 }
 
+/// Result of parsing an XDR archive file during a verified mirror write.
+/// Carries computed hashes for the caller to feed into [`XdrVerificationManager`].
+/// `None` is returned for SCP files and unrecognized file types.
 pub enum XdrParseResult {
     Ledger(BTreeMap<u32, LedgerVerificationData>),
     Transactions(HashMap<u32, [u8; 32]>),
@@ -841,6 +919,9 @@ async fn cleanup_non_atomic_partial_write(path: &str, dst_store: &StorageRef) {
     }
 }
 
+/// Decompress, verify XDR structure, and write to destination in a single streaming pass.
+/// The file type is determined from `path` (ledger, transaction, result, or SCP).
+/// Returns the parsed hashes for the caller to record with [`XdrVerificationManager`].
 pub async fn verify_and_write_xdr(
     path: &str,
     reader: Reader,


### PR DESCRIPTION
Follow up to #16 

- Update docs                                                                                                                     
- Consolidate/parameterize XDR verification tests (~20 tests → parameterized rstests)                                             
- Fix flaky backoff timing test using a task-local virtual clock; re-enable in CI ([2f49f46](https://github.com/stellar/rs-stellar-archivist/pull/18/commits/2f49f46786d35431e57b02d3f941b76300c45d48))
- Extract `with_retries()` helper to consolidate pipeline retry loops ([2dddbd3](https://github.com/stellar/rs-stellar-archivist/pull/18/commits/2dddbd34ad89309862fc22806cb2e2079b3aec58))                                                             
- Miscellaneous cleanup for clarity 

see commit history for full details.