### PR TITLE
follow-up 2: more cleanup and refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Stellar Development Foundation <info@stellar.org>"]
 license = "Apache-2.0"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.89.0"
+rust-version = "1.91.0"
 
 [lib]
 name = "stellar_archivist"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Stellar Archivist
 
+> **This software is under active development and has not undergone a security
+> audit. It is provided "as is" with no warranties. Use at your own risk. This
+> project is not covered by the
+> [Stellar Bug Bounty Program](https://stellar.org/bug-bounty-program).**
+
 A Rust implementation of tools for working with Stellar History Archives.
 
 ## Description

--- a/src/cli/mirror.rs
+++ b/src/cli/mirror.rs
@@ -48,8 +48,7 @@ impl MirrorCmd {
             self.allow_mirror_gaps,
             &args.storage_config,
             args.verify,
-        )
-        .await?;
+        )?;
 
         let pipeline_config = PipelineConfig {
             source: self.src.clone(),

--- a/src/cli/mirror.rs
+++ b/src/cli/mirror.rs
@@ -5,7 +5,6 @@ use crate::{
     storage, utils,
 };
 use clap::Parser;
-use std::sync::Arc;
 use tracing::info;
 
 #[derive(Parser, Debug)]
@@ -69,12 +68,7 @@ impl MirrorCmd {
             storage_config: args.storage_config,
         };
 
-        let pipeline = Arc::new(Pipeline::new(
-            operation,
-            pipeline_config,
-            src_store,
-            Some(dst_store),
-        ));
+        let pipeline = Pipeline::new(operation, pipeline_config, src_store, Some(dst_store));
 
         pipeline.run().await.map_err(utils::map_pipeline_error)?;
 

--- a/src/cli/mirror.rs
+++ b/src/cli/mirror.rs
@@ -2,7 +2,7 @@ use crate::cli::{Error, GlobalArgs};
 use crate::{
     mirror_operation::MirrorOperation,
     pipeline::{Pipeline, PipelineConfig},
-    utils,
+    storage, utils,
 };
 use clap::Parser;
 use std::sync::Arc;
@@ -40,28 +40,41 @@ impl MirrorCmd {
             self.src, self.dst, args.concurrency
         );
 
+        let src_store = storage::from_url_with_config(&self.src, &args.storage_config)
+            .map_err(|e| Error::Other(format!("Failed to create source backend: {e}")))?;
+
+        let dst_store = storage::from_url_with_config(&self.dst, &args.storage_config)
+            .map_err(|e| Error::Other(format!("Failed to create destination backend: {e}")))?;
+
+        if !dst_store.supports_writes() {
+            return Err(Error::Other(format!(
+                "Destination does not support writes: {}",
+                self.dst
+            )));
+        }
+
         let operation = MirrorOperation::new(
-            &self.dst,
+            dst_store.clone(),
             self.overwrite,
             self.low,
             self.high,
             self.allow_mirror_gaps,
             &args.storage_config,
             args.verify,
-        )?;
+        );
 
         let pipeline_config = PipelineConfig {
-            source: self.src.clone(),
             concurrency: args.concurrency,
             skip_optional: args.skip_optional,
             storage_config: args.storage_config,
         };
 
-        let pipeline = Arc::new(
-            Pipeline::new(operation, pipeline_config)
-                .await
-                .map_err(utils::map_pipeline_error)?,
-        );
+        let pipeline = Arc::new(Pipeline::new(
+            operation,
+            pipeline_config,
+            src_store,
+            Some(dst_store),
+        ));
 
         pipeline.run().await.map_err(utils::map_pipeline_error)?;
 

--- a/src/cli/scan.rs
+++ b/src/cli/scan.rs
@@ -39,7 +39,7 @@ impl ScanCmd {
             args.storage_config.max_retries as u32,
             args.storage_config.retry_min_delay.as_millis() as u64,
             args.verify,
-        )?;
+        );
 
         let src_store = storage::from_url_with_config(&self.archive, &args.storage_config)
             .map_err(|e| Error::Other(format!("Failed to create source backend: {e}")))?;

--- a/src/cli/scan.rs
+++ b/src/cli/scan.rs
@@ -2,7 +2,7 @@ use crate::cli::{Error, GlobalArgs};
 use crate::{
     pipeline::{Pipeline, PipelineConfig},
     scan_operation::ScanOperation,
-    utils,
+    storage, utils,
 };
 use clap::Parser;
 use std::sync::Arc;
@@ -42,20 +42,16 @@ impl ScanCmd {
             args.verify,
         )?;
 
-        // Configure the pipeline with low/high bounds and storage config
+        let src_store = storage::from_url_with_config(&self.archive, &args.storage_config)
+            .map_err(|e| Error::Other(format!("Failed to create source backend: {e}")))?;
+
         let pipeline_config = PipelineConfig {
-            source: self.archive.clone(),
             concurrency: args.concurrency,
             skip_optional: args.skip_optional,
             storage_config: args.storage_config,
         };
 
-        // Create and run the pipeline
-        let pipeline = Arc::new(
-            Pipeline::new(operation, pipeline_config)
-                .await
-                .map_err(utils::map_pipeline_error)?,
-        );
+        let pipeline = Arc::new(Pipeline::new(operation, pipeline_config, src_store, None));
 
         pipeline.run().await.map_err(utils::map_pipeline_error)?;
 

--- a/src/cli/scan.rs
+++ b/src/cli/scan.rs
@@ -40,8 +40,7 @@ impl ScanCmd {
             args.storage_config.max_retries as u32,
             args.storage_config.retry_min_delay.as_millis() as u64,
             args.verify,
-        )
-        .await?;
+        )?;
 
         // Configure the pipeline with low/high bounds and storage config
         let pipeline_config = PipelineConfig {

--- a/src/cli/scan.rs
+++ b/src/cli/scan.rs
@@ -5,7 +5,6 @@ use crate::{
     storage, utils,
 };
 use clap::Parser;
-use std::sync::Arc;
 use tracing::info;
 
 #[derive(Parser, Debug)]
@@ -51,7 +50,7 @@ impl ScanCmd {
             storage_config: args.storage_config,
         };
 
-        let pipeline = Arc::new(Pipeline::new(operation, pipeline_config, src_store, None));
+        let pipeline = Pipeline::new(operation, pipeline_config, src_store, None);
 
         pipeline.run().await.map_err(utils::map_pipeline_error)?;
 

--- a/src/history_format.rs
+++ b/src/history_format.rs
@@ -317,6 +317,22 @@ impl HistoryFileState {
     }
 }
 
+/// Parse and validate a history file from a buffer.
+///
+/// Deserializes the JSON in `buffer` into a `HistoryFileState` and runs
+/// `validate()`. Used by both the pipeline (when downloading per-checkpoint
+/// history files) and repair (when reading destination-side history files).
+pub fn parse_history(buffer: &opendal::Buffer, path: &str) -> Result<HistoryFileState, Error> {
+    use bytes::Buf;
+    let state: HistoryFileState =
+        serde_json::from_reader(buffer.clone().reader()).map_err(|e| Error::InvalidJson {
+            path: path.to_string(),
+            error: e.to_string(),
+        })?;
+    state.validate()?;
+    Ok(state)
+}
+
 // Check if ledger is a checkpoint (63, 127, 191, ...)
 #[must_use]
 pub fn is_checkpoint(ledger: u32) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,12 @@
+// Raised from the default of 128 to accommodate deeply nested OpenDAL layer
+// types. Each .layer() call (Timeout, ConcurrentLimit, Logging, HttpClient,
+// Throttle) wraps the previous accessor in another generic struct. Async
+// methods in each layer compile to state machines that embed the inner layer's
+// future, so the compiler must recurse through all layers to compute type
+// layouts. The SFTP backend with all layers stacked pushes the nesting past 128
+// (the compiler reports a depth increase of ~130 for a single method like
+// create_dir). 256 gives comfortable headroom.
+#![recursion_limit = "256"]
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::missing_panics_doc)]
 #![allow(clippy::must_use_candidate)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,6 @@ pub mod test_helpers {
         scan_operation::ScanOperation,
         storage::StorageConfig,
     };
-    use std::sync::Arc;
     use std::time::Duration;
 
     /// Create a `StorageConfig` suitable for testing (generous timeouts, limited concurrency)
@@ -263,7 +262,7 @@ pub mod test_helpers {
             storage_config: config.storage_config,
         };
 
-        let pipeline = Arc::new(Pipeline::new(operation, pipeline_config, src_store, None));
+        let pipeline = Pipeline::new(operation, pipeline_config, src_store, None);
         pipeline
             .run()
             .await
@@ -304,12 +303,7 @@ pub mod test_helpers {
             storage_config: config.storage_config,
         };
 
-        let pipeline = Arc::new(Pipeline::new(
-            operation,
-            pipeline_config,
-            src_store,
-            Some(dst_store),
-        ));
+        let pipeline = Pipeline::new(operation, pipeline_config, src_store, Some(dst_store));
         pipeline
             .run()
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,18 +252,18 @@ pub mod test_helpers {
             config.verify,
         )?;
 
+        let src_store =
+            crate::storage::from_url_with_config(&config.archive, &config.storage_config).map_err(
+                |e| crate::Error::Other(format!("Failed to create source backend: {e}")),
+            )?;
+
         let pipeline_config = PipelineConfig {
-            source: config.archive,
             concurrency: config.concurrency,
             skip_optional: config.skip_optional,
             storage_config: config.storage_config,
         };
 
-        let pipeline = Arc::new(
-            Pipeline::new(operation, pipeline_config)
-                .await
-                .map_err(crate::utils::map_pipeline_error)?,
-        );
+        let pipeline = Arc::new(Pipeline::new(operation, pipeline_config, src_store, None));
         pipeline
             .run()
             .await
@@ -271,28 +271,45 @@ pub mod test_helpers {
     }
 
     pub async fn run_mirror(config: MirrorConfig) -> Result<(), crate::Error> {
+        let src_store = crate::storage::from_url_with_config(&config.src, &config.storage_config)
+            .map_err(|e| {
+            crate::Error::Other(format!("Failed to create source backend: {e}"))
+        })?;
+
+        let dst_store = crate::storage::from_url_with_config(&config.dst, &config.storage_config)
+            .map_err(|e| {
+            crate::Error::Other(format!("Failed to create destination backend: {e}"))
+        })?;
+
+        if !dst_store.supports_writes() {
+            return Err(crate::Error::Other(format!(
+                "Destination does not support writes: {}",
+                config.dst
+            )));
+        }
+
         let operation = MirrorOperation::new(
-            &config.dst,
+            dst_store.clone(),
             config.overwrite,
             config.low,
             config.high,
             config.allow_mirror_gaps,
             &config.storage_config,
             config.verify,
-        )?;
+        );
 
         let pipeline_config = PipelineConfig {
-            source: config.src,
             concurrency: config.concurrency,
             skip_optional: config.skip_optional,
             storage_config: config.storage_config,
         };
 
-        let pipeline = Arc::new(
-            Pipeline::new(operation, pipeline_config)
-                .await
-                .map_err(crate::utils::map_pipeline_error)?,
-        );
+        let pipeline = Arc::new(Pipeline::new(
+            operation,
+            pipeline_config,
+            src_store,
+            Some(dst_store),
+        ));
         pipeline
             .run()
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,8 +241,7 @@ pub mod test_helpers {
             config.storage_config.max_retries as u32,
             config.storage_config.retry_min_delay.as_millis() as u64,
             config.verify,
-        )
-        .await?;
+        )?;
 
         let pipeline_config = PipelineConfig {
             source: config.archive,
@@ -271,8 +270,7 @@ pub mod test_helpers {
             config.allow_mirror_gaps,
             &config.storage_config,
             config.verify,
-        )
-        .await?;
+        )?;
 
         let pipeline_config = PipelineConfig {
             source: config.src,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,7 @@ pub mod test_helpers {
             config.storage_config.max_retries as u32,
             config.storage_config.retry_min_delay.as_millis() as u64,
             config.verify,
-        )?;
+        );
 
         let src_store =
             crate::storage::from_url_with_config(&config.archive, &config.storage_config).map_err(

--- a/src/mirror_operation.rs
+++ b/src/mirror_operation.rs
@@ -68,7 +68,7 @@ impl MirrorOperation {
         storage_config: &StorageConfig,
         verify: bool,
     ) -> Result<Self, Error> {
-        let dst_store = crate::storage::from_url_with_config(dst, storage_config).await?;
+        let dst_store = crate::storage::from_url_with_config(dst, storage_config)?;
 
         if !dst_store.supports_writes() {
             return Err(std::io::Error::new(

--- a/src/mirror_operation.rs
+++ b/src/mirror_operation.rs
@@ -227,7 +227,7 @@ impl MirrorOperation {
 
         if let Some(base_path) = self.dst_store.get_base_path() {
             let file_path = base_path.join(path);
-            if file_path.exists() {
+            if tokio::fs::try_exists(&file_path).await.unwrap_or(false) {
                 tokio::fs::remove_file(&file_path).await.map_err(|e| {
                     StorageError::fatal(format!(
                         "Failed to remove partial file {}: {}",

--- a/src/mirror_operation.rs
+++ b/src/mirror_operation.rs
@@ -2,10 +2,11 @@
 
 use crate::history_format;
 use crate::pipeline::{async_trait, Operation};
+use crate::storage::cleanup_partial_file;
 use crate::storage::{Error as StorageError, StorageConfig, StorageRef};
 use crate::utils::{compute_checkpoint_bounds, fetch_well_known_history_file, ArchiveStats};
 use crate::xdr_verify::XdrVerificationManager;
-use opendal::{Buffer, Reader};
+use opendal::Reader;
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::OnceCell;
@@ -40,7 +41,6 @@ pub enum Error {
 pub struct MirrorOperation {
     dst_store: StorageRef,
     overwrite: bool,
-    stats: ArchiveStats,
 
     // User-specified arguments from CLI
     low: Option<u32>,
@@ -60,27 +60,22 @@ pub struct MirrorOperation {
 
 impl MirrorOperation {
     pub fn new(
-        dst: &str,
+        dst_store: StorageRef,
         overwrite: bool,
         low: Option<u32>,
         high: Option<u32>,
         allow_mirror_gaps: bool,
         storage_config: &StorageConfig,
         verify: bool,
-    ) -> Result<Self, Error> {
-        let dst_store = crate::storage::from_url_with_config(dst, storage_config)?;
+    ) -> Self {
+        debug_assert!(
+            dst_store.supports_writes(),
+            "MirrorOperation requires a writable destination store"
+        );
 
-        if !dst_store.supports_writes() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Unsupported,
-                format!("Destination storage backend does not support write operations. Only filesystem destinations (file://) are currently supported: {dst}"),
-            ).into());
-        }
-
-        Ok(Self {
+        Self {
             dst_store,
             overwrite,
-            stats: ArchiveStats::new(),
             low,
             high,
             allow_mirror_gaps,
@@ -92,7 +87,7 @@ impl MirrorOperation {
             } else {
                 None
             },
-        })
+        }
     }
 
     /// Get the destination's initial checkpoint from .well-known file, caching the result
@@ -214,31 +209,10 @@ impl MirrorOperation {
         match self.dst_store.copy_from_reader(path, reader).await {
             Ok(()) => Ok(()),
             Err(e) => {
-                self.cleanup_partial_file(path).await?;
+                cleanup_partial_file(&self.dst_store, path).await?;
                 Err(e)
             }
         }
-    }
-
-    async fn cleanup_partial_file(&self, path: &str) -> Result<(), StorageError> {
-        if self.dst_store.uses_atomic_writes() {
-            return Ok(());
-        }
-
-        if let Some(base_path) = self.dst_store.get_base_path() {
-            let file_path = base_path.join(path);
-            if tokio::fs::try_exists(&file_path).await.unwrap_or(false) {
-                tokio::fs::remove_file(&file_path).await.map_err(|e| {
-                    StorageError::fatal(format!(
-                        "Failed to remove partial file {}: {}",
-                        file_path.display(),
-                        e
-                    ))
-                })?;
-            }
-        }
-
-        Ok(())
     }
 
     fn checkpoint_from_verified_path(path: &str) -> Result<u32, StorageError> {
@@ -404,13 +378,14 @@ impl Operation for MirrorOperation {
         }
     }
 
-    async fn process_object(&self, path: &str, reader: Reader) -> Result<(), StorageError> {
+    async fn process_object(&self, path: &str, src_store: &StorageRef) -> Result<(), StorageError> {
+        let reader = src_store.open_reader(path).await?;
         if let Some(ref manager) = self.verification_manager {
             if crate::history_format::is_bucket_file(path) {
                 match crate::verify::verify_and_write_bucket(path, reader, &self.dst_store).await {
                     Ok(()) => Ok(()),
                     Err(e) => {
-                        self.cleanup_partial_file(path).await?;
+                        cleanup_partial_file(&self.dst_store, path).await?;
                         Err(e)
                     }
                 }
@@ -426,7 +401,7 @@ impl Operation for MirrorOperation {
                     {
                         Ok(result) => result,
                         Err(e) => {
-                            self.cleanup_partial_file(path).await?;
+                            cleanup_partial_file(&self.dst_store, path).await?;
                             return Err(e);
                         }
                     };
@@ -457,44 +432,21 @@ impl Operation for MirrorOperation {
         }
     }
 
-    async fn process_buffer(&self, path: &str, buffer: Buffer) {
-        match self.dst_store.write(path, buffer).await {
-            Ok(()) => {
-                self.stats.record_success(path);
-            }
-            Err(e) => {
-                if let Err(cleanup_err) = self.cleanup_partial_file(path).await {
-                    error!("Failed to cleanup partial file {}: {}", path, cleanup_err);
-                }
-                error!("Failed to write history file {}: {}", path, e);
-                self.stats.record_failure(path).await;
-            }
-        }
-    }
-
-    fn record_success(&self, path: &str) {
-        self.stats.record_success(path);
-    }
-
-    async fn record_failure(&self, path: &str) {
-        self.stats.record_failure(path).await;
-    }
-
-    fn record_skipped(&self, path: &str) {
-        self.stats.record_skipped(path);
-    }
-
-    async fn finalize(&self, highest_checkpoint: u32) -> Result<(), crate::pipeline::Error> {
+    async fn finalize(
+        &self,
+        highest_checkpoint: u32,
+        stats: &ArchiveStats,
+    ) -> Result<(), crate::pipeline::Error> {
         if let Some(ref manager) = self.verification_manager {
             let chain_errors = manager.verify_checkpoint_chain();
             for err in &chain_errors {
                 error!("Checkpoint {}: {}", err.checkpoint, err.message);
-                self.stats.record_failure("xdr-chain-verification").await;
+                stats.record_failure("xdr-chain-verification").await;
             }
 
             let accumulated_errors = manager.get_errors();
             for _ in &accumulated_errors {
-                self.stats.record_failure("xdr-cross-verification").await;
+                stats.record_failure("xdr-cross-verification").await;
             }
 
             let total_errors = chain_errors.len() + accumulated_errors.len();
@@ -506,9 +458,9 @@ impl Operation for MirrorOperation {
             }
         }
 
-        self.stats.report("mirror").await;
+        stats.report("mirror").await;
 
-        if self.stats.has_failures() {
+        if stats.has_failures() {
             return Err(Error::MirrorFailed.into());
         }
 

--- a/src/mirror_operation.rs
+++ b/src/mirror_operation.rs
@@ -59,7 +59,7 @@ pub struct MirrorOperation {
 }
 
 impl MirrorOperation {
-    pub async fn new(
+    pub fn new(
         dst: &str,
         overwrite: bool,
         low: Option<u32>,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -270,15 +270,7 @@ impl<Op: Operation> Pipeline<Op> {
         };
 
         // Parse and validate
-        let parse_result: Result<HistoryFileState, Error> = (|| {
-            let state: HistoryFileState = serde_json::from_reader(buffer.clone().reader())
-                .map_err(|e| history_format::Error::InvalidJson {
-                    path: history_path.clone(),
-                    error: e.to_string(),
-                })?;
-            state.validate()?;
-            Ok(state)
-        })();
+        let parse_result = parse_history(&buffer, &history_path);
 
         match parse_result {
             Ok(state) => {
@@ -370,6 +362,18 @@ impl<Op: Operation> Pipeline<Op> {
             }
         }
     }
+}
+
+fn parse_history(buffer: &Buffer, path: &str) -> Result<HistoryFileState, Error> {
+    let state: HistoryFileState =
+        serde_json::from_reader(buffer.clone().reader()).map_err(|e| {
+            history_format::Error::InvalidJson {
+                path: path.to_string(),
+                error: e.to_string(),
+            }
+        })?;
+    state.validate()?;
+    Ok(state)
 }
 
 pub use async_trait::async_trait;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -165,28 +165,24 @@ impl<Op: Operation> Pipeline<Op> {
         }
 
         // Form a lazy iterator that produces checkpoint-processing futures
+        let num_completed = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let checkpoints = (lower_bound..=upper_bound)
             .step_by(history_format::CHECKPOINT_FREQUENCY as usize)
             .map(|ck| {
                 let pipeline = self.clone();
+                let completed = num_completed.clone();
                 async move {
                     pipeline.process_checkpoint(ck).await;
+                    let done = completed.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+                    if done % PROGRESS_REPORTING_FREQUENCY == 0 || done == total_count {
+                        info!("Progress: {}/{} checkpoints processed", done, total_count);
+                    }
                 }
             });
 
         // Process checkpoints concurrently, limiting to config.concurrency at a time
         stream::iter(checkpoints)
-            .enumerate()
-            .for_each_concurrent(self.config.concurrency, |(i, fut)| async move {
-                fut.await;
-                let completed = i + 1;
-                if completed % PROGRESS_REPORTING_FREQUENCY == 0 || completed == total_count {
-                    info!(
-                        "Progress: {}/{} checkpoints processed",
-                        completed, total_count
-                    );
-                }
-            })
+            .for_each_concurrent(self.config.concurrency, |fut| fut)
             .await;
 
         // Finalize operation with the highest checkpoint we processed

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -6,19 +6,18 @@
 
 use crate::{
     history_format::{self, bucket_path, checkpoint_path, HistoryFileState},
-    storage::StorageConfig,
-    utils::RetryState,
+    storage::{cleanup_partial_file, download_buffer, StorageConfig, StorageRef},
+    utils::{self, ArchiveStats},
 };
-use bytes::Buf;
 use futures_util::{
     future::{join, join3, join_all},
     stream, StreamExt,
 };
 use lru::LruCache;
-use opendal::{Buffer, Reader};
+use opendal::Buffer;
 use std::sync::{Arc, Mutex};
 use thiserror::Error;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 /// Pipeline errors
 #[derive(Error, Debug)]
@@ -45,72 +44,68 @@ const BUCKET_LRU_CACHE_SIZE: usize = 1_000_000;
 /// How often to report progress (every N checkpoints)
 const PROGRESS_REPORTING_FREQUENCY: usize = 100;
 
-/// Unified operation trait for scan and mirror
+// ============================================================================
+// Operation trait
+// ============================================================================
+
+/// Operation trait for scan, mirror, and repair.
+///
+/// Pipeline owns `src_store`, `dst_store` (optional), `stats`, and handles
+/// buffer writing and stats recording. Operations implement domain-specific
+/// logic: checkpoint bounds, file processing, verification, and finalization.
 #[async_trait::async_trait]
 pub trait Operation: Send + Sync + 'static {
-    /// Get the checkpoint bounds for this operation
-    /// Returns (`lower_bound`, `upper_bound`) checkpoints to process
-    async fn get_checkpoint_bounds(
+    /// Get the checkpoint bounds for this operation.
+    /// Returns (`lower_bound`, `upper_bound`) checkpoints to process.
+    async fn get_checkpoint_bounds(&self, source: &StorageRef) -> Result<(u32, u32), Error>;
+
+    /// Process a file from the source archive.
+    /// Each operation decides how to handle it (existence check, verify, copy, etc.).
+    async fn process_object(
         &self,
-        source: &crate::storage::StorageRef,
-    ) -> Result<(u32, u32), Error>;
+        path: &str,
+        _src_store: &StorageRef,
+    ) -> Result<(), crate::storage::Error>;
 
-    /// Process an object by streaming its content from the provided reader.
-    /// Only called when `existence_check_only()` returns false.
-    ///
-    /// Returns:
-    /// - Ok(()) on success
-    /// - Err(e) on failure (storage layer handles retries internally)
-    async fn process_object(&self, path: &str, reader: Reader)
-        -> Result<(), crate::storage::Error>;
-
-    /// Process an object from an in-memory buffer.
-    /// Used when the content is already loaded (e.g., history files that are parsed).
-    /// Each operation handles success/failure recording internally.
-    async fn process_buffer(&self, path: &str, buffer: Buffer);
-
-    /// Record a successful file processing
-    fn record_success(&self, path: &str);
-
-    /// Record a failed file processing
-    async fn record_failure(&self, path: &str);
-
-    /// Record a skipped file (already exists at destination)
-    fn record_skipped(&self, path: &str);
-
-    /// Called when all work is complete
-    /// The pipeline passes the highest checkpoint that was processed
-    /// This is where operations should check their internal failure counts and return an error if needed
-    async fn finalize(&self, highest_checkpoint: u32) -> Result<(), Error>;
-
-    /// Indicates if this operation only needs to check file existence, not read content.
-    fn existence_check_only(&self) -> bool {
-        false
-    }
+    /// Called when all work is complete. Pipeline passes stats for operations
+    /// that need to check failure counts or record additional failures
+    /// (e.g., cross-validation).
+    async fn finalize(&self, highest_checkpoint: u32, stats: &ArchiveStats) -> Result<(), Error>;
 
     /// Pre-check before hitting the source. Allows operations to skip files
     /// without making a source request (e.g., if destination already exists).
     ///
     /// Returns:
-    /// - Some(Ok(())) to skip (file already handled)
-    /// - Some(Err(e)) if pre-check failed
-    /// - None to proceed with fetching from source
+    /// - `Some(Ok(()))` to skip (file already handled)
+    /// - `Some(Err(e))` if pre-check failed
+    /// - `None` to proceed with fetching from source
     async fn pre_check(&self, _path: &str) -> Option<Result<(), crate::storage::Error>> {
-        None // Default: always proceed to source
+        None
     }
 
     /// Called when all files for a checkpoint have been processed.
-    /// This is the hook for per-checkpoint verification to trigger
-    /// and release memory for the completed checkpoint.
-    fn finalize_checkpoint(&self, _checkpoint: u32) {
-        // No-op by default
+    fn finalize_checkpoint(&self, _checkpoint: u32) {}
+
+    /// Fetch the history buffer for a checkpoint.
+    ///
+    /// Default implementation downloads from `src_store` (scan/mirror behavior).
+    /// Repair overrides this to read from destination first, falling back to source.
+    async fn fetch_history_buffer(
+        &self,
+        history_path: &str,
+        src_store: &StorageRef,
+        _dst_store: Option<&StorageRef>,
+    ) -> Result<Buffer, crate::storage::Error> {
+        download_buffer(src_store, history_path).await
     }
 }
 
+// ============================================================================
+// Pipeline config and struct
+// ============================================================================
+
 #[derive(Debug, Clone)]
 pub struct PipelineConfig {
-    /// Source archive URL, as provided by the user
-    pub source: String,
     /// Number of concurrent checkpoint workers
     pub concurrency: usize,
     /// Whether to skip optional SCP files
@@ -122,37 +117,36 @@ pub struct PipelineConfig {
 pub struct Pipeline<Op: Operation> {
     operation: Op,
     config: PipelineConfig,
-    src_store: crate::storage::StorageRef,
+    src_store: StorageRef,
+    dst_store: Option<StorageRef>,
+    stats: ArchiveStats,
     bucket_lru: Mutex<LruCache<String, ()>>,
 }
 
 impl<Op: Operation> Pipeline<Op> {
-    /// Create a new pipeline
-    pub async fn new(operation: Op, config: PipelineConfig) -> Result<Self, Error> {
-        let src_store =
-            crate::storage::from_url_with_config(&config.source, &config.storage_config).map_err(
-                |e| {
-                    std::io::Error::other(format!(
-                        "Failed to create storage backend for {}: {}",
-                        config.source, e
-                    ))
-                },
-            )?;
-
+    /// Create a new pipeline.
+    /// Callers create storage backends and pass them in directly.
+    pub fn new(
+        operation: Op,
+        config: PipelineConfig,
+        src_store: StorageRef,
+        dst_store: Option<StorageRef>,
+    ) -> Self {
         let bucket_lru = Mutex::new(LruCache::new(
             std::num::NonZeroUsize::new(BUCKET_LRU_CACHE_SIZE).unwrap(),
         ));
 
-        Ok(Self {
+        Self {
             operation,
             config,
             src_store,
+            dst_store,
+            stats: ArchiveStats::new(),
             bucket_lru,
-        })
+        }
     }
 
     pub async fn run(self: Arc<Self>) -> Result<(), Error> {
-        // Get checkpoint bounds from the operation
         let (lower_bound, upper_bound) = self
             .operation
             .get_checkpoint_bounds(&self.src_store)
@@ -164,7 +158,6 @@ impl<Op: Operation> Pipeline<Op> {
             return Ok(());
         }
 
-        // Form a lazy iterator that produces checkpoint-processing futures
         let num_completed = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let checkpoints = (lower_bound..=upper_bound)
             .step_by(history_format::CHECKPOINT_FREQUENCY as usize)
@@ -174,32 +167,28 @@ impl<Op: Operation> Pipeline<Op> {
                 async move {
                     pipeline.process_checkpoint(ck).await;
                     let done = completed.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
-                    if done % PROGRESS_REPORTING_FREQUENCY == 0 || done == total_count {
+                    if done.is_multiple_of(PROGRESS_REPORTING_FREQUENCY) || done == total_count {
                         info!("Progress: {}/{} checkpoints processed", done, total_count);
                     }
                 }
             });
 
-        // Process checkpoints concurrently, limiting to config.concurrency at a time
         stream::iter(checkpoints)
             .for_each_concurrent(self.config.concurrency, |fut| fut)
             .await;
 
-        // Finalize operation with the highest checkpoint we processed
-        self.operation.finalize(upper_bound).await?;
+        self.operation.finalize(upper_bound, &self.stats).await?;
 
         Ok(())
     }
 
     async fn process_checkpoint(self: Arc<Self>, checkpoint: u32) {
-        // Process history file and categories concurrently
-        let hist = self.clone().process_history(checkpoint);
+        let hist = self.clone().process_history_and_buckets(checkpoint);
         let cats = join_all(["ledger", "transactions", "results"].map(|cat| {
             let path = checkpoint_path(cat, checkpoint);
             self.clone().process_file(path)
         }));
 
-        // Optionally add SCP files
         if self.config.skip_optional {
             let _ = join(hist, cats).await;
         } else {
@@ -208,90 +197,81 @@ impl<Op: Operation> Pipeline<Op> {
             let _ = join3(hist, cats, scp).await;
         }
 
-        // Notify operation that all files for this checkpoint are processed
         self.operation.finalize_checkpoint(checkpoint);
     }
 
-    /// Run an async operation with retries and exponential backoff.
-    ///
-    /// Creates a per-call `RetryState`, retries on transient errors, and returns
-    /// `Ok(T)` on success or the final `Err` when retries are exhausted.
-    async fn with_retries<T>(
-        &self,
-        path: &str,
-        action: &str,
-        mut f: impl AsyncFnMut() -> Result<T, crate::storage::Error>,
-    ) -> Result<T, crate::storage::Error> {
-        let mut retry = RetryState::new(
-            self.config.storage_config.max_retries as u32,
-            self.config.storage_config.retry_min_delay.as_millis() as u64,
-        );
-        loop {
-            match f().await {
-                Ok(val) => return Ok(val),
-                Err(e) => {
-                    if retry.should_retry(&e, action, path) {
-                        retry.backoff().await;
-                        continue;
-                    }
-                    return Err(e);
-                }
-            }
-        }
-    }
-
-    /// Process a history file for a checkpoint.
-    /// Downloads and parses the history JSON, then processes buckets.
-    /// Retries are handled at this level to avoid file corruption from partial streams.
-    async fn process_history(self: Arc<Self>, checkpoint: u32) {
-        use futures_util::TryStreamExt;
-
+    /// Process a history file for a checkpoint: download, parse, write buffer
+    /// to destination (if present), and process buckets.
+    async fn process_history_and_buckets(self: Arc<Self>, checkpoint: u32) {
         let history_path = checkpoint_path("history", checkpoint);
 
-        // Download the history file with retries
-        let Ok(buffer) = self
-            .with_retries(&history_path, "download history", async || {
-                let reader = self.src_store.open_reader(&history_path).await?;
-                let stream = reader
-                    .into_stream(..)
+        // Download history buffer (operation can override sourcing)
+        let Ok(buffer) = utils::with_retries(
+            self.config.storage_config.max_retries as u32,
+            self.config.storage_config.retry_min_delay.as_millis() as u64,
+            "download history",
+            &history_path,
+            async || {
+                self.operation
+                    .fetch_history_buffer(&history_path, &self.src_store, self.dst_store.as_ref())
                     .await
-                    .map_err(|e| crate::storage::from_opendal_error(e, "Stream error"))?;
-                let chunks: Vec<Buffer> = stream
-                    .try_collect()
-                    .await
-                    .map_err(|e| crate::storage::from_opendal_error(e, "Read error"))?;
-                let buffer: Buffer = chunks.into_iter().flatten().collect();
-                Ok(buffer)
-            })
-            .await
+            },
+        )
+        .await
         else {
-            self.operation.record_failure(&history_path).await;
+            warn!(
+                "Bucket references for checkpoint {} (0x{:08x}) were not checked \
+                 because {} could not be downloaded",
+                checkpoint, checkpoint, history_path
+            );
+            self.stats.record_failure(&history_path).await;
             return;
         };
 
         // Parse and validate
-        let parse_result = parse_history(&buffer, &history_path);
-
-        match parse_result {
+        match history_format::parse_history(&buffer, &history_path) {
             Ok(state) => {
-                // Process the history file and process buckets concurrently
-                let history_path_clone = history_path.clone();
-                let process_history = self.operation.process_buffer(&history_path_clone, buffer);
+                // Write buffer to destination (if present) and process buckets concurrently
+                let write_history_buffer = self.process_buffer(&history_path, buffer);
                 let buckets = self.clone().process_buckets(state);
-                let _ = join(process_history, buckets).await;
+                let _ = join(write_history_buffer, buckets).await;
             }
             Err(e) => {
                 error!(
                     "Failed to parse history JSON for checkpoint {} (0x{:08x}): {}",
                     checkpoint, checkpoint, e
                 );
-                self.operation.record_failure(&history_path).await;
+                warn!(
+                    "Bucket references for checkpoint {} (0x{:08x}) were not checked \
+                     because {} could not be parsed",
+                    checkpoint, checkpoint, history_path
+                );
+                self.stats.record_failure(&history_path).await;
             }
         }
     }
 
+    /// Write the history buffer to the destination store (if present).
+    /// For scan (no dst_store), just records success.
+    async fn process_buffer(&self, path: &str, buffer: Buffer) {
+        if let Some(ref dst) = self.dst_store {
+            match dst.write(path, buffer).await {
+                Ok(()) => self.stats.record_success(path),
+                Err(e) => {
+                    if let Err(cleanup_err) = cleanup_partial_file(dst, path).await {
+                        error!("Failed to cleanup partial file {}: {}", path, cleanup_err);
+                    }
+                    error!("Failed to write history file {}: {}", path, e);
+                    self.stats.record_failure(path).await;
+                }
+            }
+        } else {
+            // Scan mode: no destination, just record success
+            self.stats.record_success(path);
+        }
+    }
+
     async fn process_buckets(self: Arc<Self>, state: HistoryFileState) {
-        // Filter buckets through LRU cache for deduplication
         let bucket_futures: Vec<_> = {
             let mut cache = self.bucket_lru.lock().unwrap();
             state
@@ -299,7 +279,6 @@ impl<Op: Operation> Pipeline<Op> {
                 .iter()
                 .filter_map(|bucket| {
                     if cache.put(bucket.clone(), ()).is_none() {
-                        // New bucket, process it
                         bucket_path(bucket).ok().map(|path| {
                             let pipeline = self.clone();
                             async move {
@@ -307,7 +286,6 @@ impl<Op: Operation> Pipeline<Op> {
                             }
                         })
                     } else {
-                        // Already seen, skip
                         None
                     }
                 })
@@ -318,62 +296,41 @@ impl<Op: Operation> Pipeline<Op> {
     }
 
     /// Process a single file (bucket, ledger, transactions, results, scp).
-    /// All retries are handled at this level - no automatic retries in `OpenDAL`.
     async fn process_file(self: Arc<Self>, path: String) {
         // Pre-check: allow operation to skip without querying source
         if let Some(result) = self.operation.pre_check(&path).await {
             match result {
                 Ok(()) => {
                     debug!("Skipping: {}", path);
-                    self.operation.record_skipped(&path);
+                    self.stats.record_skipped(&path);
                 }
                 Err(e) => {
                     error!("Pre-check failed for {}: {}", path, e);
-                    self.operation.record_failure(&path).await;
+                    self.stats.record_failure(&path).await;
                 }
             }
             return;
         }
 
-        let result = if self.operation.existence_check_only() {
-            self.with_retries(&path, "check existence of", async || {
-                if self.src_store.exists(&path).await? {
-                    Ok(())
-                } else {
-                    Err(crate::storage::Error::not_found())
-                }
-            })
-            .await
-        } else {
-            self.with_retries(&path, "process", async || {
-                let reader = self.src_store.open_reader(&path).await?;
-                self.operation.process_object(&path, reader).await
-            })
-            .await
-        };
+        let result = utils::with_retries(
+            self.config.storage_config.max_retries as u32,
+            self.config.storage_config.retry_min_delay.as_millis() as u64,
+            "process",
+            &path,
+            async || self.operation.process_object(&path, &self.src_store).await,
+        )
+        .await;
 
         match result {
             Ok(()) => {
                 debug!("Processed: {}", path);
-                self.operation.record_success(&path);
+                self.stats.record_success(&path);
             }
             Err(_) => {
-                self.operation.record_failure(&path).await;
+                self.stats.record_failure(&path).await;
             }
         }
     }
-}
-
-fn parse_history(buffer: &Buffer, path: &str) -> Result<HistoryFileState, Error> {
-    let state: HistoryFileState =
-        serde_json::from_reader(buffer.clone().reader()).map_err(|e| {
-            history_format::Error::InvalidJson {
-                path: path.to_string(),
-                error: e.to_string(),
-            }
-        })?;
-    state.validate()?;
-    Ok(state)
 }
 
 pub use async_trait::async_trait;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -130,13 +130,14 @@ impl<Op: Operation> Pipeline<Op> {
     /// Create a new pipeline
     pub async fn new(operation: Op, config: PipelineConfig) -> Result<Self, Error> {
         let src_store =
-            crate::storage::from_url_with_config(&config.source, &config.storage_config)
-                .map_err(|e| {
+            crate::storage::from_url_with_config(&config.source, &config.storage_config).map_err(
+                |e| {
                     std::io::Error::other(format!(
                         "Failed to create storage backend for {}: {}",
                         config.source, e
                     ))
-                })?;
+                },
+            )?;
 
         let bucket_lru = Mutex::new(LruCache::new(
             std::num::NonZeroUsize::new(BUCKET_LRU_CACHE_SIZE).unwrap(),

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -131,7 +131,6 @@ impl<Op: Operation> Pipeline<Op> {
     pub async fn new(operation: Op, config: PipelineConfig) -> Result<Self, Error> {
         let src_store =
             crate::storage::from_url_with_config(&config.source, &config.storage_config)
-                .await
                 .map_err(|e| {
                     std::io::Error::other(format!(
                         "Failed to create storage backend for {}: {}",

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -15,7 +15,7 @@ use futures_util::{
 };
 use lru::LruCache;
 use opendal::Buffer;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 use thiserror::Error;
 use tracing::{debug, error, info, warn};
 
@@ -146,7 +146,7 @@ impl<Op: Operation> Pipeline<Op> {
         }
     }
 
-    pub async fn run(self: Arc<Self>) -> Result<(), Error> {
+    pub async fn run(&self) -> Result<(), Error> {
         let (lower_bound, upper_bound) = self
             .operation
             .get_checkpoint_bounds(&self.src_store)
@@ -158,23 +158,19 @@ impl<Op: Operation> Pipeline<Op> {
             return Ok(());
         }
 
-        let num_completed = Arc::new(std::sync::atomic::AtomicUsize::new(0));
-        let checkpoints = (lower_bound..=upper_bound)
-            .step_by(history_format::CHECKPOINT_FREQUENCY as usize)
-            .map(|ck| {
-                let pipeline = self.clone();
-                let completed = num_completed.clone();
-                async move {
-                    pipeline.process_checkpoint(ck).await;
-                    let done = completed.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
-                    if done.is_multiple_of(PROGRESS_REPORTING_FREQUENCY) || done == total_count {
-                        info!("Progress: {}/{} checkpoints processed", done, total_count);
-                    }
-                }
-            });
+        let num_completed = std::sync::atomic::AtomicUsize::new(0);
+        let completed_ref = &num_completed;
+        let checkpoints =
+            (lower_bound..=upper_bound).step_by(history_format::CHECKPOINT_FREQUENCY as usize);
 
         stream::iter(checkpoints)
-            .for_each_concurrent(self.config.concurrency, |fut| fut)
+            .for_each_concurrent(self.config.concurrency, |ck| async move {
+                self.process_checkpoint(ck).await;
+                let done = completed_ref.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+                if done.is_multiple_of(PROGRESS_REPORTING_FREQUENCY) || done == total_count {
+                    info!("Progress: {}/{} checkpoints processed", done, total_count);
+                }
+            })
             .await;
 
         self.operation.finalize(upper_bound, &self.stats).await?;
@@ -182,18 +178,25 @@ impl<Op: Operation> Pipeline<Op> {
         Ok(())
     }
 
-    async fn process_checkpoint(self: Arc<Self>, checkpoint: u32) {
-        let hist = self.clone().process_history_and_buckets(checkpoint);
+    /// Process a single checkpoint: history+buckets concurrently with the
+    /// per-checkpoint files (ledger, transactions, results, optional scp).
+    ///
+    /// Public so external callers (e.g. repair's retry phase, which builds a
+    /// `Pipeline<MirrorOperation>` to re-mirror failed checkpoints) can drive
+    /// the pipeline machinery directly without `Pipeline::run`'s full bounds +
+    /// iteration loop.
+    pub async fn process_checkpoint(&self, checkpoint: u32) {
+        let hist = self.process_history_and_buckets(checkpoint);
         let cats = join_all(["ledger", "transactions", "results"].map(|cat| {
             let path = checkpoint_path(cat, checkpoint);
-            self.clone().process_file(path)
+            self.process_file(path)
         }));
 
         if self.config.skip_optional {
             let _ = join(hist, cats).await;
         } else {
             let path = checkpoint_path("scp", checkpoint);
-            let scp = self.clone().process_file(path);
+            let scp = self.process_file(path);
             let _ = join3(hist, cats, scp).await;
         }
 
@@ -202,7 +205,7 @@ impl<Op: Operation> Pipeline<Op> {
 
     /// Process a history file for a checkpoint: download, parse, write buffer
     /// to destination (if present), and process buckets.
-    async fn process_history_and_buckets(self: Arc<Self>, checkpoint: u32) {
+    async fn process_history_and_buckets(&self, checkpoint: u32) {
         let history_path = checkpoint_path("history", checkpoint);
 
         // Download history buffer (operation can override sourcing)
@@ -211,10 +214,12 @@ impl<Op: Operation> Pipeline<Op> {
             self.config.storage_config.retry_min_delay.as_millis() as u64,
             "download history",
             &history_path,
-            async || {
-                self.operation
-                    .fetch_history_buffer(&history_path, &self.src_store, self.dst_store.as_ref())
-                    .await
+            || {
+                self.operation.fetch_history_buffer(
+                    &history_path,
+                    &self.src_store,
+                    self.dst_store.as_ref(),
+                )
             },
         )
         .await
@@ -233,7 +238,7 @@ impl<Op: Operation> Pipeline<Op> {
             Ok(state) => {
                 // Write buffer to destination (if present) and process buckets concurrently
                 let write_history_buffer = self.process_buffer(&history_path, buffer);
-                let buckets = self.clone().process_buckets(state);
+                let buckets = self.process_buckets(state);
                 let _ = join(write_history_buffer, buckets).await;
             }
             Err(e) => {
@@ -271,7 +276,7 @@ impl<Op: Operation> Pipeline<Op> {
         }
     }
 
-    async fn process_buckets(self: Arc<Self>, state: HistoryFileState) {
+    async fn process_buckets(&self, state: HistoryFileState) {
         let bucket_futures: Vec<_> = {
             let mut cache = self.bucket_lru.lock().unwrap();
             state
@@ -279,12 +284,7 @@ impl<Op: Operation> Pipeline<Op> {
                 .iter()
                 .filter_map(|bucket| {
                     if cache.put(bucket.clone(), ()).is_none() {
-                        bucket_path(bucket).ok().map(|path| {
-                            let pipeline = self.clone();
-                            async move {
-                                pipeline.process_file(path).await;
-                            }
-                        })
+                        bucket_path(bucket).ok().map(|path| self.process_file(path))
                     } else {
                         None
                     }
@@ -296,7 +296,7 @@ impl<Op: Operation> Pipeline<Op> {
     }
 
     /// Process a single file (bucket, ledger, transactions, results, scp).
-    async fn process_file(self: Arc<Self>, path: String) {
+    async fn process_file(&self, path: String) {
         // Pre-check: allow operation to skip without querying source
         if let Some(result) = self.operation.pre_check(&path).await {
             match result {
@@ -317,7 +317,7 @@ impl<Op: Operation> Pipeline<Op> {
             self.config.storage_config.retry_min_delay.as_millis() as u64,
             "process",
             &path,
-            async || self.operation.process_object(&path, &self.src_store).await,
+            || self.operation.process_object(&path, &self.src_store),
         )
         .await;
 

--- a/src/scan_operation.rs
+++ b/src/scan_operation.rs
@@ -39,7 +39,7 @@ pub struct ScanOperation {
 }
 
 impl ScanOperation {
-    pub async fn new(
+    pub fn new(
         low: Option<u32>,
         high: Option<u32>,
         max_retries: u32,

--- a/src/scan_operation.rs
+++ b/src/scan_operation.rs
@@ -43,8 +43,8 @@ impl ScanOperation {
         max_retries: u32,
         retry_min_delay_ms: u64,
         verify: bool,
-    ) -> Result<Self, Error> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             low,
             high,
             max_retries,
@@ -54,7 +54,7 @@ impl ScanOperation {
             } else {
                 None
             },
-        })
+        }
     }
 
     async fn consume_stream(&self, path: &str, reader: Reader) -> Result<(), StorageError> {

--- a/src/scan_operation.rs
+++ b/src/scan_operation.rs
@@ -3,7 +3,7 @@ use crate::pipeline::{async_trait, Operation};
 use crate::storage::{from_opendal_error, Error as StorageError, StorageRef};
 use crate::utils::{compute_checkpoint_bounds, fetch_well_known_history_file, ArchiveStats};
 use crate::xdr_verify::XdrVerificationManager;
-use opendal::{Buffer, Reader};
+use opendal::Reader;
 use std::sync::Arc;
 use thiserror::Error;
 use tracing::error;
@@ -24,8 +24,6 @@ pub enum Error {
 }
 
 pub struct ScanOperation {
-    stats: ArchiveStats,
-
     // User-specified arguments from CLI
     low: Option<u32>,
     high: Option<u32>,
@@ -47,7 +45,6 @@ impl ScanOperation {
         verify: bool,
     ) -> Result<Self, Error> {
         Ok(Self {
-            stats: ArchiveStats::new(),
             low,
             high,
             max_retries,
@@ -95,13 +92,10 @@ impl Operation for ScanOperation {
             .map_err(|e| crate::pipeline::Error::ScanOperation(Error::Utils(e)))
     }
 
-    async fn process_object(&self, path: &str, reader: Reader) -> Result<(), StorageError> {
-        debug_assert!(
-            !self.existence_check_only(),
-            "process_object called but existence_check_only() is true"
-        );
-
+    async fn process_object(&self, path: &str, src_store: &StorageRef) -> Result<(), StorageError> {
         if let Some(ref manager) = self.verification_manager {
+            // Verify mode: stream content and validate
+            let reader = src_store.open_reader(path).await?;
             if crate::history_format::is_bucket_file(path) {
                 crate::verify::verify_bucket_stream(path, reader).await
             } else if crate::history_format::is_ledger_file(path) {
@@ -125,38 +119,30 @@ impl Operation for ScanOperation {
                 self.consume_stream(path, reader).await
             }
         } else {
-            self.consume_stream(path, reader).await
+            // Existence-only mode: just check if file exists (no streaming)
+            if src_store.exists(path).await? {
+                Ok(())
+            } else {
+                Err(StorageError::not_found())
+            }
         }
     }
 
-    async fn process_buffer(&self, path: &str, _buffer: Buffer) {
-        // Scan doesn't write - just record that we successfully downloaded and parsed the history
-        self.stats.record_success(path);
-    }
-
-    fn record_success(&self, path: &str) {
-        self.stats.record_success(path);
-    }
-
-    async fn record_failure(&self, path: &str) {
-        self.stats.record_failure(path).await;
-    }
-
-    fn record_skipped(&self, _path: &str) {
-        // Scan never skips files
-    }
-
-    async fn finalize(&self, _highest_checkpoint: u32) -> Result<(), crate::pipeline::Error> {
+    async fn finalize(
+        &self,
+        _highest_checkpoint: u32,
+        stats: &ArchiveStats,
+    ) -> Result<(), crate::pipeline::Error> {
         if let Some(ref manager) = self.verification_manager {
             let chain_errors = manager.verify_checkpoint_chain();
             for err in &chain_errors {
                 error!("Checkpoint {}: {}", err.checkpoint, err.message);
-                self.stats.record_failure("xdr-chain-verification").await;
+                stats.record_failure("xdr-chain-verification").await;
             }
 
             let accumulated_errors = manager.get_errors();
             for _ in &accumulated_errors {
-                self.stats.record_failure("xdr-cross-verification").await;
+                stats.record_failure("xdr-cross-verification").await;
             }
 
             let total_errors = chain_errors.len() + accumulated_errors.len();
@@ -168,17 +154,13 @@ impl Operation for ScanOperation {
             }
         }
 
-        self.stats.report("scan").await;
+        stats.report("scan").await;
 
-        if self.stats.has_failures() {
+        if stats.has_failures() {
             return Err(Error::ScanFailed.into());
         }
 
         Ok(())
-    }
-
-    fn existence_check_only(&self) -> bool {
-        self.verification_manager.is_none()
     }
 
     fn finalize_checkpoint(&self, checkpoint: u32) {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -345,18 +345,17 @@ impl OpendalStore {
             return Err(e);
         }
 
-        tokio::fs::rename(&tmp_path, &file_path)
-            .await
-            .map_err(|e| {
-                from_io_error(
-                    e,
-                    &format!(
-                        "Failed to rename {} to {}",
-                        tmp_path.display(),
-                        file_path.display()
-                    ),
-                )
-            })?;
+        if let Err(e) = tokio::fs::rename(&tmp_path, &file_path).await {
+            let _ = tokio::fs::remove_file(&tmp_path).await;
+            return Err(from_io_error(
+                e,
+                &format!(
+                    "Failed to rename {} to {}",
+                    tmp_path.display(),
+                    file_path.display()
+                ),
+            ));
+        }
 
         Ok(())
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -769,7 +769,7 @@ impl Storage for OpendalStore {
 /// - `sftp://[user@]host[:port]/path` - SFTP (uses `SFTP_USER`, `SFTP_KEY` env vars)
 ///
 /// Creates a backend from a URL string with configuration.
-pub async fn from_url_with_config(
+pub fn from_url_with_config(
     url_str: &str,
     config: &StorageConfig,
 ) -> Result<StorageRef, Error> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1048,3 +1048,40 @@ fn file_url_to_path(url: &url::Url, url_str: &str) -> Result<PathBuf, Error> {
         "Invalid file URL '{url_str}': unable to convert to filesystem path"
     )))
 }
+
+/// Download a file into a buffer from a storage backend.
+pub async fn download_buffer(store: &StorageRef, path: &str) -> Result<opendal::Buffer, Error> {
+    use futures_util::TryStreamExt;
+
+    let reader = store.open_reader(path).await?;
+    let stream = reader
+        .into_stream(..)
+        .await
+        .map_err(|e| from_opendal_error(e, "Stream error"))?;
+    let chunks: Vec<opendal::Buffer> = stream
+        .try_collect()
+        .await
+        .map_err(|e| from_opendal_error(e, "Read error"))?;
+    Ok(chunks.into_iter().flatten().collect())
+}
+
+/// Clean up a partial file on the destination after a write failure.
+/// No-op on atomic-write backends (temp file is discarded automatically).
+pub async fn cleanup_partial_file(store: &StorageRef, path: &str) -> Result<(), Error> {
+    if store.uses_atomic_writes() {
+        return Ok(());
+    }
+    if let Some(base_path) = store.get_base_path() {
+        let file_path = base_path.join(path);
+        if tokio::fs::try_exists(&file_path).await.unwrap_or(false) {
+            tokio::fs::remove_file(&file_path).await.map_err(|e| {
+                Error::fatal(format!(
+                    "Failed to remove partial file {}: {}",
+                    file_path.display(),
+                    e
+                ))
+            })?;
+        }
+    }
+    Ok(())
+}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -284,9 +284,14 @@ impl OpendalStore {
         }
     }
 
-    /// Direct file write that bypasses `OpenDAL`'s writer layer.
-    /// This avoids the `WriteGenerator` buffering and the fsync in `close()`.
-    /// Used when `fsync_file_writes` is false for filesystem backends.
+    /// Direct file write that bypasses `OpenDAL`'s writer layer. This avoids
+    /// the `WriteGenerator` buffering and the fsync in `close()`.
+    ///
+    /// Writes to a `.tmp` file first, then renames to the final path. This
+    /// prevents partial files from being visible at the final path if the
+    /// process is killed mid-write (SIGKILL, OOM etc.). Without this, a resumed
+    /// mirror would see the partial file via `pre_check()` and skip
+    /// re-downloading it.
     async fn copy_from_reader_direct(
         &self,
         root_path: &Path,
@@ -295,6 +300,7 @@ impl OpendalStore {
     ) -> Result<(), Error> {
         let object = object.trim_start_matches('/');
         let file_path = root_path.join(object);
+        let tmp_path = file_path.with_extension("tmp");
 
         if let Some(parent) = file_path.parent() {
             tokio::fs::create_dir_all(parent).await.map_err(|e| {
@@ -305,8 +311,11 @@ impl OpendalStore {
             })?;
         }
 
-        let mut file = tokio::fs::File::create(&file_path).await.map_err(|e| {
-            from_io_error(e, &format!("Failed to create file {}", file_path.display()))
+        let mut file = tokio::fs::File::create(&tmp_path).await.map_err(|e| {
+            from_io_error(
+                e,
+                &format!("Failed to create temp file {}", tmp_path.display()),
+            )
         })?;
 
         let mut stream = reader
@@ -314,18 +323,40 @@ impl OpendalStore {
             .await
             .map_err(|e| from_opendal_error(e, &format!("Failed to create stream for {object}")))?;
 
-        while let Some(result) = stream.next().await {
-            let buffer = result.map_err(|e| from_opendal_error(e, "Failed to read from source"))?;
-            for bytes in buffer {
-                file.write_all(&bytes).await.map_err(|e| {
-                    from_io_error(e, &format!("Failed to write to {}", file_path.display()))
-                })?;
+        let write_result: Result<(), Error> = async {
+            while let Some(result) = stream.next().await {
+                let buffer =
+                    result.map_err(|e| from_opendal_error(e, "Failed to read from source"))?;
+                for bytes in buffer {
+                    file.write_all(&bytes).await.map_err(|e| {
+                        from_io_error(e, &format!("Failed to write to {}", tmp_path.display()))
+                    })?;
+                }
             }
+            file.flush().await.map_err(|e| {
+                from_io_error(e, &format!("Failed to flush {}", tmp_path.display()))
+            })?;
+            Ok(())
+        }
+        .await;
+
+        if let Err(e) = write_result {
+            let _ = tokio::fs::remove_file(&tmp_path).await;
+            return Err(e);
         }
 
-        file.flush()
+        tokio::fs::rename(&tmp_path, &file_path)
             .await
-            .map_err(|e| from_io_error(e, &format!("Failed to flush {}", file_path.display())))?;
+            .map_err(|e| {
+                from_io_error(
+                    e,
+                    &format!(
+                        "Failed to rename {} to {}",
+                        tmp_path.display(),
+                        file_path.display()
+                    ),
+                )
+            })?;
 
         Ok(())
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -769,10 +769,7 @@ impl Storage for OpendalStore {
 /// - `sftp://[user@]host[:port]/path` - SFTP (uses `SFTP_USER`, `SFTP_KEY` env vars)
 ///
 /// Creates a backend from a URL string with configuration.
-pub fn from_url_with_config(
-    url_str: &str,
-    config: &StorageConfig,
-) -> Result<StorageRef, Error> {
+pub fn from_url_with_config(url_str: &str, config: &StorageConfig) -> Result<StorageRef, Error> {
     use url::Url;
 
     let normalized_url_str = if url_str.starts_with("file://") {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -300,7 +300,7 @@ impl OpendalStore {
     ) -> Result<(), Error> {
         let object = object.trim_start_matches('/');
         let file_path = root_path.join(object);
-        let tmp_path = file_path.with_extension("tmp");
+        let tmp_path = file_path.with_added_extension("tmp");
 
         if let Some(parent) = file_path.parent() {
             tokio::fs::create_dir_all(parent).await.map_err(|e| {

--- a/src/tests/mirror_op_test.rs
+++ b/src/tests/mirror_op_test.rs
@@ -621,6 +621,62 @@ async fn test_mirror_replaces_empty_files() {
     );
 }
 
+/// Verifies that a process crash during non-atomic writes doesn't leave partial
+/// files at the final path, preventing silent corruption on resume.
+///
+/// Scenario: mirror checkpoints 63 and 127, then simulate a crash by deleting
+/// a file at checkpoint 127 and leaving a truncated `.tmp` (as the temp+rename
+/// write strategy would). Resume mirror and verify the file is re-downloaded
+/// correctly and `.well-known` only advances once everything succeeds.
+#[tokio::test]
+async fn test_mirror_resume_after_crash_redownloads_missing_file() {
+    let src = file_url_from_path(&testnet_small_archive_path());
+    let temp_dir = TempDir::new().unwrap();
+    let dest_path = temp_dir.path().join("mirror_dest");
+    let dst = file_url_from_path(&dest_path);
+
+    // Mirror checkpoints 63 and 127
+    run_mirror(MirrorConfig::new(&src, &dst).skip_optional().high(127))
+        .await
+        .expect("Initial mirror should succeed");
+
+    // Record correct content of a file at checkpoint 127
+    let ledger_file = dest_path.join("ledger/00/00/00/ledger-0000007f.xdr.gz");
+    let correct_content = std::fs::read(&ledger_file).unwrap();
+    assert!(correct_content.len() > 10);
+
+    // Simulate crash: remove the final file, leave a truncated .tmp behind.
+    // With temp+rename, a killed process leaves only the .tmp — the final
+    // path was never created/updated for this write.
+    let tmp_file = ledger_file.with_extension("tmp");
+    std::fs::write(&tmp_file, &correct_content[..5]).unwrap();
+    std::fs::remove_file(&ledger_file).unwrap();
+
+    // Roll back .well-known to checkpoint 63 so resume re-processes checkpoint 127.
+    // This simulates the state after a crash: .well-known was at 63 (the previous
+    // successful run), and the run that was mirroring 127 was killed before finalize.
+    let wellknown = dest_path.join(".well-known/stellar-history.json");
+    let history_63 = dest_path.join("history/00/00/00/history-0000003f.json");
+    std::fs::copy(&history_63, &wellknown).unwrap();
+
+    // Resume mirror — should re-download the missing file at checkpoint 127
+    run_mirror(MirrorConfig::new(&src, &dst).skip_optional().high(127))
+        .await
+        .expect("Resume mirror should succeed");
+
+    // Final file should exist with correct content
+    let resumed_content = std::fs::read(&ledger_file).unwrap();
+    assert_eq!(resumed_content, correct_content);
+
+    // Stale .tmp should be gone (overwritten by the new write's temp, then renamed)
+    assert!(!tmp_file.exists(), "Stale .tmp should not remain");
+
+    // .well-known should now be at checkpoint 127
+    let wk_content = std::fs::read_to_string(&wellknown).unwrap();
+    let wk: serde_json::Value = serde_json::from_str(&wk_content).unwrap();
+    assert_eq!(wk["currentLedger"].as_u64().unwrap(), 127);
+}
+
 //=============================================================================
 // .well-known update tests
 //=============================================================================

--- a/src/tests/mirror_op_test.rs
+++ b/src/tests/mirror_op_test.rs
@@ -14,6 +14,7 @@ use crate::{
     test_helpers::{run_mirror, run_scan, test_storage_config, MirrorConfig, ScanConfig},
 };
 use axum::{routing::get_service, Router};
+use rstest::rstest;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -621,46 +622,61 @@ async fn test_mirror_replaces_empty_files() {
     );
 }
 
-/// Verifies that a process crash during non-atomic writes doesn't leave partial
-/// files at the final path, preventing silent corruption on resume.
+/// Verifies that a process crash during non-atomic writes doesn't leave
+/// partial files at the final path, preventing silent corruption on resume.
 ///
-/// Scenario: mirror checkpoints 63 and 127, then simulate a crash by deleting
-/// a file at checkpoint 127 and leaving a truncated `.tmp` (as the temp+rename
-/// write strategy would). Resume mirror and verify the file is re-downloaded
-/// correctly and `.well-known` only advances once everything succeeds.
+/// Two cases cover the two distinct write paths in `MirrorOperation::process_object`:
+/// - `no_verify`: ledger files go through `OpendalStore::copy_from_reader_direct`
+///   (storage.rs) — pure tokio::fs temp+rename.
+/// - `verify`: ledger files go through `xdr_verify::verify_and_write_xdr` —
+///   OpenDAL writer/sink + tokio::fs::rename at commit.
+///
+/// Scenario: mirror checkpoints 63 and 127, simulate a crash on a ledger file
+/// at checkpoint 127 by deleting the final file and leaving a truncated `.tmp`
+/// behind (matching what a killed temp+rename would leave). Resume and confirm
+/// the file is re-downloaded correctly, the stale `.tmp` is gone, and
+/// `.well-known` only advances once everything succeeds.
+#[rstest]
+#[case::no_verify(false)]
+#[case::verify(true)]
 #[tokio::test]
-async fn test_mirror_resume_after_crash_redownloads_missing_file() {
+async fn test_mirror_resume_after_crash_redownloads_missing_file(#[case] verify: bool) {
     let src = file_url_from_path(&testnet_small_archive_path());
     let temp_dir = TempDir::new().unwrap();
     let dest_path = temp_dir.path().join("mirror_dest");
     let dst = file_url_from_path(&dest_path);
 
+    let make_config = || {
+        let mut c = MirrorConfig::new(&src, &dst).skip_optional().high(127);
+        if verify {
+            c = c.verify();
+        }
+        c
+    };
+
     // Mirror checkpoints 63 and 127
-    run_mirror(MirrorConfig::new(&src, &dst).skip_optional().high(127))
+    run_mirror(make_config())
         .await
         .expect("Initial mirror should succeed");
 
-    // Record correct content of a file at checkpoint 127
+    // Record correct content of a ledger file at checkpoint 127
     let ledger_file = dest_path.join("ledger/00/00/00/ledger-0000007f.xdr.gz");
     let correct_content = std::fs::read(&ledger_file).unwrap();
     assert!(correct_content.len() > 10);
 
     // Simulate crash: remove the final file, leave a truncated .tmp behind.
-    // With temp+rename, a killed process leaves only the .tmp — the final
-    // path was never created/updated for this write.
+    // Both write paths use "{final}.tmp" as the temp name.
     let tmp_file = ledger_file.with_added_extension("tmp");
     std::fs::write(&tmp_file, &correct_content[..5]).unwrap();
     std::fs::remove_file(&ledger_file).unwrap();
 
     // Roll back .well-known to checkpoint 63 so resume re-processes checkpoint 127.
-    // This simulates the state after a crash: .well-known was at 63 (the previous
-    // successful run), and the run that was mirroring 127 was killed before finalize.
     let wellknown = dest_path.join(".well-known/stellar-history.json");
     let history_63 = dest_path.join("history/00/00/00/history-0000003f.json");
     std::fs::copy(&history_63, &wellknown).unwrap();
 
-    // Resume mirror — should re-download the missing file at checkpoint 127
-    run_mirror(MirrorConfig::new(&src, &dst).skip_optional().high(127))
+    // Resume — should re-download the missing file at checkpoint 127
+    run_mirror(make_config())
         .await
         .expect("Resume mirror should succeed");
 

--- a/src/tests/mirror_op_test.rs
+++ b/src/tests/mirror_op_test.rs
@@ -648,7 +648,7 @@ async fn test_mirror_resume_after_crash_redownloads_missing_file() {
     // Simulate crash: remove the final file, leave a truncated .tmp behind.
     // With temp+rename, a killed process leaves only the .tmp — the final
     // path was never created/updated for this write.
-    let tmp_file = ledger_file.with_extension("tmp");
+    let tmp_file = ledger_file.with_added_extension("tmp");
     std::fs::write(&tmp_file, &correct_content[..5]).unwrap();
     std::fs::remove_file(&ledger_file).unwrap();
 

--- a/src/tests/mirror_op_test.rs
+++ b/src/tests/mirror_op_test.rs
@@ -879,10 +879,10 @@ async fn test_mirror_race_condition_with_advancing_archive() {
                 let count = request_count.fetch_add(1, Ordering::Relaxed);
                 let well_known_content = if count >= advance_threshold {
                     // Return advanced .well-known after threshold
-                    advanced_well_known.to_string()
+                    advanced_well_known.clone()
                 } else {
                     // Initial reads get initial .well-known
-                    initial_well_known.to_string()
+                    initial_well_known.clone()
                 };
                 async move { well_known_content }
             }),

--- a/src/tests/path_normalization_test.rs
+++ b/src/tests/path_normalization_test.rs
@@ -26,7 +26,6 @@ async fn test_file_url_round_trip_base_path() {
     let url = file_url_from_path(temp_dir.path());
 
     let store = from_url_with_config(&url, &test_storage_config())
-        .await
         .expect("Failed to create store from file URL");
     let base = store
         .get_base_path()
@@ -42,7 +41,6 @@ async fn test_file_url_backslashes_are_accepted() {
     let raw = format!("file://{}", temp_dir.path().display());
 
     let store = from_url_with_config(&raw, &test_storage_config())
-        .await
         .expect("Failed to create store from backslash file URL");
     let base = store
         .get_base_path()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -304,19 +304,35 @@ impl RetryState {
     }
 }
 
-/// Run an async fallible operation with retry-on-transient-error and
+/// Run a fallible async operation with retry-on-transient-error and
 /// exponential backoff.
 ///
 /// Wraps `f` in a `RetryState` loop: on `Err`, calls `should_retry` to
 /// classify the error and (if retryable) waits via `backoff()` before retrying.
 /// Used by the pipeline (per-file processing) and by repair manual mode.
-pub async fn with_retries<T>(
+///
+/// **Signature note.** `F: FnMut() -> Fut` with an explicit `Fut: Send` bound
+/// (rather than `impl AsyncFnMut() -> ...`) so the future's `Send`-ness is a
+/// concrete constraint on a named type — this propagates cleanly through
+/// outer compositions, including async_trait-wrapped methods that demand Send
+/// on the boxed future. `AsyncFnMut`'s implicit `CallMutFuture` associated
+/// type has no Send bound and is opaque, which trips Send-HRTB inference when
+/// the resulting future is composed inside another async_trait method.
+///
+/// Caller usage: pass `|| obj.async_method(args)` (closure returns the future
+/// directly) rather than `async || obj.async_method(args).await` — both work,
+/// but the former avoids an extra opaque async-block layer.
+pub async fn with_retries<T, F, Fut>(
     max_retries: u32,
     retry_min_delay_ms: u64,
     action: &str,
     path: &str,
-    mut f: impl AsyncFnMut() -> Result<T, crate::storage::Error>,
-) -> Result<T, crate::storage::Error> {
+    mut f: F,
+) -> Result<T, crate::storage::Error>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, crate::storage::Error>> + Send,
+{
     let mut retry = RetryState::new(max_retries, retry_min_delay_ms);
     loop {
         match f().await {
@@ -344,46 +360,18 @@ pub async fn fetch_well_known_history_file(
     retry_min_delay_ms: u64,
 ) -> Result<HistoryFileState, Error> {
     use crate::history_format::ROOT_WELL_KNOWN_PATH;
-    use futures_util::TryStreamExt;
-    use opendal::Buffer;
 
     debug!("Fetching .well-known from path: {}", ROOT_WELL_KNOWN_PATH);
 
-    let mut retry_state = RetryState::new(max_retries, retry_min_delay_ms);
-
-    // Download the .well-known file with retries at this level
-    let buffer = loop {
-        let download_result: Result<Buffer, crate::storage::Error> = async {
-            let reader = store.open_reader(ROOT_WELL_KNOWN_PATH).await?;
-            // Convert to stream and collect all chunks
-            let stream = reader
-                .into_stream(..)
-                .await
-                .map_err(|e| crate::storage::from_opendal_error(e, "Stream error"))?;
-            let chunks: Vec<Buffer> = stream
-                .try_collect()
-                .await
-                .map_err(|e| crate::storage::from_opendal_error(e, "Read error"))?;
-            // Merge chunks into a single buffer
-            let buffer: Buffer = chunks.into_iter().flatten().collect();
-            Ok(buffer)
-        }
-        .await;
-
-        match download_result {
-            Ok(buf) => break buf,
-            Err(e) => {
-                if retry_state.should_retry(&e, "download", ROOT_WELL_KNOWN_PATH) {
-                    retry_state.backoff().await;
-                    continue;
-                }
-                return Err(std::io::Error::other(format!(
-                    "Failed to fetch {ROOT_WELL_KNOWN_PATH}: {e}"
-                ))
-                .into());
-            }
-        }
-    };
+    let buffer = with_retries(
+        max_retries,
+        retry_min_delay_ms,
+        "download",
+        ROOT_WELL_KNOWN_PATH,
+        || crate::storage::download_buffer(store, ROOT_WELL_KNOWN_PATH),
+    )
+    .await
+    .map_err(|e| std::io::Error::other(format!("Failed to fetch {ROOT_WELL_KNOWN_PATH}: {e}")))?;
 
     // Parse the JSON
     tracing::debug!("Read {} bytes from {}", buffer.len(), ROOT_WELL_KNOWN_PATH);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -304,6 +304,34 @@ impl RetryState {
     }
 }
 
+/// Run an async fallible operation with retry-on-transient-error and
+/// exponential backoff.
+///
+/// Wraps `f` in a `RetryState` loop: on `Err`, calls `should_retry` to
+/// classify the error and (if retryable) waits via `backoff()` before retrying.
+/// Used by the pipeline (per-file processing) and by repair manual mode.
+pub async fn with_retries<T>(
+    max_retries: u32,
+    retry_min_delay_ms: u64,
+    action: &str,
+    path: &str,
+    mut f: impl AsyncFnMut() -> Result<T, crate::storage::Error>,
+) -> Result<T, crate::storage::Error> {
+    let mut retry = RetryState::new(max_retries, retry_min_delay_ms);
+    loop {
+        match f().await {
+            Ok(val) => return Ok(val),
+            Err(e) => {
+                if retry.should_retry(&e, action, path) {
+                    retry.backoff().await;
+                    continue;
+                }
+                return Err(e);
+            }
+        }
+    }
+}
+
 /// Fetch and validate .well-known/stellar-history.json from store
 ///
 /// Parameters:

--- a/src/xdr_verify.rs
+++ b/src/xdr_verify.rs
@@ -44,6 +44,10 @@ pub(crate) const EMPTY_XDR_ARRAY_HASH: [u8; 32] = [
 const DECOMPRESS_BUFFER_SIZE: usize = 64 * 1024;
 const CHANNEL_CAPACITY: usize = 64;
 
+/// Inclusive `(first_ledger, last_ledger)` range covered by a given checkpoint.
+///
+/// - **Genesis checkpoint (63)**: `(1, 63)` — ledger 0 has no header entry.
+/// - **All others**: `(checkpoint - 63, checkpoint)` — 64 ledgers per checkpoint.
 pub(crate) fn expected_ledger_range(checkpoint: u32) -> (u32, u32) {
     if checkpoint == GENESIS_CHECKPOINT_LEDGER {
         (1, GENESIS_CHECKPOINT_LEDGER)
@@ -120,6 +124,7 @@ pub struct XdrVerificationManager {
 }
 
 impl XdrVerificationManager {
+    /// Construct an empty manager with no pending data, boundaries, or errors.
     pub fn new() -> Self {
         Self {
             pending: Mutex::new(HashMap::new()),
@@ -128,18 +133,26 @@ impl XdrVerificationManager {
         }
     }
 
+    /// Record per-ledger data parsed from the **ledger** file of a checkpoint.
+    /// Overwrites any previously recorded ledger data for the same checkpoint.
+    /// Pair with `record_tx_set_hashes` and `record_result_hashes`, then call
+    /// [`verify_and_release`](Self::verify_and_release) once all three are in.
     pub fn record_ledger_data(&self, checkpoint: u32, data: BTreeMap<u32, LedgerVerificationData>) {
         let mut pending = self.pending.lock().unwrap();
         let entry = pending.entry(checkpoint).or_default();
         entry.ledger_data = Some(data);
     }
 
+    /// Record per-ledger transaction-set hashes parsed from the **transactions**
+    /// file of a checkpoint. See [`record_ledger_data`](Self::record_ledger_data).
     pub fn record_tx_set_hashes(&self, checkpoint: u32, hashes: HashMap<u32, [u8; 32]>) {
         let mut pending = self.pending.lock().unwrap();
         let entry = pending.entry(checkpoint).or_default();
         entry.tx_set_hashes = Some(hashes);
     }
 
+    /// Record per-ledger result-set hashes parsed from the **results** file of
+    /// a checkpoint. See [`record_ledger_data`](Self::record_ledger_data).
     pub fn record_result_hashes(&self, checkpoint: u32, hashes: HashMap<u32, [u8; 32]>) {
         let mut pending = self.pending.lock().unwrap();
         let entry = pending.entry(checkpoint).or_default();
@@ -190,8 +203,13 @@ impl XdrVerificationManager {
         self.store_boundary(checkpoint, &ledger_data);
     }
 
-    // verifies entries in the `ledger_data` matches exactly to the ledgers in
-    // this `checkpoint`
+    /// Verify that `ledger_data` covers exactly the ledger sequences expected
+    /// for this checkpoint (per [`expected_ledger_range`]).
+    ///
+    /// Records two error kinds in `self.errors`:
+    /// - **Unexpected**: ledger entries with sequences outside the expected range
+    /// - **Missing**: ledger sequences in the expected range with no entry
+    ///   (truncated to the first 5 + a count when more than 10 are missing)
     fn verify_checkpoint_completeness(
         &self,
         checkpoint: u32,
@@ -251,6 +269,19 @@ impl XdrVerificationManager {
         }
     }
 
+    /// Cross-verify per-ledger tx-set hashes from the **transactions** file
+    /// against the `expected_tx_set_hash` field embedded in the ledger header.
+    ///
+    /// For each ledger sequence in `ledger_data`:
+    /// - **Mismatch**: actual tx-set hash differs from `expected_tx_set_hash`
+    /// - **Missing**: no entry in `tx_set_hashes`, *and* the ledger isn't
+    ///   genuinely empty. A missing entry is acceptable only when both the
+    ///   expected result hash equals [`EMPTY_XDR_ARRAY_HASH`] *and* the
+    ///   expected tx-set hash is one of the recognized "empty tx set"
+    ///   sentinels (see [`is_empty_tx_set_hash`]) — stellar-core omits empty
+    ///   tx-set entries from the transactions file.
+    ///
+    /// Errors are pushed to `self.errors`.
     fn verify_tx_set_hashes_internal(
         &self,
         checkpoint: u32,
@@ -292,6 +323,16 @@ impl XdrVerificationManager {
         }
     }
 
+    /// Cross-verify per-ledger result-set hashes from the **results** file
+    /// against the `expected_result_hash` field embedded in the ledger header.
+    ///
+    /// For each ledger sequence in `ledger_data`:
+    /// - **Mismatch**: actual result-set hash differs from `expected_result_hash`
+    /// - **Missing**: no entry in `result_hashes` *and* `expected_result_hash`
+    ///   is non-zero and not [`EMPTY_XDR_ARRAY_HASH`] (those two values mark
+    ///   "no result entry expected" and are tolerated as missing).
+    ///
+    /// Errors are pushed to `self.errors`.
     fn verify_result_hashes_internal(
         &self,
         checkpoint: u32,
@@ -331,6 +372,15 @@ impl XdrVerificationManager {
         }
     }
 
+    /// Verify the hash chain *within* a single checkpoint.
+    ///
+    /// For each adjacent ledger pair `(prev, curr)` in `ledger_data`:
+    /// - **Consecutive**: `curr.seq == prev.seq + 1` (else "missing predecessor")
+    /// - **Linked**: `curr.prev_hash == prev.computed_hash` (else "hash chain break")
+    ///
+    /// Failures are pushed to `self.errors`. The link across checkpoint
+    /// boundaries (this checkpoint's first ledger ↔ prior checkpoint's last)
+    /// is handled separately by [`verify_checkpoint_chain`](Self::verify_checkpoint_chain).
     fn verify_internal_chain(
         &self,
         checkpoint: u32,
@@ -375,6 +425,17 @@ impl XdrVerificationManager {
         }
     }
 
+    /// Stash the first/last ledger hashes of this checkpoint into
+    /// `self.boundaries` so that [`verify_checkpoint_chain`](Self::verify_checkpoint_chain)
+    /// can later check hash continuity across adjacent checkpoints.
+    ///
+    /// Stores:
+    /// - `first_prev_hash` = first entry's `previous_ledger_hash`
+    ///   (must equal the prior checkpoint's `last_computed_hash`)
+    /// - `last_computed_hash` = last entry's `computed_hash` (the SHA-256 of
+    ///   that ledger's header, which the next checkpoint will reference)
+    ///
+    /// No-op when `ledger_data` is empty (nothing to bracket).
     fn store_boundary(&self, checkpoint: u32, ledger_data: &BTreeMap<u32, LedgerVerificationData>) {
         let (Some((_, first_data)), Some((_, last_data))) =
             (ledger_data.first_key_value(), ledger_data.last_key_value())
@@ -401,19 +462,15 @@ impl XdrVerificationManager {
         let boundaries = self.boundaries.lock().unwrap();
         let mut chain_errors = Vec::new();
 
-        let mut checkpoints: Vec<_> = boundaries.keys().copied().collect();
-        checkpoints.sort_unstable();
+        let entries: Vec<_> = boundaries.iter().collect();
 
-        for window in checkpoints.windows(2) {
-            let prev_checkpoint = window[0];
-            let curr_checkpoint = window[1];
+        for window in entries.windows(2) {
+            let (&prev_checkpoint, prev_boundary) = window[0];
+            let (&curr_checkpoint, curr_boundary) = window[1];
 
             if curr_checkpoint != prev_checkpoint + CHECKPOINT_FREQUENCY {
                 continue;
             }
-
-            let prev_boundary = &boundaries[&prev_checkpoint];
-            let curr_boundary = &boundaries[&curr_checkpoint];
 
             if curr_boundary.first_prev_hash != prev_boundary.last_computed_hash {
                 let first_ledger = curr_checkpoint.saturating_sub(63);
@@ -435,6 +492,8 @@ impl XdrVerificationManager {
         chain_errors
     }
 
+    /// Snapshot of all verification errors accumulated so far. Each call
+    /// returns a fresh `Vec`; the manager retains the underlying state.
     pub fn get_errors(&self) -> Vec<VerificationError> {
         self.errors.lock().unwrap().clone()
     }
@@ -459,6 +518,8 @@ pub fn parse_ledger_entries(
     parse_ledger_entries_for_checkpoint(decompressed_data, None)
 }
 
+/// Same as [`parse_ledger_entries`] but additionally rejects ledger sequences
+/// outside the expected range when `checkpoint` is provided.
 pub(crate) fn parse_ledger_entries_for_checkpoint(
     decompressed_data: &[u8],
     checkpoint: Option<u32>,
@@ -535,10 +596,14 @@ pub(crate) fn parse_ledger_entries_for_checkpoint(
     Ok(data)
 }
 
+/// Hash of an empty V0 `TransactionSet`: `SHA256(previous_ledger_hash)` —
+/// equivalent to the V0 hash recipe with zero transactions concatenated.
 pub(crate) fn compute_empty_v0_tx_set_hash(previous_ledger_hash: &[u8; 32]) -> [u8; 32] {
     Sha256::digest(previous_ledger_hash).into()
 }
 
+/// Hash of an empty V1 `GeneralizedTransactionSet`: SHA-256 of the
+/// XDR-serialized struct with `previous_ledger_hash` set and no phases.
 pub(crate) fn compute_empty_v1_tx_set_hash(previous_ledger_hash: &[u8; 32]) -> [u8; 32] {
     let empty_v1 = GeneralizedTransactionSet::V1(TransactionSetV1 {
         previous_ledger_hash: Hash(*previous_ledger_hash),
@@ -550,6 +615,16 @@ pub(crate) fn compute_empty_v1_tx_set_hash(previous_ledger_hash: &[u8; 32]) -> [
     Sha256::digest(&xdr).into()
 }
 
+/// Whether `expected` is one of the recognized "no transactions in this ledger"
+/// markers, given the ledger's `prev_hash`.
+///
+/// Treated as empty if `expected` matches any of:
+/// - all-zero hash (`[0; 32]`)
+/// - [`compute_empty_v0_tx_set_hash`]`(prev_hash)` — empty V0 set
+/// - [`compute_empty_v1_tx_set_hash`]`(prev_hash)` — empty V1 set
+///
+/// Used by [`verify_tx_set_hashes_internal`](XdrVerificationManager::verify_tx_set_hashes_internal)
+/// to decide whether a missing transactions-file entry is acceptable.
 pub(crate) fn is_empty_tx_set_hash(expected: &[u8; 32], prev_hash: &[u8; 32]) -> bool {
     *expected == [0; 32]
         || *expected == compute_empty_v0_tx_set_hash(prev_hash)
@@ -616,6 +691,8 @@ pub fn parse_result_entries(
     parse_result_entries_for_checkpoint(decompressed_data, None)
 }
 
+/// Same as [`parse_result_entries`] but additionally rejects ledger sequences
+/// outside the expected range when `checkpoint` is provided.
 pub(crate) fn parse_result_entries_for_checkpoint(
     decompressed_data: &[u8],
     checkpoint: Option<u32>,
@@ -673,7 +750,8 @@ pub(crate) fn parse_result_entries_for_checkpoint(
     Ok(hashes)
 }
 
-/// Decompress gzip data from a reader into an in-memory buffer.
+/// Decompress a gzipped reader into an in-memory `Vec<u8>`. No write side —
+/// thin wrapper over [`decompress_and_write_internal`] with `writer = None`.
 pub(crate) async fn decompress_to_buffer(
     path: &str,
     reader: Reader,
@@ -717,6 +795,8 @@ pub fn parse_transaction_entries(
     parse_transaction_entries_for_checkpoint(decompressed_data, None)
 }
 
+/// Same as [`parse_transaction_entries`] but additionally rejects ledger
+/// sequences outside the expected range when `checkpoint` is provided.
 pub(crate) fn parse_transaction_entries_for_checkpoint(
     decompressed_data: &[u8],
     checkpoint: Option<u32>,
@@ -812,6 +892,29 @@ pub enum XdrParseResult {
     None,
 }
 
+/// Streaming core: read gzipped bytes from `reader`, optionally tee-write the
+/// raw (still-compressed) bytes to `writer`, and return the fully decompressed
+/// payload alongside the **unclosed** sink.
+///
+/// Pipeline:
+/// 1. Pull gzipped chunks from `reader`'s opendal stream.
+/// 2. For each chunk: forward the compressed bytes to `sink` (if present), and
+///    push them through an mpsc channel into a spawned decompression task.
+/// 3. The decompression task feeds the channel through a `GzipDecoder` and
+///    accumulates the decompressed bytes into a `Vec<u8>`.
+/// 4. When the source stream ends, the channel closes and the decompression
+///    task returns.
+///
+/// **Sink lifecycle**: the returned sink is *not* closed. The caller closes it
+/// only after additional verification (e.g. XDR parse) succeeds — that way a
+/// post-write verification failure can `drop(sink)` and avoid committing
+/// corrupt data on atomic-write backends. On non-atomic backends, partial data
+/// is already on disk via `sink.send`, so the caller must additionally call
+/// [`cleanup_non_atomic_partial_write`] on failure.
+///
+/// Errors:
+/// - **Retry**: malformed gzip framing (decompression error)
+/// - **Fatal**: storage I/O error on read or write, or decompress task panic
 async fn decompress_and_write_internal(
     path: &str,
     reader: Reader,
@@ -902,10 +1005,15 @@ async fn decompress_and_write_internal(
     Ok((decompressed, sink))
 }
 
-/// On non-atomic backends, data sent via `sink.send()` is written directly to
-/// the target path. If the write is abandoned (sink dropped without close),
-/// the partial file must be removed. On atomic backends the sink drop alone
-/// prevents the temp-to-target rename, so no file cleanup is needed.
+/// Remove a partially-written file after a verified-write fails.
+///
+/// - **Atomic backends**: no-op — dropping the sink without `close()` already
+///   prevents the temp-to-target rename, so nothing landed at `path`.
+/// - **Non-atomic backends**: data sent via `sink.send()` is written directly
+///   to `path`, so the abandoned partial file is `tokio::fs::remove_file`'d.
+///   `NotFound` is silently tolerated; other errors are warned but not raised.
+///
+/// Safe to call on backends without a base path (e.g. HTTP) — does nothing.
 async fn cleanup_non_atomic_partial_write(path: &str, dst_store: &StorageRef) {
     if dst_store.uses_atomic_writes() {
         return;
@@ -924,9 +1032,24 @@ async fn cleanup_non_atomic_partial_write(path: &str, dst_store: &StorageRef) {
     }
 }
 
-/// Decompress, verify XDR structure, and write to destination in a single streaming pass.
-/// The file type is determined from `path` (ledger, transaction, result, or SCP).
-/// Returns the parsed hashes for the caller to record with [`XdrVerificationManager`].
+/// Decompress, verify XDR structure, and write to destination in a single
+/// streaming pass.
+///
+/// File type is inferred from `path`:
+/// - **ledger** → `XdrParseResult::Ledger` with per-ledger hashes
+/// - **transactions** → `XdrParseResult::Transactions`
+/// - **results** → `XdrParseResult::Results`
+/// - **scp** → `XdrParseResult::None` (frame structure validated, no hashes)
+/// - other → `XdrParseResult::None`
+///
+/// Atomicity: the sink is closed (committing the write) only after the
+/// in-memory decompressed payload parses successfully. On parse or
+/// decompression failure the sink is dropped without close; for non-atomic
+/// backends the partial file is additionally removed on disk.
+///
+/// Caller passes the returned hashes to
+/// [`XdrVerificationManager::record_*`](XdrVerificationManager) for
+/// cross-file verification.
 pub async fn verify_and_write_xdr(
     path: &str,
     reader: Reader,

--- a/src/xdr_verify.rs
+++ b/src/xdr_verify.rs
@@ -163,58 +163,78 @@ impl XdrVerificationManager {
     ///
     /// Runs (in order): completeness check, tx set hash cross-check, result hash
     /// cross-check, internal hash chain, then stores the first/last boundary hashes
-    /// for later cross-checkpoint verification. Errors are accumulated, not returned —
-    /// retrieve via [`get_errors`](Self::get_errors).
+    /// for later cross-checkpoint verification. Errors are accumulated in
+    /// [`get_errors`](Self::get_errors) **and** returned to the caller so they can
+    /// observe per-checkpoint outcomes (used by repair to drive its retry phase).
     ///
-    /// No-op if no data was recorded for this checkpoint. If ledger data is missing
-    /// but tx/result data exists, records a warning and skips all checks.
-    pub fn verify_and_release(&self, checkpoint: u32) {
+    /// No-op (returns empty Vec) if no data was recorded for this checkpoint.
+    /// If ledger data is missing but tx/result data exists, records a warning
+    /// error and returns it.
+    pub fn verify_and_release(&self, checkpoint: u32) -> Vec<VerificationError> {
         let data = {
             let mut pending = self.pending.lock().unwrap();
             pending.remove(&checkpoint)
         };
 
         let Some(data) = data else {
-            return;
+            return Vec::new();
         };
 
         let Some(ledger_data) = data.ledger_data else {
             let err_msg = "missing ledger verification data for checkpoint";
             warn!("Checkpoint {checkpoint}: skipping cross-verification because {err_msg}");
-            self.errors.lock().unwrap().push(VerificationError {
+            let err = VerificationError {
                 checkpoint,
                 ledger_seq: None,
                 message: err_msg.to_string(),
-            });
-            return;
+            };
+            self.errors.lock().unwrap().push(err.clone());
+            return vec![err];
         };
 
-        self.verify_checkpoint_completeness(checkpoint, &ledger_data);
+        let mut errors = Vec::new();
+        errors.extend(Self::verify_checkpoint_completeness(
+            checkpoint,
+            &ledger_data,
+        ));
 
         if let Some(tx_set_hashes) = data.tx_set_hashes {
-            self.verify_tx_set_hashes_internal(checkpoint, &ledger_data, &tx_set_hashes);
+            errors.extend(Self::verify_tx_set_hashes_internal(
+                checkpoint,
+                &ledger_data,
+                &tx_set_hashes,
+            ));
         }
 
         if let Some(result_hashes) = data.result_hashes {
-            self.verify_result_hashes_internal(checkpoint, &ledger_data, &result_hashes);
+            errors.extend(Self::verify_result_hashes_internal(
+                checkpoint,
+                &ledger_data,
+                &result_hashes,
+            ));
         }
 
-        self.verify_internal_chain(checkpoint, &ledger_data);
+        errors.extend(Self::verify_internal_chain(checkpoint, &ledger_data));
         self.store_boundary(checkpoint, &ledger_data);
+
+        if !errors.is_empty() {
+            self.errors.lock().unwrap().extend(errors.iter().cloned());
+        }
+        errors
     }
 
     /// Verify that `ledger_data` covers exactly the ledger sequences expected
     /// for this checkpoint (per [`expected_ledger_range`]).
     ///
-    /// Records two error kinds in `self.errors`:
+    /// Returns two error kinds:
     /// - **Unexpected**: ledger entries with sequences outside the expected range
     /// - **Missing**: ledger sequences in the expected range with no entry
     ///   (truncated to the first 5 + a count when more than 10 are missing)
     fn verify_checkpoint_completeness(
-        &self,
         checkpoint: u32,
         ledger_data: &BTreeMap<u32, LedgerVerificationData>,
-    ) {
+    ) -> Vec<VerificationError> {
+        let mut errors = Vec::new();
         let (first_ledger, last_ledger) = expected_ledger_range(checkpoint);
         let range = first_ledger..=last_ledger;
         let fmt_list = |seqs: &[u32]| {
@@ -236,7 +256,7 @@ impl XdrVerificationManager {
                 fmt_list(&unexpected),
             );
             error!("Checkpoint {checkpoint}: {err_msg}");
-            self.errors.lock().unwrap().push(VerificationError {
+            errors.push(VerificationError {
                 checkpoint,
                 ledger_seq: unexpected.first().copied(),
                 message: err_msg,
@@ -261,12 +281,13 @@ impl XdrVerificationManager {
                 last_ledger - first_ledger + 1,
             );
             error!("Checkpoint {checkpoint}: {err_msg}");
-            self.errors.lock().unwrap().push(VerificationError {
+            errors.push(VerificationError {
                 checkpoint,
                 ledger_seq: missing.first().copied(),
                 message: err_msg,
             });
         }
+        errors
     }
 
     /// Cross-verify per-ledger tx-set hashes from the **transactions** file
@@ -280,14 +301,12 @@ impl XdrVerificationManager {
     ///   expected tx-set hash is one of the recognized "empty tx set"
     ///   sentinels (see [`is_empty_tx_set_hash`]) — stellar-core omits empty
     ///   tx-set entries from the transactions file.
-    ///
-    /// Errors are pushed to `self.errors`.
     fn verify_tx_set_hashes_internal(
-        &self,
         checkpoint: u32,
         ledger_data: &BTreeMap<u32, LedgerVerificationData>,
         tx_set_hashes: &HashMap<u32, [u8; 32]>,
-    ) {
+    ) -> Vec<VerificationError> {
+        let mut errors = Vec::new();
         for (&seq, data) in ledger_data {
             let expected = data.expected_tx_set_hash;
 
@@ -314,13 +333,14 @@ impl XdrVerificationManager {
 
             if let Some(err_msg) = err_msg {
                 error!("Ledger {seq}: {err_msg}");
-                self.errors.lock().unwrap().push(VerificationError {
+                errors.push(VerificationError {
                     checkpoint,
                     ledger_seq: Some(seq),
                     message: err_msg,
                 });
             }
         }
+        errors
     }
 
     /// Cross-verify per-ledger result-set hashes from the **results** file
@@ -331,14 +351,12 @@ impl XdrVerificationManager {
     /// - **Missing**: no entry in `result_hashes` *and* `expected_result_hash`
     ///   is non-zero and not [`EMPTY_XDR_ARRAY_HASH`] (those two values mark
     ///   "no result entry expected" and are tolerated as missing).
-    ///
-    /// Errors are pushed to `self.errors`.
     fn verify_result_hashes_internal(
-        &self,
         checkpoint: u32,
         ledger_data: &BTreeMap<u32, LedgerVerificationData>,
         result_hashes: &HashMap<u32, [u8; 32]>,
-    ) {
+    ) -> Vec<VerificationError> {
+        let mut errors = Vec::new();
         for (&seq, data) in ledger_data {
             let expected = data.expected_result_hash;
 
@@ -363,13 +381,14 @@ impl XdrVerificationManager {
 
             if let Some(err_msg) = err_msg {
                 error!("Ledger {seq}: {err_msg}");
-                self.errors.lock().unwrap().push(VerificationError {
+                errors.push(VerificationError {
                     checkpoint,
                     ledger_seq: Some(seq),
                     message: err_msg,
                 });
             }
         }
+        errors
     }
 
     /// Verify the hash chain *within* a single checkpoint.
@@ -378,14 +397,14 @@ impl XdrVerificationManager {
     /// - **Consecutive**: `curr.seq == prev.seq + 1` (else "missing predecessor")
     /// - **Linked**: `curr.prev_hash == prev.computed_hash` (else "hash chain break")
     ///
-    /// Failures are pushed to `self.errors`. The link across checkpoint
-    /// boundaries (this checkpoint's first ledger ↔ prior checkpoint's last)
-    /// is handled separately by [`verify_checkpoint_chain`](Self::verify_checkpoint_chain).
+    /// The link across checkpoint boundaries (this checkpoint's first ledger ↔
+    /// prior checkpoint's last) is handled separately by
+    /// [`verify_checkpoint_chain`](Self::verify_checkpoint_chain).
     fn verify_internal_chain(
-        &self,
         checkpoint: u32,
         ledger_data: &BTreeMap<u32, LedgerVerificationData>,
-    ) {
+    ) -> Vec<VerificationError> {
+        let mut errors = Vec::new();
         let entries: Vec<_> = ledger_data.iter().collect();
 
         for pair in entries.windows(2) {
@@ -416,13 +435,14 @@ impl XdrVerificationManager {
 
             if let Some(err_msg) = err_msg {
                 error!("Checkpoint {checkpoint}: {err_msg}");
-                self.errors.lock().unwrap().push(VerificationError {
+                errors.push(VerificationError {
                     checkpoint,
                     ledger_seq,
                     message: err_msg,
                 });
             }
         }
+        errors
     }
 
     /// Stash the first/last ledger hashes of this checkpoint into

--- a/src/xdr_verify.rs
+++ b/src/xdr_verify.rs
@@ -1077,18 +1077,29 @@ pub async fn verify_and_write_xdr(
 ) -> Result<XdrParseResult, StorageError> {
     use futures_util::SinkExt;
 
-    let writer = dst_store.open_writer(path).await?;
-    let (decompressed, sink) = match decompress_and_write_internal(path, reader, Some(writer)).await
-    {
-        Ok(result) => result,
-        Err(e) => {
-            // Decompression or I/O error — sink was dropped inside
-            // decompress_and_write_internal without close. Clean up any
-            // partial data on non-atomic backends.
-            cleanup_non_atomic_partial_write(path, dst_store).await;
-            return Err(e);
-        }
+    // For non-atomic backends, write to a `.tmp` sibling first and rename to
+    // `path` only after parsing succeeds. This prevents a partial file from
+    // being visible at the final path if the process is killed mid-stream
+    // (SIGKILL, OOM), which would otherwise cause `pre_check()` to skip
+    // re-downloading on resume. Atomic backends handle this internally.
+    let write_path: String = if dst_store.uses_atomic_writes() {
+        path.to_string()
+    } else {
+        format!("{path}.tmp")
     };
+
+    let writer = dst_store.open_writer(&write_path).await?;
+    let (decompressed, sink) =
+        match decompress_and_write_internal(&write_path, reader, Some(writer)).await {
+            Ok(result) => result,
+            Err(e) => {
+                // Decompression or I/O error — sink was dropped inside
+                // decompress_and_write_internal without close. Clean up any
+                // partial data on non-atomic backends.
+                cleanup_non_atomic_partial_write(&write_path, dst_store).await;
+                return Err(e);
+            }
+        };
 
     let parse_result = if crate::history_format::is_ledger_file(path) {
         parse_ledger_entries_for_checkpoint(
@@ -1118,9 +1129,26 @@ pub async fn verify_and_write_xdr(
         Ok(result) => {
             // Verification passed — close sink to commit the write
             if let Some(mut s) = sink {
-                s.close()
-                    .await
-                    .map_err(|e| from_opendal_error(e, &format!("failed to close {}", path)))?;
+                s.close().await.map_err(|e| {
+                    from_opendal_error(e, &format!("failed to close {}", write_path))
+                })?;
+            }
+            // Non-atomic FS backend: rename the temp to the final path.
+            // Removes the temp on rename failure to avoid leaking `.tmp` files.
+            if write_path != path {
+                if let Some(base) = dst_store.get_base_path() {
+                    let tmp_full = base.join(&write_path);
+                    let final_full = base.join(path);
+                    if let Err(e) = tokio::fs::rename(&tmp_full, &final_full).await {
+                        let _ = tokio::fs::remove_file(&tmp_full).await;
+                        return Err(StorageError::fatal(format!(
+                            "failed to rename {} to {}: {}",
+                            tmp_full.display(),
+                            final_full.display(),
+                            e
+                        )));
+                    }
+                }
             }
             Ok(result)
         }
@@ -1128,7 +1156,7 @@ pub async fn verify_and_write_xdr(
             // Verification failed — don't close sink, prevents committing corrupt data
             // on atomic backends. For non-atomic backends, data is already on disk via
             // send() so clean up the partial file.
-            cleanup_non_atomic_partial_write(path, dst_store).await;
+            cleanup_non_atomic_partial_write(&write_path, dst_store).await;
             Err(err)
         }
     }


### PR DESCRIPTION
## Summary

A series of clean up, refactoring, documentation. Mostly stylistic and for better maintainability. 
A main motivation is to make the `trait Operation` leaner and clean up boundaries between `Pipeline` and `Operation`, to make them easily extendable for Repair mode (PR https://github.com/stellar/rs-stellar-archivist/pull/21). 

- Remove unnecessary Arc<Self> on pipeline functions signatures (it is already internally mutable)
- Make `with_retries`'s  `Send` bound explicit (see code docs for explanation)
- Make xdr_verify functions return list of errors
- split out some common functionalities to storage, utils
- split `record_` functions out of `trait Operation`
- remove dedicated "existence check" flag
- construct storage from the outside (be shared by `Pipeline` and `Operation`)

and miscellaneous cleanups:
  - Remove unnecessary `async` from three functions that were purely synchronous: `from_url_with_config`, `ScanOperation::new`, `MirrorOperation::new`
  - Replace blocking `file_path.exists()` with `tokio::fs::try_exists` in async context                                        
  - Fix progress reporting: replace stream index with atomic counter that actual completions. 
  - Extract `parse_history` helper
  - Use temp+rename in non-atomic file writes to prevent partial files from visible at the final path after a process crash (SIGKILL, OOM).
  - (CI fix) Raise `recursion_limit` to 256 for deeply nested OpenDAL layer types
  - Add security disclaimer to README