### PR TITLE
Add repair mode

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,8 +1,9 @@
 pub mod mirror;
+pub mod repair;
 pub mod scan;
 
 use crate::storage::StorageConfig;
-use crate::{self as stellar_archivist, mirror_operation, scan_operation};
+use crate::{self as stellar_archivist, mirror_operation, repair_operation, scan_operation};
 use clap::{Parser, Subcommand};
 use std::ffi::OsString;
 use std::io;
@@ -25,6 +26,9 @@ pub enum Error {
     #[error(transparent)]
     MirrorOperation(#[from] mirror_operation::Error),
 
+    #[error(transparent)]
+    RepairOperation(#[from] repair_operation::Error),
+
     #[error("{0}")]
     Other(String),
 }
@@ -35,6 +39,7 @@ impl From<stellar_archivist::Error> for Error {
             stellar_archivist::Error::Io(e) => Error::Io(e),
             stellar_archivist::Error::ScanOperation(e) => Error::ScanOperation(e),
             stellar_archivist::Error::MirrorOperation(e) => Error::MirrorOperation(e),
+            stellar_archivist::Error::RepairOperation(e) => Error::RepairOperation(e),
             stellar_archivist::Error::Other(s) => Error::Other(s),
         }
     }
@@ -104,6 +109,8 @@ struct Cli {
 pub enum Commands {
     /// Mirror files from source archive to destination
     Mirror(mirror::MirrorCmd),
+    /// Repair a corrupted archive by re-downloading broken files from a known-good source
+    Repair(repair::RepairCmd),
     /// Scan archive and verify integrity
     Scan(scan::ScanCmd),
 }
@@ -164,6 +171,7 @@ where
 
     match cli.command {
         Commands::Mirror(cmd) => cmd.run(global_args).await,
+        Commands::Repair(cmd) => cmd.run(global_args).await,
         Commands::Scan(cmd) => cmd.run(global_args).await,
     }
 }

--- a/src/cli/repair.rs
+++ b/src/cli/repair.rs
@@ -1,0 +1,105 @@
+use crate::cli::{Error, GlobalArgs};
+use crate::{
+    pipeline::{Pipeline, PipelineConfig},
+    repair_operation::RepairOperation,
+    storage, utils,
+};
+use clap::Parser;
+use std::path::PathBuf;
+use tracing::info;
+
+#[derive(Parser, Debug)]
+pub struct RepairCmd {
+    /// Source archive URL (known-good archive to fetch repairs from)
+    pub src: String,
+
+    /// Destination archive path to repair (must be file://)
+    pub dst: String,
+
+    /// Repair starting from this ledger (will round down to nearest checkpoint)
+    #[arg(long)]
+    pub low: Option<u32>,
+
+    /// Repair up to this ledger (will round up to nearest checkpoint)
+    #[arg(long)]
+    pub high: Option<u32>,
+
+    /// JSON file listing specific file paths to repair (manual mode)
+    #[arg(long)]
+    pub files: Option<PathBuf>,
+
+    /// Show what would be repaired without downloading
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+impl RepairCmd {
+    pub async fn run(self, args: GlobalArgs) -> Result<(), Error> {
+        info!(
+            "Starting repair from {} to {} with {} workers",
+            self.src, self.dst, args.concurrency
+        );
+
+        // Parse manual file list if provided
+        let file_list = if let Some(ref path) = self.files {
+            let content = std::fs::read_to_string(path).map_err(|e| {
+                Error::Other(format!(
+                    "Failed to read file list from {}: {}",
+                    path.display(),
+                    e
+                ))
+            })?;
+            let list = crate::repair_operation::parse_file_list_json(&content)?;
+            info!(
+                "Manual mode: {} files to repair from {}",
+                list.len(),
+                path.display()
+            );
+            Some(list)
+        } else {
+            None
+        };
+
+        let src_store = storage::from_url_with_config(&self.src, &args.storage_config)
+            .map_err(|e| Error::Other(format!("Failed to create source backend: {e}")))?;
+
+        let dst_store = storage::from_url_with_config(&self.dst, &args.storage_config)
+            .map_err(|e| Error::Other(format!("Failed to create destination backend: {e}")))?;
+
+        if !dst_store.supports_writes() {
+            return Err(Error::Other(format!(
+                "Destination does not support writes: {}",
+                self.dst
+            )));
+        }
+
+        let operation = RepairOperation::new(
+            src_store.clone(),
+            dst_store.clone(),
+            self.low,
+            self.high,
+            args.verify,
+            self.dry_run,
+            args.concurrency,
+            args.skip_optional,
+            &args.storage_config,
+        );
+
+        if let Some(files) = file_list {
+            operation.run_manual(&files).await?;
+            return Ok(());
+        }
+
+        let pipeline_config = PipelineConfig {
+            concurrency: args.concurrency,
+            skip_optional: args.skip_optional,
+            storage_config: args.storage_config,
+        };
+
+        let pipeline = Pipeline::new(operation, pipeline_config, src_store, Some(dst_store));
+
+        pipeline.run().await.map_err(utils::map_pipeline_error)?;
+
+        Ok(())
+    }
+}

--- a/src/cli/scan.rs
+++ b/src/cli/scan.rs
@@ -33,13 +33,7 @@ impl ScanCmd {
         }
 
         // Create the scan operation
-        let operation = ScanOperation::new(
-            self.low,
-            self.high,
-            args.storage_config.max_retries as u32,
-            args.storage_config.retry_min_delay.as_millis() as u64,
-            args.verify,
-        );
+        let operation = ScanOperation::new(self.low, self.high, &args.storage_config, args.verify);
 
         let src_store = storage::from_url_with_config(&self.archive, &args.storage_config)
             .map_err(|e| Error::Other(format!("Failed to create source backend: {e}")))?;

--- a/src/history_format.rs
+++ b/src/history_format.rs
@@ -496,6 +496,16 @@ pub fn is_bucket_file(path: &str) -> bool {
         && bucket_hash_from_path(path).is_some()
 }
 
+/// Check if a path is a checkpoint history JSON file (under `history/`).
+/// Excludes the singleton `.well-known/stellar-history.json` (root) — that
+/// is matched directly against [`ROOT_WELL_KNOWN_PATH`].
+pub fn is_history_file(path: &str) -> bool {
+    path.starts_with("history/")
+        && std::path::Path::new(path)
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("json"))
+}
+
 /// Check if a path is a ledger-header file (under `ledger/`, containing
 /// `LedgerHeaderHistoryEntry` frames — NOT bucket-resident `LedgerEntry`s).
 pub fn is_ledger_header_file(path: &str) -> bool {

--- a/src/history_format.rs
+++ b/src/history_format.rs
@@ -4,6 +4,7 @@
 //! Archive history files.
 
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 use thiserror::Error;
 
 // Both Bucket List types have exactly 11 levels
@@ -61,7 +62,10 @@ pub struct HistoryFileState {
     pub hot_archive_buckets: Option<[BucketLevel; NUM_BUCKETLIST_LEVELS]>,
 }
 
-// Bucket state for a single bucketlist level
+/// One level of Stellar's multi-level bucketlist as serialized in
+/// `.well-known/stellar-history.json`: the two committed bucket hashes
+/// (`curr` = current; `snap` = pending downward-merge into the next level)
+/// plus the in-progress merge descriptor (`next`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BucketLevel {
     pub curr: String,
@@ -69,8 +73,22 @@ pub struct BucketLevel {
     pub next: NextState,
 }
 
-// Merge state for bucket level
-// state: 0=idle, 1=running (output), 2=merging (curr/snap/shadow)
+/// In-progress merge state for a [`BucketLevel`]. The bucketlist merges
+/// snap-into-the-next-level incrementally across many ledgers, so a
+/// checkpoint snapshot has to encode wherever the merge happens to be:
+///
+/// - **`state = 0` (idle)**: no merge running. All option fields must be `None`.
+/// - **`state = 1` (running output)**: merge has produced a new bucket;
+///   `output` carries its hash and the resulting file must be backed up.
+///   All other option fields must be `None`.
+/// - **`state = 2` (merging)**: merge is in flight; `curr` and `snap` hold
+///   the merge's input hashes; `shadow` is an optional list of older bucket
+///   hashes shadowing entries during the merge. `output` must be `None`.
+///
+/// [`HistoryFileState::validate_bucket_level`] enforces these field
+/// combinations. [`HistoryFileState::buckets`] harvests only `output` — the
+/// state-2 fields point at buckets already enumerated at adjacent
+/// `BucketLevel`s, so re-collecting them would double-count.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NextState {
     pub state: u32,
@@ -85,7 +103,10 @@ pub struct NextState {
 }
 
 impl HistoryFileState {
-    // Helper function to validate a single bucket level
+    /// Validate one bucket level's hashes and its [`NextState`] field
+    /// combinations per the state-0/1/2 contract documented on
+    /// [`NextState`]. Called by [`Self::validate`] for every level of
+    /// `current_buckets` (and v2 `hot_archive_buckets`).
     fn validate_bucket_level(level: &BucketLevel, index: usize, prefix: &str) -> Result<(), Error> {
         if !is_valid_bucket_hash(&level.curr) {
             return Err(Error::MalformedBucketHash {
@@ -251,45 +272,35 @@ impl HistoryFileState {
         Ok(())
     }
 
-    // Extract all unique bucket hashes from current state, except for empty buckets with 0 hash
+    /// Every unique non-zero bucket hash this checkpoint references — the
+    /// backup set for this checkpoint. From each [`BucketLevel`] we take
+    /// `curr`, `snap`, and `next.output` (the only [`NextState`] field that
+    /// can introduce a bucket not already enumerated at some other level —
+    /// see the [`NextState`] doc).
     #[must_use]
-    pub fn buckets(&self) -> Vec<String> {
-        let mut result = Vec::new();
-
-        // Collect from currentBuckets
-        for level in &self.current_buckets {
-            if !level.curr.is_empty() && !is_zero_hash(&level.curr) {
-                result.push(level.curr.clone());
-            }
-            if !level.snap.is_empty() && !is_zero_hash(&level.snap) {
-                result.push(level.snap.clone());
-            }
-            if let Some(output) = &level.next.output {
-                if !output.is_empty() && !is_zero_hash(output) {
-                    result.push(output.clone());
-                }
-            }
-        }
-
-        // Collect from hotArchiveBuckets if present (version 2)
-        if let Some(ref hot_buckets) = self.hot_archive_buckets {
-            for level in hot_buckets {
+    pub(crate) fn buckets(&self) -> BTreeSet<String> {
+        let mut result = BTreeSet::new();
+        let mut push_levels = |levels: &[BucketLevel]| {
+            for level in levels {
                 if !level.curr.is_empty() && !is_zero_hash(&level.curr) {
-                    result.push(level.curr.clone());
+                    result.insert(level.curr.clone());
                 }
                 if !level.snap.is_empty() && !is_zero_hash(&level.snap) {
-                    result.push(level.snap.clone());
+                    result.insert(level.snap.clone());
                 }
                 if let Some(output) = &level.next.output {
                     if !output.is_empty() && !is_zero_hash(output) {
-                        result.push(output.clone());
+                        result.insert(output.clone());
                     }
                 }
             }
+        };
+
+        push_levels(&self.current_buckets);
+        if let Some(ref hot_buckets) = self.hot_archive_buckets {
+            push_levels(hot_buckets);
         }
 
-        result.sort();
-        result.dedup();
         result
     }
 

--- a/src/history_format.rs
+++ b/src/history_format.rs
@@ -485,8 +485,9 @@ pub fn is_bucket_file(path: &str) -> bool {
         && bucket_hash_from_path(path).is_some()
 }
 
-/// Check if a path is a ledger file.
-pub fn is_ledger_file(path: &str) -> bool {
+/// Check if a path is a ledger-header file (under `ledger/`, containing
+/// `LedgerHeaderHistoryEntry` frames — NOT bucket-resident `LedgerEntry`s).
+pub fn is_ledger_header_file(path: &str) -> bool {
     path.starts_with("ledger/") && path.ends_with(".xdr.gz")
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,8 +251,7 @@ pub mod test_helpers {
         let operation = ScanOperation::new(
             config.low,
             config.high,
-            config.storage_config.max_retries as u32,
-            config.storage_config.retry_min_delay.as_millis() as u64,
+            &config.storage_config,
             config.verify,
         );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
 pub mod history_format;
 pub mod mirror_operation;
 pub mod pipeline;
+pub mod repair_operation;
 pub mod scan_operation;
 pub mod storage;
 pub mod utils;
@@ -56,6 +57,9 @@ pub enum Error {
     #[error(transparent)]
     ScanOperation(#[from] scan_operation::Error),
 
+    #[error(transparent)]
+    RepairOperation(#[from] repair_operation::Error),
+
     #[error("{0}")]
     Other(String),
 }
@@ -69,6 +73,7 @@ pub mod test_helpers {
     use crate::{
         mirror_operation::MirrorOperation,
         pipeline::{Pipeline, PipelineConfig},
+        repair_operation::RepairOperation,
         scan_operation::ScanOperation,
         storage::StorageConfig,
     };
@@ -296,6 +301,134 @@ pub mod test_helpers {
             &config.storage_config,
             config.verify,
         );
+
+        let pipeline_config = PipelineConfig {
+            concurrency: config.concurrency,
+            skip_optional: config.skip_optional,
+            storage_config: config.storage_config,
+        };
+
+        let pipeline = Pipeline::new(operation, pipeline_config, src_store, Some(dst_store));
+        pipeline
+            .run()
+            .await
+            .map_err(crate::utils::map_pipeline_error)
+    }
+
+    pub struct RepairConfig {
+        pub src: String,
+        pub dst: String,
+        pub concurrency: usize,
+        pub skip_optional: bool,
+        pub low: Option<u32>,
+        pub high: Option<u32>,
+        pub verify: bool,
+        pub dry_run: bool,
+        pub file_list: Option<Vec<String>>,
+        pub storage_config: StorageConfig,
+    }
+
+    impl RepairConfig {
+        pub fn new(src: impl Into<String>, dst: impl Into<String>) -> Self {
+            Self {
+                src: src.into(),
+                dst: dst.into(),
+                concurrency: 4,
+                skip_optional: false,
+                low: None,
+                high: None,
+                verify: false,
+                dry_run: false,
+                file_list: None,
+                storage_config: test_storage_config(),
+            }
+        }
+
+        #[must_use]
+        pub fn concurrency(mut self, concurrency: usize) -> Self {
+            self.concurrency = concurrency;
+            self
+        }
+
+        #[must_use]
+        pub fn skip_optional(mut self) -> Self {
+            self.skip_optional = true;
+            self
+        }
+
+        #[must_use]
+        pub fn low(mut self, low: u32) -> Self {
+            self.low = Some(low);
+            self
+        }
+
+        #[must_use]
+        pub fn high(mut self, high: u32) -> Self {
+            self.high = Some(high);
+            self
+        }
+
+        #[must_use]
+        pub fn verify(mut self) -> Self {
+            self.verify = true;
+            self
+        }
+
+        #[must_use]
+        pub fn dry_run(mut self) -> Self {
+            self.dry_run = true;
+            self
+        }
+
+        #[must_use]
+        pub fn files(mut self, list: Vec<String>) -> Self {
+            self.file_list = Some(list);
+            self
+        }
+
+        #[must_use]
+        pub fn storage_config(mut self, config: StorageConfig) -> Self {
+            self.storage_config = config;
+            self
+        }
+    }
+
+    pub async fn run_repair(config: RepairConfig) -> Result<(), crate::Error> {
+        let src_store = crate::storage::from_url_with_config(&config.src, &config.storage_config)
+            .map_err(|e| {
+            crate::Error::Other(format!("Failed to create source backend: {e}"))
+        })?;
+
+        let dst_store = crate::storage::from_url_with_config(&config.dst, &config.storage_config)
+            .map_err(|e| {
+            crate::Error::Other(format!("Failed to create destination backend: {e}"))
+        })?;
+
+        if !dst_store.supports_writes() {
+            return Err(crate::Error::Other(format!(
+                "Destination does not support writes: {}",
+                config.dst
+            )));
+        }
+
+        let operation = RepairOperation::new(
+            src_store.clone(),
+            dst_store.clone(),
+            config.low,
+            config.high,
+            config.verify,
+            config.dry_run,
+            config.concurrency,
+            config.skip_optional,
+            &config.storage_config,
+        );
+
+        if let Some(files) = config.file_list {
+            return operation
+                .run_manual(&files)
+                .await
+                .map_err(crate::Error::from);
+        }
 
         let pipeline_config = PipelineConfig {
             concurrency: config.concurrency,

--- a/src/mirror_operation.rs
+++ b/src/mirror_operation.rs
@@ -48,9 +48,8 @@ pub struct MirrorOperation {
     high: Option<u32>,
     allow_mirror_gaps: bool,
 
-    // Retry configuration for source fetches
-    max_retries: u32,
-    retry_min_delay_ms: u64,
+    // Storage configuration (retry params for fetches live here)
+    storage_config: StorageConfig,
 
     // Cached destination checkpoint at start of operation (or None if destination doesn't exist)
     initial_dest_checkpoint: OnceCell<Option<u32>>,
@@ -80,8 +79,7 @@ impl MirrorOperation {
             low,
             high,
             allow_mirror_gaps,
-            max_retries: storage_config.max_retries as u32,
-            retry_min_delay_ms: storage_config.retry_min_delay.as_millis() as u64,
+            storage_config: storage_config.clone(),
             initial_dest_checkpoint: OnceCell::new(),
             verification_manager: if verify {
                 Some(Arc::new(XdrVerificationManager::new()))
@@ -100,8 +98,8 @@ impl MirrorOperation {
                 // Try to read the destination's .well-known file
                 match fetch_well_known_history_file(
                     &self.dst_store,
-                    self.max_retries,
-                    self.retry_min_delay_ms,
+                    self.storage_config.max_retries as u32,
+                    self.storage_config.retry_min_delay.as_millis() as u64,
                 )
                 .await
                 {
@@ -241,10 +239,13 @@ impl Operation for MirrorOperation {
         //    - If destination doesn't exist: start from genesis checkpoint
 
         // First, get the source's latest checkpoint to know what's available
-        let source_state =
-            fetch_well_known_history_file(source, self.max_retries, self.retry_min_delay_ms)
-                .await
-                .map_err(|e| crate::pipeline::Error::MirrorOperation(Error::Utils(e)))?;
+        let source_state = fetch_well_known_history_file(
+            source,
+            self.storage_config.max_retries as u32,
+            self.storage_config.retry_min_delay.as_millis() as u64,
+        )
+        .await
+        .map_err(|e| crate::pipeline::Error::MirrorOperation(Error::Utils(e)))?;
         let source_checkpoint =
             history_format::round_to_lower_checkpoint(source_state.current_ledger);
 

--- a/src/mirror_operation.rs
+++ b/src/mirror_operation.rs
@@ -391,7 +391,7 @@ impl Operation for MirrorOperation {
                         Err(e)
                     }
                 }
-            } else if crate::history_format::is_ledger_file(path)
+            } else if crate::history_format::is_ledger_header_file(path)
                 || crate::history_format::is_transactions_file(path)
                 || crate::history_format::is_results_file(path)
                 || crate::history_format::is_scp_file(path)
@@ -415,7 +415,7 @@ impl Operation for MirrorOperation {
                 };
                 match result {
                     XdrParseResult::Ledger(data) => {
-                        manager.record_ledger_data(checkpoint.unwrap(), data);
+                        manager.record_header_data(checkpoint.unwrap(), data);
                     }
                     XdrParseResult::Transactions(hashes) => {
                         manager.record_tx_set_hashes(checkpoint.unwrap(), hashes);

--- a/src/mirror_operation.rs
+++ b/src/mirror_operation.rs
@@ -3,9 +3,10 @@
 use crate::history_format;
 use crate::pipeline::{async_trait, Operation};
 use crate::storage::cleanup_partial_file;
-use crate::storage::{Error as StorageError, StorageConfig, StorageRef};
+use crate::storage::{self, Error as StorageError, StorageConfig, StorageRef};
 use crate::utils::{compute_checkpoint_bounds, fetch_well_known_history_file, ArchiveStats};
 use crate::xdr_verify::XdrVerificationManager;
+use opendal::Buffer;
 use opendal::Reader;
 use std::sync::Arc;
 use thiserror::Error;
@@ -475,6 +476,17 @@ impl Operation for MirrorOperation {
     fn finalize_checkpoint(&self, checkpoint: u32) {
         if let Some(ref manager) = self.verification_manager {
             manager.verify_and_release(checkpoint);
+        }
+    }
+
+    /// Mirror writes the history buffer to its own dst.
+    async fn process_buffer(&self, path: &str, buffer: Buffer, stats: &ArchiveStats) {
+        match storage::write_buffer_with_cleanup(&self.dst_store, path, buffer).await {
+            Ok(()) => stats.record_success(path),
+            Err(e) => {
+                error!("Failed to write history file {}: {}", path, e);
+                stats.record_failure(path).await;
+            }
         }
     }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -41,7 +41,9 @@ pub enum Error {
     Other(String),
 }
 
-/// Maximum number of bucket entries to cache in the LRU for deduplication
+/// Max entries in the bucket-dedup LRU. Buckets are content-addressed and the
+/// same hash often appears in many checkpoints' history files; the LRU lets
+/// `process_buckets` skip repeat sightings within one pipeline run.
 const BUCKET_LRU_CACHE_SIZE: usize = 1_000_000;
 
 /// How often to report progress (every N checkpoints)
@@ -131,6 +133,8 @@ pub struct Pipeline<Op: Operation> {
     src_store: StorageRef,
     dst_store: Option<StorageRef>,
     stats: ArchiveStats,
+    /// Hash → () presence cache used by `process_buckets` to skip buckets
+    /// already seen elsewhere in this pipeline run.
     bucket_lru: Mutex<LruCache<String, ()>>,
 }
 
@@ -282,6 +286,11 @@ impl<Op: Operation> Pipeline<Op> {
         }
     }
 
+    /// Process every bucket referenced by `state`, deduped against the
+    /// pipeline-wide `bucket_lru`. The lock is held only across the filter-map
+    /// → collect (CPU-only — `LruCache::put` returns `None` iff the key is
+    /// new); each surviving `process_file` future then runs concurrently
+    /// outside the lock.
     async fn process_buckets(&self, state: HistoryFileState) {
         let bucket_futures: Vec<_> = {
             let mut cache = self.bucket_lru.lock().unwrap();

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -31,6 +31,9 @@ pub enum Error {
     #[error("Scan operation error: {0}")]
     ScanOperation(#[from] crate::scan_operation::Error),
 
+    #[error("Repair operation error: {0}")]
+    RepairOperation(#[from] crate::repair_operation::Error),
+
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     history_format::{self, bucket_path, checkpoint_path, HistoryFileState},
-    storage::{cleanup_partial_file, download_buffer, StorageConfig, StorageRef},
+    storage::{download_buffer, StorageConfig, StorageRef},
     utils::{self, ArchiveStats},
 };
 use futures_util::{
@@ -101,6 +101,14 @@ pub trait Operation: Send + Sync + 'static {
     ) -> Result<Buffer, crate::storage::Error> {
         download_buffer(src_store, history_path).await
     }
+
+    /// Write a fetched buffer (currently the history file) to the operation's
+    /// destination and record the outcome into `stats`.
+    ///
+    /// Implementations diverge by mode: scan records success without writing;
+    /// mirror writes via `storage::write_buffer_with_cleanup`; repair skips the
+    /// write entirely in dry-run mode and otherwise writes like mirror.
+    async fn process_buffer(&self, path: &str, buffer: Buffer, stats: &ArchiveStats);
 }
 
 // ============================================================================
@@ -189,29 +197,49 @@ impl<Op: Operation> Pipeline<Op> {
     /// the pipeline machinery directly without `Pipeline::run`'s full bounds +
     /// iteration loop.
     pub async fn process_checkpoint(&self, checkpoint: u32) {
-        let hist = self.process_history_and_buckets(checkpoint);
+        // History work: fetch + parse, then concurrently write the buffer to
+        // dst and process the buckets it references. Fetch/parse failures are
+        // logged and recorded inside `fetch_history_file_state`; on failure
+        // this future just returns early so the rest of the checkpoint's files
+        // still get processed.
+        let history_work = async {
+            let Some((state, buffer)) = self.fetch_history_file_state(checkpoint).await else {
+                return;
+            };
+            let history_path = checkpoint_path("history", checkpoint);
+            let write_history_buffer =
+                self.operation
+                    .process_buffer(&history_path, buffer, &self.stats);
+            let buckets = self.process_buckets(state);
+            let _ = join(write_history_buffer, buckets).await;
+        };
+
         let cats = join_all(["ledger", "transactions", "results"].map(|cat| {
             let path = checkpoint_path(cat, checkpoint);
             self.process_file(path)
         }));
 
         if self.config.skip_optional {
-            let _ = join(hist, cats).await;
+            let _ = join(history_work, cats).await;
         } else {
-            let path = checkpoint_path("scp", checkpoint);
-            let scp = self.process_file(path);
-            let _ = join3(hist, cats, scp).await;
+            let scp_path = checkpoint_path("scp", checkpoint);
+            let scp = self.process_file(scp_path);
+            let _ = join3(history_work, cats, scp).await;
         }
 
         self.operation.finalize_checkpoint(checkpoint);
     }
 
-    /// Process a history file for a checkpoint: download, parse, write buffer
-    /// to destination (if present), and process buckets.
-    async fn process_history_and_buckets(&self, checkpoint: u32) {
+    /// Fetch and parse a checkpoint's history file. On download or parse
+    /// failure, logs the error and records a failure into `stats`, returning
+    /// `None`. On success, returns the parsed state alongside the raw buffer
+    /// (the caller needs the buffer to write it to dst).
+    async fn fetch_history_file_state(
+        &self,
+        checkpoint: u32,
+    ) -> Option<(HistoryFileState, Buffer)> {
         let history_path = checkpoint_path("history", checkpoint);
 
-        // Download history buffer (operation can override sourcing)
         let Ok(buffer) = utils::with_retries(
             self.config.storage_config.max_retries as u32,
             self.config.storage_config.retry_min_delay.as_millis() as u64,
@@ -233,17 +261,11 @@ impl<Op: Operation> Pipeline<Op> {
                 checkpoint, checkpoint, history_path
             );
             self.stats.record_failure(&history_path).await;
-            return;
+            return None;
         };
 
-        // Parse and validate
         match history_format::parse_history(&buffer, &history_path) {
-            Ok(state) => {
-                // Write buffer to destination (if present) and process buckets concurrently
-                let write_history_buffer = self.process_buffer(&history_path, buffer);
-                let buckets = self.process_buckets(state);
-                let _ = join(write_history_buffer, buckets).await;
-            }
+            Ok(state) => Some((state, buffer)),
             Err(e) => {
                 error!(
                     "Failed to parse history JSON for checkpoint {} (0x{:08x}): {}",
@@ -255,27 +277,8 @@ impl<Op: Operation> Pipeline<Op> {
                     checkpoint, checkpoint, history_path
                 );
                 self.stats.record_failure(&history_path).await;
+                None
             }
-        }
-    }
-
-    /// Write the history buffer to the destination store (if present).
-    /// For scan (no dst_store), just records success.
-    async fn process_buffer(&self, path: &str, buffer: Buffer) {
-        if let Some(ref dst) = self.dst_store {
-            match dst.write(path, buffer).await {
-                Ok(()) => self.stats.record_success(path),
-                Err(e) => {
-                    if let Err(cleanup_err) = cleanup_partial_file(dst, path).await {
-                        error!("Failed to cleanup partial file {}: {}", path, cleanup_err);
-                    }
-                    error!("Failed to write history file {}: {}", path, e);
-                    self.stats.record_failure(path).await;
-                }
-            }
-        } else {
-            // Scan mode: no destination, just record success
-            self.stats.record_success(path);
         }
     }
 

--- a/src/repair_operation.rs
+++ b/src/repair_operation.rs
@@ -27,7 +27,7 @@ use crate::history_format;
 use crate::mirror_operation::MirrorOperation;
 use crate::pipeline::{self, async_trait, Operation, Pipeline, PipelineConfig};
 use crate::storage::{
-    self, cleanup_partial_file, Error as StorageError, StorageConfig, StorageRef,
+    self, cleanup_partial_file, Error as StorageError, ErrorClass, StorageConfig, StorageRef,
 };
 use crate::utils::{self, ArchiveStats};
 use crate::xdr_verify::{self, XdrParseResult, XdrVerificationManager};
@@ -241,70 +241,98 @@ impl RepairOperation {
     /// Check whether dst already has a good copy of `path` and (when `--verify`
     /// is on) record the parsed data into the manager.
     ///
-    /// Returns `Ok(true)` if dst is acceptable (caller should skip src fetch),
-    /// `Ok(false)` on missing or corrupt dst (caller should fetch from src),
-    /// or `Err` if `path` doesn't match any recognized archive file type
-    /// (a contract violation from the pipeline's dispatch).
+    /// Returns:
+    /// - `Ok(true)` — dst is acceptable; caller skips src fetch.
+    /// - `Ok(false)` — dst is missing or corrupt; caller should fetch from src.
+    ///   NotFound on `open_reader`/`exists()` is treated as "missing" so the
+    ///   repair can fetch from src immediately. Same for parse failures on a
+    ///   present-but-corrupt file.
+    /// - `Err(StorageError)` — non-NotFound storage error on the dst probe
+    ///   (permission denied, transient I/O, malformed backend response, etc.),
+    ///   OR `path` doesn't match any recognized archive file type (contract
+    ///   violation). The pipeline wraps `process_object` in `with_retries`, so
+    ///   transient errors (`ErrorClass::Retry`) are retried automatically. If
+    ///   the error persists after retries there's a real filesystem issue at
+    ///   `path`; fetching from src is likely to fail too, so we record the
+    ///   failure and move on instead of attempting a src fetch under broken
+    ///   conditions.
     ///
     /// When `--verify` is off, only existence is checked — content is not
     /// validated and nothing is recorded into the manager.
     async fn verify_and_record_dst(&self, path: &str) -> Result<bool, StorageError> {
         if !self.verify {
-            return Ok(self.dst_store.exists(path).await.unwrap_or(false));
+            return match self.dst_store.exists(path).await {
+                Ok(present) => Ok(present),
+                Err(e) if e.class == ErrorClass::NotFound => Ok(false),
+                Err(e) => Err(e),
+            };
         }
 
         // Buckets and SCP files have no per-checkpoint manager state — verify
         // structurally on dst, no recording.
         if history_format::is_bucket_file(path) {
-            let Ok(reader) = self.dst_store.open_reader(path).await else {
-                return Ok(false);
+            return match self.dst_store.open_reader(path).await {
+                Ok(reader) => Ok(crate::verify::verify_bucket_stream(path, reader)
+                    .await
+                    .is_ok()),
+                Err(e) if e.class == ErrorClass::NotFound => Ok(false),
+                Err(e) => Err(e),
             };
-            return Ok(crate::verify::verify_bucket_stream(path, reader)
-                .await
-                .is_ok());
         }
         if history_format::is_scp_file(path) {
-            let Ok(reader) = self.dst_store.open_reader(path).await else {
-                return Ok(false);
+            return match self.dst_store.open_reader(path).await {
+                Ok(reader) => Ok(xdr_verify::parse_scp_stream(path, reader).await.is_ok()),
+                Err(e) if e.class == ErrorClass::NotFound => Ok(false),
+                Err(e) => Err(e),
             };
-            return Ok(xdr_verify::parse_scp_stream(path, reader).await.is_ok());
         }
 
-        // XDR file types: parse into a uniform `XdrParseResult` and route
-        // recording through the shared `record_result` helper.
-        let parsed = if history_format::is_ledger_header_file(path) {
-            let Ok(reader) = self.dst_store.open_reader(path).await else {
-                return Ok(false);
+        // XDR file types: open, parse, and route recording through the shared
+        // `record_result` helper inside the success arm.
+        if history_format::is_ledger_header_file(path) {
+            return match self.dst_store.open_reader(path).await {
+                Ok(reader) => match xdr_verify::parse_ledger_header_stream(path, reader).await {
+                    Ok(data) => {
+                        self.record_result(path, XdrParseResult::Ledger(data));
+                        Ok(true)
+                    }
+                    Err(_) => Ok(false),
+                },
+                Err(e) if e.class == ErrorClass::NotFound => Ok(false),
+                Err(e) => Err(e),
             };
-            match xdr_verify::parse_ledger_header_stream(path, reader).await {
-                Ok(data) => XdrParseResult::Ledger(data),
-                Err(_) => return Ok(false),
-            }
-        } else if history_format::is_transactions_file(path) {
-            let Ok(reader) = self.dst_store.open_reader(path).await else {
-                return Ok(false);
+        }
+        if history_format::is_transactions_file(path) {
+            return match self.dst_store.open_reader(path).await {
+                Ok(reader) => match xdr_verify::parse_transactions_stream(path, reader).await {
+                    Ok(hashes) => {
+                        self.record_result(path, XdrParseResult::Transactions(hashes));
+                        Ok(true)
+                    }
+                    Err(_) => Ok(false),
+                },
+                Err(e) if e.class == ErrorClass::NotFound => Ok(false),
+                Err(e) => Err(e),
             };
-            match xdr_verify::parse_transactions_stream(path, reader).await {
-                Ok(hashes) => XdrParseResult::Transactions(hashes),
-                Err(_) => return Ok(false),
-            }
-        } else if history_format::is_results_file(path) {
-            let Ok(reader) = self.dst_store.open_reader(path).await else {
-                return Ok(false);
+        }
+        if history_format::is_results_file(path) {
+            return match self.dst_store.open_reader(path).await {
+                Ok(reader) => match xdr_verify::parse_results_stream(path, reader).await {
+                    Ok(hashes) => {
+                        self.record_result(path, XdrParseResult::Results(hashes));
+                        Ok(true)
+                    }
+                    Err(_) => Ok(false),
+                },
+                Err(e) if e.class == ErrorClass::NotFound => Ok(false),
+                Err(e) => Err(e),
             };
-            match xdr_verify::parse_results_stream(path, reader).await {
-                Ok(hashes) => XdrParseResult::Results(hashes),
-                Err(_) => return Ok(false),
-            }
-        } else {
-            return Err(StorageError::fatal(format!(
-                "verify_and_record_dst: unrecognized archive path '{path}' \
-                 (expected bucket / ledger / transactions / results / scp)"
-            )));
-        };
+        }
 
-        self.record_result(path, parsed);
-        Ok(true)
+        Err(StorageError::fatal(format!(
+            "verify_and_record_dst: unrecognized archive path '{path}' \
+             (expected bucket / ledger / transactions / results / scp)"
+        )))
     }
 
     /// Record a parsed XDR result into the verification manager. Used for both

--- a/src/repair_operation.rs
+++ b/src/repair_operation.rs
@@ -546,6 +546,23 @@ impl Operation for RepairOperation {
 
         Ok(())
     }
+
+    /// Repair writes the history buffer to its own dst, except in dry-run mode
+    /// where the write is skipped entirely (and stats are left untouched —
+    /// dry-run reports via `needs_repair_count`, populated in
+    /// `fetch_history_buffer`).
+    async fn process_buffer(&self, path: &str, buffer: Buffer, stats: &ArchiveStats) {
+        if self.dry_run {
+            return;
+        }
+        match storage::write_buffer_with_cleanup(&self.dst_store, path, buffer).await {
+            Ok(()) => stats.record_success(path),
+            Err(e) => {
+                error!("Failed to write history file {}: {}", path, e);
+                stats.record_failure(path).await;
+            }
+        }
+    }
 }
 
 // ============================================================================

--- a/src/repair_operation.rs
+++ b/src/repair_operation.rs
@@ -215,7 +215,7 @@ impl RepairOperation {
                     }
                 };
             }
-            if history_format::is_ledger_file(path)
+            if history_format::is_ledger_header_file(path)
                 || history_format::is_transactions_file(path)
                 || history_format::is_results_file(path)
                 || history_format::is_scp_file(path)
@@ -272,11 +272,11 @@ impl RepairOperation {
 
         // XDR file types: parse into a uniform `XdrParseResult` and route
         // recording through the shared `record_result` helper.
-        let parsed = if history_format::is_ledger_file(path) {
+        let parsed = if history_format::is_ledger_header_file(path) {
             let Ok(reader) = self.dst_store.open_reader(path).await else {
                 return Ok(false);
             };
-            match xdr_verify::parse_ledger_stream(path, reader).await {
+            match xdr_verify::parse_ledger_header_stream(path, reader).await {
                 Ok(data) => XdrParseResult::Ledger(data),
                 Err(_) => return Ok(false),
             }
@@ -319,7 +319,7 @@ impl RepairOperation {
             return;
         };
         match result {
-            XdrParseResult::Ledger(data) => manager.record_ledger_data(cp, data),
+            XdrParseResult::Ledger(data) => manager.record_header_data(cp, data),
             XdrParseResult::Transactions(hashes) => manager.record_tx_set_hashes(cp, hashes),
             XdrParseResult::Results(hashes) => manager.record_result_hashes(cp, hashes),
             XdrParseResult::None => {}

--- a/src/repair_operation.rs
+++ b/src/repair_operation.rs
@@ -80,8 +80,6 @@ pub struct RepairOperation {
     concurrency: usize,
     skip_optional: bool,
     storage_config: StorageConfig,
-    max_retries: u32,
-    retry_min_delay_ms: u64,
     /// Verification manager — populated only when `verify` is on. Records
     /// per-file XDR data (from dst-first parse or src-fetched verify) so that
     /// `finalize_checkpoint` can run cross-file checks and `finalize` can run
@@ -123,8 +121,6 @@ impl RepairOperation {
             concurrency,
             skip_optional,
             storage_config: storage_config.clone(),
-            max_retries: storage_config.max_retries as u32,
-            retry_min_delay_ms: storage_config.retry_min_delay.as_millis() as u64,
             verification_manager: if verify {
                 Some(Arc::new(XdrVerificationManager::new()))
             } else {
@@ -162,8 +158,8 @@ impl RepairOperation {
                 let completed = &completed;
                 async move {
                     let result = utils::with_retries(
-                        self.max_retries,
-                        self.retry_min_delay_ms,
+                        self.storage_config.max_retries as u32,
+                        self.storage_config.retry_min_delay.as_millis() as u64,
                         "repair",
                         path,
                         || async { self.fetch_from_src(path).await.map(|_| ()) },
@@ -411,7 +407,7 @@ impl Operation for RepairOperation {
         let dst_result = utils::fetch_well_known_history_file(
             &self.dst_store,
             0, // no retries for local filesystem
-            self.retry_min_delay_ms,
+            self.storage_config.retry_min_delay.as_millis() as u64,
         )
         .await;
 
@@ -427,8 +423,8 @@ impl Operation for RepairOperation {
                 // Fall back to source .well-known
                 let src_state = utils::fetch_well_known_history_file(
                     source,
-                    self.max_retries,
-                    self.retry_min_delay_ms,
+                    self.storage_config.max_retries as u32,
+                    self.storage_config.retry_min_delay.as_millis() as u64,
                 )
                 .await
                 .map_err(|e| pipeline::Error::RepairOperation(Error::Utils(e)))?;

--- a/src/repair_operation.rs
+++ b/src/repair_operation.rs
@@ -634,6 +634,19 @@ fn report_dry_run(files: &[String]) {
 }
 
 /// Validate a JSON file list for manual repair mode.
+///
+/// Each entry must be a recognized archive path — `.well-known/stellar-history.json`
+/// or one of the per-category checkpoint/bucket paths under `history/`,
+/// `ledger/`, `transactions/`, `results/`, `scp/`, or `bucket/`. This prevents
+/// path traversal: manual-mode paths flow into `dst_store.copy_from_reader`,
+/// which on filesystem-backed destinations joins onto the archive root, so
+/// arbitrary input like `../../etc/foo` or `/absolute/path` would otherwise
+/// allow writes outside the archive.
+///
+/// Defense-in-depth: also reject any path containing `..` segments, a leading
+/// `/`, or a backslash, even if the per-category predicate were to drift in
+/// the future. Empty strings are skipped (legacy behavior). Duplicates are
+/// deduped.
 pub fn validate_file_list(file_list: &[String]) -> Result<Vec<String>, Error> {
     let mut seen = HashSet::new();
     let mut result = Vec::new();
@@ -641,6 +654,37 @@ pub fn validate_file_list(file_list: &[String]) -> Result<Vec<String>, Error> {
         if path.is_empty() {
             continue;
         }
+
+        // Path-traversal guards. Reject anything that looks like an absolute
+        // path, a Windows path separator, or contains a `..` segment.
+        if path.starts_with('/') || path.contains('\\') {
+            return Err(Error::InvalidFileList(format!(
+                "path '{path}' must be a relative archive path \
+                 (no leading '/', no '\\\\' separators)"
+            )));
+        }
+        if path.split('/').any(|seg| seg == "..") {
+            return Err(Error::InvalidFileList(format!(
+                "path '{path}' contains '..' segment; archive paths must not traverse"
+            )));
+        }
+
+        // Must be a recognized archive path shape.
+        let recognized = path == history_format::ROOT_WELL_KNOWN_PATH
+            || history_format::is_history_file(path)
+            || history_format::is_ledger_header_file(path)
+            || history_format::is_transactions_file(path)
+            || history_format::is_results_file(path)
+            || history_format::is_scp_file(path)
+            || history_format::is_bucket_file(path);
+        if !recognized {
+            return Err(Error::InvalidFileList(format!(
+                "path '{path}' is not a recognized archive path \
+                 (expected .well-known/stellar-history.json or a file under \
+                 history/ ledger/ transactions/ results/ scp/ bucket/)"
+            )));
+        }
+
         if seen.insert(path.clone()) {
             result.push(path.clone());
         }
@@ -707,6 +751,64 @@ mod tests {
         ];
         let result = validate_file_list(&list).unwrap();
         assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn test_validate_file_list_accepts_all_recognized_kinds() {
+        let list = vec![
+            ".well-known/stellar-history.json".to_string(),
+            "history/00/00/3f/history-0000003f.json".to_string(),
+            "ledger/00/00/3f/ledger-0000003f.xdr.gz".to_string(),
+            "transactions/00/00/3f/transactions-0000003f.xdr.gz".to_string(),
+            "results/00/00/3f/results-0000003f.xdr.gz".to_string(),
+            "scp/00/00/3f/scp-0000003f.xdr.gz".to_string(),
+            "bucket/ab/cd/ef/bucket-abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890.xdr.gz".to_string(),
+        ];
+        let result = validate_file_list(&list).unwrap();
+        assert_eq!(result.len(), 7);
+    }
+
+    #[test]
+    fn test_validate_file_list_rejects_path_traversal() {
+        let list = vec!["ledger/../etc/passwd".to_string()];
+        let err = validate_file_list(&list).unwrap_err().to_string();
+        assert!(err.contains(".."), "got: {err}");
+    }
+
+    #[test]
+    fn test_validate_file_list_rejects_path_traversal_at_start() {
+        let list = vec!["../escape.txt".to_string()];
+        let err = validate_file_list(&list).unwrap_err().to_string();
+        assert!(err.contains(".."), "got: {err}");
+    }
+
+    #[test]
+    fn test_validate_file_list_rejects_absolute_path() {
+        let list = vec!["/etc/passwd".to_string()];
+        let err = validate_file_list(&list).unwrap_err().to_string();
+        assert!(err.contains("relative"), "got: {err}");
+    }
+
+    #[test]
+    fn test_validate_file_list_rejects_backslash() {
+        let list = vec!["ledger\\foo.xdr.gz".to_string()];
+        let err = validate_file_list(&list).unwrap_err().to_string();
+        assert!(err.contains("relative"), "got: {err}");
+    }
+
+    #[test]
+    fn test_validate_file_list_rejects_unknown_prefix() {
+        let list = vec!["garbage/foo.xdr.gz".to_string()];
+        let err = validate_file_list(&list).unwrap_err().to_string();
+        assert!(err.contains("not a recognized"), "got: {err}");
+    }
+
+    #[test]
+    fn test_validate_file_list_rejects_bucket_with_bad_hash() {
+        // Right prefix, but the hash isn't 64 hex chars → is_bucket_file returns false.
+        let list = vec!["bucket/ab/cd/ef/bucket-shorthash.xdr.gz".to_string()];
+        let err = validate_file_list(&list).unwrap_err().to_string();
+        assert!(err.contains("not a recognized"), "got: {err}");
     }
 
     #[test]

--- a/src/repair_operation.rs
+++ b/src/repair_operation.rs
@@ -1,0 +1,718 @@
+//! Repair operation — detects and fixes corrupted or missing files in a Stellar History Archive.
+//!
+//! Implements the `Operation` trait and runs inside the existing `Pipeline`.
+//! Pipeline source = SOURCE archive (known-good). RepairOperation holds both
+//! `src_store` and `dst_store`; the destination is what's being repaired.
+//!
+//! **Per-file flow** (in `process_object`, matching scan/mirror's "all verification
+//! in process_object" pattern): try the destination first — open dst reader, parse
+//! XDR (or verify bucket hash), and on success record the parsed data into the
+//! verification manager and stop. On parse failure or missing dst file, fetch
+//! from src via `verify_and_write_xdr` (or `verify_and_write_bucket`) and record
+//! the result.
+//!
+//! **Retry phase** (in `finalize`): after the main pass completes, the manager
+//! has data for every file in the range. Run `verify_checkpoint_chain` (cross-
+//! checkpoint chain) and accumulate any failing checkpoints (both ends of a
+//! break) into `retry_checkpoints`. `finalize_checkpoint` already added per-
+//! checkpoint cross-file failures during the main pass. For each retry
+//! checkpoint, drive `pipeline::process_checkpoint` with a fresh
+//! `MirrorOperation` (overwrite=true, verify=false) — pure copy from src,
+//! trusting src is canonical.
+//!
+//! **Manual mode** (`run_manual`): downloads a fixed list of paths directly,
+//! bypassing the pipeline and the retry machinery.
+
+use crate::history_format;
+use crate::mirror_operation::MirrorOperation;
+use crate::pipeline::{self, async_trait, Operation, Pipeline, PipelineConfig};
+use crate::storage::{
+    self, cleanup_partial_file, Error as StorageError, StorageConfig, StorageRef,
+};
+use crate::utils::{self, ArchiveStats};
+use crate::xdr_verify::{self, XdrParseResult, XdrVerificationManager};
+use futures_util::{stream, StreamExt};
+use opendal::Buffer;
+use std::collections::{BTreeSet, HashSet};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use thiserror::Error;
+use tracing::{debug, error, info, warn};
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Archive repair failed")]
+    RepairFailed,
+
+    #[error("Invalid file list: {0}")]
+    InvalidFileList(String),
+
+    #[error(transparent)]
+    Utils(#[from] utils::Error),
+
+    #[error(transparent)]
+    Storage(#[from] storage::Error),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("History format error: {0}")]
+    HistoryFormat(#[from] history_format::Error),
+
+    #[error("Scan operation error: {0}")]
+    ScanOperation(#[from] crate::scan_operation::Error),
+}
+
+/// How often to report progress (every N files) in manual mode
+const MANUAL_PROGRESS_FREQUENCY: usize = 100;
+
+// ============================================================================
+// RepairOperation
+// ============================================================================
+
+pub struct RepairOperation {
+    src_store: StorageRef,
+    dst_store: StorageRef,
+    low: Option<u32>,
+    high: Option<u32>,
+    verify: bool,
+    dry_run: bool,
+    concurrency: usize,
+    skip_optional: bool,
+    storage_config: StorageConfig,
+    max_retries: u32,
+    retry_min_delay_ms: u64,
+    /// Verification manager — populated only when `verify` is on. Records
+    /// per-file XDR data (from dst-first parse or src-fetched verify) so that
+    /// `finalize_checkpoint` can run cross-file checks and `finalize` can run
+    /// the cross-checkpoint chain check.
+    verification_manager: Option<Arc<XdrVerificationManager>>,
+    /// Set during get_checkpoint_bounds if dest .well-known needs repair
+    well_known_needs_repair: AtomicBool,
+    /// Dry-run counter: files that would be repaired
+    needs_repair_count: AtomicU64,
+    /// Checkpoints whose cross-file or chain checks failed; re-mirrored from
+    /// src in `finalize`.
+    retry_checkpoints: Mutex<BTreeSet<u32>>,
+}
+
+impl RepairOperation {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        src_store: StorageRef,
+        dst_store: StorageRef,
+        low: Option<u32>,
+        high: Option<u32>,
+        verify: bool,
+        dry_run: bool,
+        concurrency: usize,
+        skip_optional: bool,
+        storage_config: &StorageConfig,
+    ) -> Self {
+        debug_assert!(
+            dst_store.supports_writes(),
+            "RepairOperation requires a writable destination store"
+        );
+        Self {
+            src_store,
+            dst_store,
+            low,
+            high,
+            verify,
+            dry_run,
+            concurrency,
+            skip_optional,
+            storage_config: storage_config.clone(),
+            max_retries: storage_config.max_retries as u32,
+            retry_min_delay_ms: storage_config.retry_min_delay.as_millis() as u64,
+            verification_manager: if verify {
+                Some(Arc::new(XdrVerificationManager::new()))
+            } else {
+                None
+            },
+            well_known_needs_repair: AtomicBool::new(false),
+            needs_repair_count: AtomicU64::new(0),
+            retry_checkpoints: Mutex::new(BTreeSet::new()),
+        }
+    }
+
+    /// Manual mode: download a fixed list of paths directly (no checkpoint
+    /// iteration, no bucket discovery, no verification manager, no retry).
+    pub async fn run_manual(&self, files: &[String]) -> Result<(), Error> {
+        info!("Manual repair mode: {} files specified", files.len());
+        let files = validate_file_list(files)?;
+        if files.is_empty() {
+            info!("No files need repair");
+            return Ok(());
+        }
+        info!("{} file(s) to repair", files.len());
+
+        if self.dry_run {
+            report_dry_run(&files);
+            return Ok(());
+        }
+
+        let stats = ArchiveStats::new();
+        let completed = AtomicUsize::new(0);
+        let total = files.len();
+
+        stream::iter(files.iter())
+            .for_each_concurrent(self.concurrency, |path| {
+                let stats = &stats;
+                let completed = &completed;
+                async move {
+                    let result = utils::with_retries(
+                        self.max_retries,
+                        self.retry_min_delay_ms,
+                        "repair",
+                        path,
+                        || async { self.fetch_from_src(path).await.map(|_| ()) },
+                    )
+                    .await;
+                    match result {
+                        Ok(()) => {
+                            debug!("Repaired: {}", path);
+                            stats.record_success(path);
+                        }
+                        Err(e) => {
+                            error!("Failed to repair {}: {}", path, e);
+                            stats.record_failure(path).await;
+                        }
+                    }
+                    let done = completed.fetch_add(1, Ordering::Relaxed) + 1;
+                    if done.is_multiple_of(MANUAL_PROGRESS_FREQUENCY) || done == total {
+                        info!("Repair progress: {}/{} files", done, total);
+                    }
+                }
+            })
+            .await;
+
+        stats.report("repair").await;
+        if stats.has_failures() {
+            return Err(Error::RepairFailed);
+        }
+        Ok(())
+    }
+
+    /// Increment the dry-run counter (signalling "we'd repair this file but
+    /// did nothing"). Used when dst checks fail and we'd otherwise fetch from src.
+    fn note_dry_run(&self, path: &str) {
+        self.needs_repair_count.fetch_add(1, Ordering::Relaxed);
+        debug!("Dry run: would repair {}", path);
+    }
+
+    /// Fetch a file from src and write to dst with optional verification.
+    /// Returns the parsed XDR data (for XDR files when `verify` is on) so the
+    /// caller can record it into the manager. Returns `None` for buckets,
+    /// non-verified copies, and unrecognized file types.
+    async fn fetch_from_src(&self, path: &str) -> Result<Option<XdrParseResult>, StorageError> {
+        let reader = self.src_store.open_reader(path).await?;
+        if self.verify {
+            if history_format::is_bucket_file(path) {
+                return match crate::verify::verify_and_write_bucket(path, reader, &self.dst_store)
+                    .await
+                {
+                    Ok(()) => Ok(None),
+                    Err(e) => {
+                        cleanup_partial_file(&self.dst_store, path).await?;
+                        Err(e)
+                    }
+                };
+            }
+            if history_format::is_ledger_file(path)
+                || history_format::is_transactions_file(path)
+                || history_format::is_results_file(path)
+                || history_format::is_scp_file(path)
+            {
+                return match xdr_verify::verify_and_write_xdr(path, reader, &self.dst_store).await {
+                    Ok(result) => Ok(Some(result)),
+                    Err(e) => {
+                        cleanup_partial_file(&self.dst_store, path).await?;
+                        Err(e)
+                    }
+                };
+            }
+        }
+        match self.dst_store.copy_from_reader(path, reader).await {
+            Ok(()) => Ok(None),
+            Err(e) => {
+                cleanup_partial_file(&self.dst_store, path).await?;
+                Err(e)
+            }
+        }
+    }
+
+    /// Check whether dst already has a good copy of `path` and (when `--verify`
+    /// is on) record the parsed data into the manager.
+    ///
+    /// Returns `Ok(true)` if dst is acceptable (caller should skip src fetch),
+    /// `Ok(false)` on missing or corrupt dst (caller should fetch from src),
+    /// or `Err` if `path` doesn't match any recognized archive file type
+    /// (a contract violation from the pipeline's dispatch).
+    ///
+    /// When `--verify` is off, only existence is checked — content is not
+    /// validated and nothing is recorded into the manager.
+    async fn verify_and_record_dst(&self, path: &str) -> Result<bool, StorageError> {
+        if !self.verify {
+            return Ok(self.dst_store.exists(path).await.unwrap_or(false));
+        }
+
+        // Buckets and SCP files have no per-checkpoint manager state — verify
+        // structurally on dst, no recording.
+        if history_format::is_bucket_file(path) {
+            let Ok(reader) = self.dst_store.open_reader(path).await else {
+                return Ok(false);
+            };
+            return Ok(crate::verify::verify_bucket_stream(path, reader)
+                .await
+                .is_ok());
+        }
+        if history_format::is_scp_file(path) {
+            let Ok(reader) = self.dst_store.open_reader(path).await else {
+                return Ok(false);
+            };
+            return Ok(xdr_verify::parse_scp_stream(path, reader).await.is_ok());
+        }
+
+        // XDR file types: parse into a uniform `XdrParseResult` and route
+        // recording through the shared `record_result` helper.
+        let parsed = if history_format::is_ledger_file(path) {
+            let Ok(reader) = self.dst_store.open_reader(path).await else {
+                return Ok(false);
+            };
+            match xdr_verify::parse_ledger_stream(path, reader).await {
+                Ok(data) => XdrParseResult::Ledger(data),
+                Err(_) => return Ok(false),
+            }
+        } else if history_format::is_transactions_file(path) {
+            let Ok(reader) = self.dst_store.open_reader(path).await else {
+                return Ok(false);
+            };
+            match xdr_verify::parse_transactions_stream(path, reader).await {
+                Ok(hashes) => XdrParseResult::Transactions(hashes),
+                Err(_) => return Ok(false),
+            }
+        } else if history_format::is_results_file(path) {
+            let Ok(reader) = self.dst_store.open_reader(path).await else {
+                return Ok(false);
+            };
+            match xdr_verify::parse_results_stream(path, reader).await {
+                Ok(hashes) => XdrParseResult::Results(hashes),
+                Err(_) => return Ok(false),
+            }
+        } else {
+            return Err(StorageError::fatal(format!(
+                "verify_and_record_dst: unrecognized archive path '{path}' \
+                 (expected bucket / ledger / transactions / results / scp)"
+            )));
+        };
+
+        self.record_result(path, parsed);
+        Ok(true)
+    }
+
+    /// Record a parsed XDR result into the verification manager. Used for both
+    /// dst-side parses (via `verify_and_record_dst`) and src-side fetches (via
+    /// `process_object` after `fetch_from_src`). No-op when `--verify` is off
+    /// (manager is `None`) or the path doesn't carry a checkpoint number.
+    fn record_result(&self, path: &str, result: XdrParseResult) {
+        let Some(ref manager) = self.verification_manager else {
+            return;
+        };
+        let Some(cp) = history_format::checkpoint_from_path(path) else {
+            return;
+        };
+        match result {
+            XdrParseResult::Ledger(data) => manager.record_ledger_data(cp, data),
+            XdrParseResult::Transactions(hashes) => manager.record_tx_set_hashes(cp, hashes),
+            XdrParseResult::Results(hashes) => manager.record_result_hashes(cp, hashes),
+            XdrParseResult::None => {}
+        }
+    }
+
+    /// Re-mirror a list of checkpoints from src using `Pipeline<MirrorOperation>`
+    /// with overwrite semantics (`overwrite=true`, `verify=false`). Trust src
+    /// is canonical — no residual verification. Retry checkpoints are
+    /// processed concurrently up to `self.concurrency`.
+    async fn run_retry(&self, retry: &[u32]) {
+        info!(
+            "Retrying {} checkpoint(s) from src (cross-file or chain inconsistency)",
+            retry.len()
+        );
+        let mirror_op = MirrorOperation::new(
+            self.dst_store.clone(),
+            /*overwrite=*/ true,
+            None,
+            None,
+            /*allow_mirror_gaps=*/ true,
+            &self.storage_config,
+            /*verify=*/ false,
+        );
+        let retry_pipeline = Pipeline::new(
+            mirror_op,
+            PipelineConfig {
+                concurrency: self.concurrency,
+                skip_optional: self.skip_optional,
+                storage_config: self.storage_config.clone(),
+            },
+            self.src_store.clone(),
+            Some(self.dst_store.clone()),
+        );
+        let pipeline_ref = &retry_pipeline;
+        stream::iter(retry.iter().copied())
+            .for_each_concurrent(self.concurrency, |cp| async move {
+                pipeline_ref.process_checkpoint(cp).await;
+            })
+            .await;
+    }
+
+    /// Repair .well-known by copying from highest checkpoint's history file.
+    async fn repair_well_known(&self, highest_checkpoint: u32) {
+        let history_path = history_format::checkpoint_path("history", highest_checkpoint);
+        let well_known_path = history_format::ROOT_WELL_KNOWN_PATH;
+
+        if let Some(base_path) = self.dst_store.get_base_path() {
+            let src_file = base_path.join(&history_path);
+            let dst_file = base_path.join(well_known_path);
+
+            if !tokio::fs::try_exists(&src_file).await.unwrap_or(false) {
+                error!(
+                    "Cannot repair .well-known: history file at checkpoint {} not found",
+                    highest_checkpoint
+                );
+                return;
+            }
+
+            if let Some(parent) = dst_file.parent() {
+                if let Err(e) = tokio::fs::create_dir_all(parent).await {
+                    error!("Failed to create .well-known directory: {}", e);
+                    return;
+                }
+            }
+
+            match tokio::fs::copy(&src_file, &dst_file).await {
+                Ok(_) => info!(
+                    "Restored .well-known from checkpoint {} (0x{:08x})",
+                    highest_checkpoint, highest_checkpoint
+                ),
+                Err(e) => error!("Failed to restore .well-known: {}", e),
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl Operation for RepairOperation {
+    async fn get_checkpoint_bounds(
+        &self,
+        source: &StorageRef,
+    ) -> Result<(u32, u32), pipeline::Error> {
+        // Try destination .well-known first (determines what range to repair)
+        let dst_result = utils::fetch_well_known_history_file(
+            &self.dst_store,
+            0, // no retries for local filesystem
+            self.retry_min_delay_ms,
+        )
+        .await;
+
+        let checkpoint = match dst_result {
+            Ok(state) => history_format::round_to_lower_checkpoint(state.current_ledger),
+            Err(e) => {
+                warn!(
+                    "Destination .well-known is unreadable ({}), falling back to source",
+                    e
+                );
+                self.well_known_needs_repair.store(true, Ordering::Relaxed);
+
+                // Fall back to source .well-known
+                let src_state = utils::fetch_well_known_history_file(
+                    source,
+                    self.max_retries,
+                    self.retry_min_delay_ms,
+                )
+                .await
+                .map_err(|e| pipeline::Error::RepairOperation(Error::Utils(e)))?;
+                history_format::round_to_lower_checkpoint(src_state.current_ledger)
+            }
+        };
+
+        utils::compute_checkpoint_bounds(checkpoint, self.low, self.high)
+            .map_err(|e| pipeline::Error::RepairOperation(Error::Utils(e)))
+    }
+
+    /// Process a file: try dst first (verify + record into manager), and on
+    /// missing/corrupt fetch from src (verify-and-write + record). All
+    /// verification logic lives here, matching scan/mirror's pattern.
+    async fn process_object(
+        &self,
+        path: &str,
+        _src_store: &StorageRef,
+    ) -> Result<(), StorageError> {
+        if self.verify_and_record_dst(path).await? {
+            return Ok(());
+        }
+        if self.dry_run {
+            self.note_dry_run(path);
+            return Ok(());
+        }
+        let result = self.fetch_from_src(path).await?;
+        if let Some(parsed) = result {
+            self.record_result(path, parsed);
+        }
+        Ok(())
+    }
+
+    /// Override history buffer sourcing: read from destination first, fall back to source.
+    async fn fetch_history_buffer(
+        &self,
+        history_path: &str,
+        src_store: &StorageRef,
+        dst_store: Option<&StorageRef>,
+    ) -> Result<Buffer, StorageError> {
+        // Try reading from destination (local, cheap)
+        if let Some(dst) = dst_store {
+            if let Ok(buffer) = storage::download_buffer(dst, history_path).await {
+                if history_format::parse_history(&buffer, history_path).is_ok() {
+                    return Ok(buffer);
+                }
+                // Exists but corrupt — fall through to source
+            }
+        }
+
+        // Destination missing or corrupt — need from source
+        if self.dry_run {
+            self.needs_repair_count.fetch_add(1, Ordering::Relaxed);
+            debug!("Dry run: would repair {}", history_path);
+        }
+
+        // Download from source (pipeline will write to dst via process_buffer)
+        storage::download_buffer(src_store, history_path).await
+    }
+
+    fn finalize_checkpoint(&self, checkpoint: u32) {
+        if let Some(ref manager) = self.verification_manager {
+            let errors = manager.verify_and_release(checkpoint);
+            if !errors.is_empty() {
+                self.retry_checkpoints.lock().unwrap().insert(checkpoint);
+            }
+        }
+    }
+
+    async fn finalize(
+        &self,
+        highest_checkpoint: u32,
+        stats: &ArchiveStats,
+    ) -> Result<(), pipeline::Error> {
+        // Step 1: cross-checkpoint chain check; both ends of any break go to retry.
+        if let Some(ref manager) = self.verification_manager {
+            let chain_errors = manager.verify_checkpoint_chain();
+            let mut retry = self.retry_checkpoints.lock().unwrap();
+            for err in chain_errors {
+                retry.insert(err.checkpoint);
+                if err.checkpoint >= history_format::CHECKPOINT_FREQUENCY {
+                    retry.insert(err.checkpoint - history_format::CHECKPOINT_FREQUENCY);
+                }
+            }
+        }
+
+        let retry: Vec<u32> = std::mem::take(&mut *self.retry_checkpoints.lock().unwrap())
+            .into_iter()
+            .collect();
+
+        // Step 2: re-mirror retry checkpoints from src using Pipeline<MirrorOperation>.
+        if !retry.is_empty() && !self.dry_run {
+            self.run_retry(&retry).await;
+        }
+
+        // Step 3: .well-known repair (after retry, so it reflects fixed data).
+        if self.well_known_needs_repair.load(Ordering::Relaxed) && !self.dry_run {
+            self.repair_well_known(highest_checkpoint).await;
+        }
+
+        // Step 4: report results.
+        if self.dry_run {
+            let count = self.needs_repair_count.load(Ordering::Relaxed);
+            info!(
+                "Dry run: {} file(s) would be repaired ({} checkpoint(s) would retry)",
+                count,
+                retry.len()
+            );
+        } else {
+            stats.report("repair").await;
+            if stats.has_failures() {
+                return Err(Error::RepairFailed.into());
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Manual-mode helpers
+// ============================================================================
+
+/// Log what would be repaired (for manual mode dry-run).
+fn report_dry_run(files: &[String]) {
+    info!("Dry run: {} file(s) would be repaired:", files.len());
+
+    let mut counts = [0u64; 7];
+    for path in files {
+        let idx = if path.starts_with("history/") || path.contains("stellar-history.json") {
+            0
+        } else if path.starts_with("ledger/") {
+            1
+        } else if path.starts_with("transactions/") {
+            2
+        } else if path.starts_with("results/") {
+            3
+        } else if path.starts_with("bucket/") {
+            4
+        } else if path.starts_with("scp/") {
+            5
+        } else {
+            6
+        };
+        counts[idx] += 1;
+    }
+
+    let labels = [
+        "history",
+        "ledger",
+        "transactions",
+        "results",
+        "bucket",
+        "scp",
+        "other",
+    ];
+    for (count, label) in counts.iter().zip(labels.iter()) {
+        if *count > 0 {
+            info!("  {} {} file(s)", count, label);
+        }
+    }
+}
+
+/// Validate a JSON file list for manual repair mode.
+pub fn validate_file_list(file_list: &[String]) -> Result<Vec<String>, Error> {
+    let mut seen = HashSet::new();
+    let mut result = Vec::new();
+    for path in file_list {
+        if path.is_empty() {
+            continue;
+        }
+        if seen.insert(path.clone()) {
+            result.push(path.clone());
+        }
+    }
+    Ok(result)
+}
+
+/// Parse a JSON file containing an array of file paths for manual repair.
+pub fn parse_file_list_json(content: &str) -> Result<Vec<String>, Error> {
+    let parsed: serde_json::Value = serde_json::from_str(content)
+        .map_err(|e| Error::InvalidFileList(format!("Invalid JSON: {e}")))?;
+
+    let array = parsed
+        .as_array()
+        .ok_or_else(|| Error::InvalidFileList("Expected a JSON array of file paths".to_string()))?;
+
+    let mut paths = Vec::with_capacity(array.len());
+    for (i, item) in array.iter().enumerate() {
+        let path = item.as_str().ok_or_else(|| {
+            Error::InvalidFileList(format!("Element at index {i} is not a string"))
+        })?;
+        paths.push(path.to_string());
+    }
+
+    validate_file_list(&paths)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_file_list_valid() {
+        let list = vec![
+            "ledger/00/00/3f/ledger-0000003f.xdr.gz".to_string(),
+            "bucket/ab/cd/ef/bucket-abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890.xdr.gz".to_string(),
+        ];
+        let result = validate_file_list(&list).unwrap();
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_validate_file_list_empty() {
+        let list: Vec<String> = vec![];
+        let result = validate_file_list(&list).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_validate_file_list_deduplicates() {
+        let list = vec![
+            "ledger/00/00/3f/ledger-0000003f.xdr.gz".to_string(),
+            "ledger/00/00/3f/ledger-0000003f.xdr.gz".to_string(),
+        ];
+        let result = validate_file_list(&list).unwrap();
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn test_validate_file_list_skips_empty_strings() {
+        let list = vec![
+            String::new(),
+            "ledger/00/00/3f/ledger-0000003f.xdr.gz".to_string(),
+        ];
+        let result = validate_file_list(&list).unwrap();
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_file_list_json_valid() {
+        let json = r#"["ledger/00/00/3f/ledger-0000003f.xdr.gz", "bucket/ab/cd/ef/bucket-abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890.xdr.gz"]"#;
+        let result = parse_file_list_json(json).unwrap();
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_file_list_json_empty_array() {
+        let json = "[]";
+        let result = parse_file_list_json(json).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_parse_file_list_json_invalid_json() {
+        let json = "not json {{";
+        let result = parse_file_list_json(json);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Invalid JSON"), "got: {err}");
+    }
+
+    #[test]
+    fn test_parse_file_list_json_non_array() {
+        let json = r#"{"key": "value"}"#;
+        let result = parse_file_list_json(json);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("JSON array"), "got: {err}");
+    }
+
+    #[test]
+    fn test_parse_file_list_json_non_string_elements() {
+        let json = "[1, 2, 3]";
+        let result = parse_file_list_json(json);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("not a string"), "got: {err}");
+    }
+
+    #[test]
+    fn test_parse_file_list_json_deduplicates() {
+        let json = r#"["ledger/00/00/3f/ledger-0000003f.xdr.gz", "ledger/00/00/3f/ledger-0000003f.xdr.gz"]"#;
+        let result = parse_file_list_json(json).unwrap();
+        assert_eq!(result.len(), 1);
+    }
+}

--- a/src/scan_operation.rs
+++ b/src/scan_operation.rs
@@ -1,6 +1,6 @@
 use crate::history_format;
 use crate::pipeline::{async_trait, Operation};
-use crate::storage::{from_opendal_error, Error as StorageError, StorageRef};
+use crate::storage::{from_opendal_error, Error as StorageError, StorageConfig, StorageRef};
 use crate::utils::{compute_checkpoint_bounds, fetch_well_known_history_file, ArchiveStats};
 use crate::xdr_verify::XdrVerificationManager;
 use opendal::Buffer;
@@ -29,9 +29,8 @@ pub struct ScanOperation {
     low: Option<u32>,
     high: Option<u32>,
 
-    // Retry configuration for source fetches
-    max_retries: u32,
-    retry_min_delay_ms: u64,
+    // Storage configuration (retry params for source fetches live here)
+    storage_config: StorageConfig,
 
     // Populated if we should verify files, otherwise None
     verification_manager: Option<Arc<XdrVerificationManager>>,
@@ -41,15 +40,13 @@ impl ScanOperation {
     pub fn new(
         low: Option<u32>,
         high: Option<u32>,
-        max_retries: u32,
-        retry_min_delay_ms: u64,
+        storage_config: &StorageConfig,
         verify: bool,
     ) -> Self {
         Self {
             low,
             high,
-            max_retries,
-            retry_min_delay_ms,
+            storage_config: storage_config.clone(),
             verification_manager: if verify {
                 Some(Arc::new(XdrVerificationManager::new()))
             } else {
@@ -82,10 +79,13 @@ impl Operation for ScanOperation {
         &self,
         source: &StorageRef,
     ) -> Result<(u32, u32), crate::pipeline::Error> {
-        let source_state =
-            fetch_well_known_history_file(source, self.max_retries, self.retry_min_delay_ms)
-                .await
-                .map_err(|e| crate::pipeline::Error::ScanOperation(Error::Utils(e)))?;
+        let source_state = fetch_well_known_history_file(
+            source,
+            self.storage_config.max_retries as u32,
+            self.storage_config.retry_min_delay.as_millis() as u64,
+        )
+        .await
+        .map_err(|e| crate::pipeline::Error::ScanOperation(Error::Utils(e)))?;
         let source_checkpoint =
             history_format::round_to_lower_checkpoint(source_state.current_ledger);
 

--- a/src/scan_operation.rs
+++ b/src/scan_operation.rs
@@ -99,10 +99,10 @@ impl Operation for ScanOperation {
             let reader = src_store.open_reader(path).await?;
             if crate::history_format::is_bucket_file(path) {
                 crate::verify::verify_bucket_stream(path, reader).await
-            } else if crate::history_format::is_ledger_file(path) {
+            } else if crate::history_format::is_ledger_header_file(path) {
                 let checkpoint = Self::checkpoint_from_verified_path(path)?;
-                let data = crate::xdr_verify::parse_ledger_stream(path, reader).await?;
-                manager.record_ledger_data(checkpoint, data);
+                let data = crate::xdr_verify::parse_ledger_header_stream(path, reader).await?;
+                manager.record_header_data(checkpoint, data);
                 Ok(())
             } else if crate::history_format::is_transactions_file(path) {
                 let checkpoint = Self::checkpoint_from_verified_path(path)?;

--- a/src/scan_operation.rs
+++ b/src/scan_operation.rs
@@ -3,6 +3,7 @@ use crate::pipeline::{async_trait, Operation};
 use crate::storage::{from_opendal_error, Error as StorageError, StorageRef};
 use crate::utils::{compute_checkpoint_bounds, fetch_well_known_history_file, ArchiveStats};
 use crate::xdr_verify::XdrVerificationManager;
+use opendal::Buffer;
 use opendal::Reader;
 use std::sync::Arc;
 use thiserror::Error;
@@ -167,5 +168,10 @@ impl Operation for ScanOperation {
         if let Some(ref manager) = self.verification_manager {
             manager.verify_and_release(checkpoint);
         }
+    }
+
+    /// Scan never writes — record success and discard the buffer.
+    async fn process_buffer(&self, path: &str, _buffer: Buffer, stats: &ArchiveStats) {
+        stats.record_success(path);
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1064,6 +1064,25 @@ pub async fn download_buffer(store: &StorageRef, path: &str) -> Result<opendal::
     Ok(chunks.into_iter().flatten().collect())
 }
 
+/// Write `buffer` to `store` at `path`. On write failure, attempt to clean up
+/// any partial file left behind (logging but not propagating cleanup errors)
+/// and return the original write error.
+pub async fn write_buffer_with_cleanup(
+    store: &StorageRef,
+    path: &str,
+    buffer: opendal::Buffer,
+) -> Result<(), Error> {
+    match store.write(path, buffer).await {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            if let Err(cleanup_err) = cleanup_partial_file(store, path).await {
+                tracing::error!("Failed to cleanup partial file {}: {}", path, cleanup_err);
+            }
+            Err(e)
+        }
+    }
+}
+
 /// Clean up a partial file on the destination after a write failure.
 /// No-op on atomic-write backends (temp file is discarded automatically).
 pub async fn cleanup_partial_file(store: &StorageRef, path: &str) -> Result<(), Error> {

--- a/src/tests/history_format.rs
+++ b/src/tests/history_format.rs
@@ -609,14 +609,11 @@ fn test_version_1_buckets_method(canonical_v1_has: HistoryFileState) {
     let buckets = canonical_v1_has.buckets();
 
     // Should not contain zero hashes
-    assert!(!buckets
-        .contains(&"0000000000000000000000000000000000000000000000000000000000000000".to_string()));
+    assert!(!buckets.contains("0000000000000000000000000000000000000000000000000000000000000000"));
 
     // Check some known buckets from v1
-    assert!(buckets
-        .contains(&"5a7e9c8d4b3f2e1d6c5a4b3f2e1d6c5a4b3f2e1d6c5a4b3f2e1d6c5a4b3f2e1d".to_string()));
-    assert!(buckets
-        .contains(&"9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c3d2e1f0a9b8c".to_string()));
+    assert!(buckets.contains("5a7e9c8d4b3f2e1d6c5a4b3f2e1d6c5a4b3f2e1d6c5a4b3f2e1d6c5a4b3f2e1d"));
+    assert!(buckets.contains("9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c3d2e1f0a9b8c"));
 
     // Verify we have a reasonable number of unique buckets
     assert!(
@@ -633,17 +630,14 @@ fn test_version_2_buckets_method(canonical_v2_has: HistoryFileState) {
     // currentBuckets and hotArchiveBuckets
 
     // Should not contain zero hashes
-    assert!(!buckets
-        .contains(&"0000000000000000000000000000000000000000000000000000000000000000".to_string()));
+    assert!(!buckets.contains("0000000000000000000000000000000000000000000000000000000000000000"));
 
     // Check that we got buckets from both arrays
     // From currentBuckets
-    assert!(buckets
-        .contains(&"5a7e9c8d4b3f2e1d6c5a4b3f2e1d6c5a4b3f2e1d6c5a4b3f2e1d6c5a4b3f2e1d".to_string()));
+    assert!(buckets.contains("5a7e9c8d4b3f2e1d6c5a4b3f2e1d6c5a4b3f2e1d6c5a4b3f2e1d6c5a4b3f2e1d"));
 
     // From hotArchiveBuckets
-    assert!(buckets
-        .contains(&"1a2b3c4d5e6f7081928394a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5".to_string()));
+    assert!(buckets.contains("1a2b3c4d5e6f7081928394a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5"));
 
     // Verify we have a reasonable number of unique buckets
     assert!(

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -9,6 +9,8 @@ mod mirror_op_test;
 #[cfg(test)]
 mod path_normalization_test;
 #[cfg(test)]
+mod repair_op_test;
+#[cfg(test)]
 mod scan_op_test;
 #[cfg(test)]
 pub(crate) mod utils;

--- a/src/tests/repair_op_test.rs
+++ b/src/tests/repair_op_test.rs
@@ -1,0 +1,1006 @@
+//! Tests for repair operation
+//!
+//! Covers: existence-only repair, verify mode repair, cross-validation repair,
+//! manual mode, dry run, error handling, idempotency, and CLI validation.
+
+use super::utils::{
+    copy_testnet_small_archive, file_url_from_path, get_files_by_pattern, start_http_server,
+    testnet_small_archive_path,
+};
+use crate::history_format;
+use crate::test_helpers::{
+    run_mirror, run_repair, run_scan, MirrorConfig, RepairConfig, ScanConfig,
+};
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use rstest::rstest;
+use std::io::Write;
+use std::path::Path;
+use tempfile::TempDir;
+
+//=============================================================================
+// Helper Functions
+//=============================================================================
+
+/// Mirror the testnet-small archive to a temp directory and return (source_url, dest_dir, dest_url)
+async fn mirror_testnet_small() -> (String, TempDir, String) {
+    let src_url = file_url_from_path(&testnet_small_archive_path());
+    let dest_dir = TempDir::new().unwrap();
+    let dest_url = file_url_from_path(dest_dir.path());
+
+    run_mirror(MirrorConfig::new(&src_url, &dest_url))
+        .await
+        .expect("Mirror setup should succeed");
+
+    (src_url, dest_dir, dest_url)
+}
+
+/// Delete a specific file pattern from the archive, returns the deleted file path (relative)
+fn delete_first_file(archive_path: &Path, pattern: &str) -> String {
+    let files = get_files_by_pattern(archive_path, pattern);
+    assert!(!files.is_empty(), "No files matching pattern '{pattern}'");
+    let file = &files[0];
+    let relative = file
+        .strip_prefix(archive_path)
+        .unwrap()
+        .to_string_lossy()
+        .replace('\\', "/");
+    std::fs::remove_file(file).expect("Failed to delete file");
+    relative
+}
+
+/// Corrupt a bucket file with garbage bytes (invalid gzip)
+fn corrupt_bucket_invalid_gzip(archive_path: &Path) -> String {
+    let files = get_files_by_pattern(archive_path, "/bucket-");
+    assert!(!files.is_empty(), "No bucket files found");
+    let file = &files[0];
+    let relative = file
+        .strip_prefix(archive_path)
+        .unwrap()
+        .to_string_lossy()
+        .replace('\\', "/");
+    std::fs::write(file, b"this is not valid gzip data at all").unwrap();
+    relative
+}
+
+/// Corrupt a bucket file with valid gzip but wrong hash
+fn corrupt_bucket_hash_mismatch(archive_path: &Path) -> String {
+    let files = get_files_by_pattern(archive_path, "/bucket-");
+    assert!(!files.is_empty(), "No bucket files found");
+    let file = &files[0];
+    let relative = file
+        .strip_prefix(archive_path)
+        .unwrap()
+        .to_string_lossy()
+        .replace('\\', "/");
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder
+        .write_all(b"Valid gzip but wrong hash content!")
+        .unwrap();
+    let compressed = encoder.finish().unwrap();
+    std::fs::write(file, compressed).unwrap();
+    relative
+}
+
+/// Corrupt an XDR file with garbage bytes
+fn corrupt_xdr_file(archive_path: &Path, pattern: &str) -> String {
+    let files = get_files_by_pattern(archive_path, pattern);
+    assert!(!files.is_empty(), "No files matching pattern '{pattern}'");
+    let file = &files[0];
+    let relative = file
+        .strip_prefix(archive_path)
+        .unwrap()
+        .to_string_lossy()
+        .replace('\\', "/");
+    std::fs::write(file, b"garbage invalid gzip bytes").unwrap();
+    relative
+}
+
+/// Corrupt an XDR file by flipping bytes (XOR with 0xFF)
+fn corrupt_xdr_flip_bytes(archive_path: &Path, pattern: &str) -> String {
+    let files = get_files_by_pattern(archive_path, pattern);
+    assert!(!files.is_empty(), "No files matching pattern '{pattern}'");
+    let file = &files[0];
+    let relative = file
+        .strip_prefix(archive_path)
+        .unwrap()
+        .to_string_lossy()
+        .replace('\\', "/");
+    let mut data = std::fs::read(file).unwrap();
+    for byte in &mut data {
+        *byte ^= 0xFF;
+    }
+    std::fs::write(file, data).unwrap();
+    relative
+}
+
+//=============================================================================
+// A. Existence-Only Mode (no --verify)
+//=============================================================================
+
+#[rstest]
+#[case::history("/history-", "history")]
+#[case::ledger("/ledger-", "ledger")]
+#[case::transactions("/transactions-", "transactions")]
+#[case::results("/results-", "results")]
+#[case::scp("/scp-", "scp")]
+#[tokio::test]
+async fn test_repair_missing_checkpoint_file(#[case] pattern: &str, #[case] category: &str) {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    // Delete a file
+    let deleted = delete_first_file(dest_dir.path(), pattern);
+
+    // Verify scan detects the missing file
+    run_scan(ScanConfig::new(&dest_url))
+        .await
+        .expect_err(&format!("Scan should detect missing {category}"));
+
+    // Repair
+    run_repair(RepairConfig::new(&src_url, &dest_url))
+        .await
+        .expect("Repair should succeed");
+
+    // Verify scan passes after repair
+    run_scan(ScanConfig::new(&dest_url))
+        .await
+        .unwrap_or_else(|e| panic!("Scan should pass after repairing {category}: {deleted}: {e}"));
+}
+
+#[tokio::test]
+async fn test_repair_missing_bucket() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    delete_first_file(dest_dir.path(), "/bucket-");
+
+    run_scan(ScanConfig::new(&dest_url))
+        .await
+        .expect_err("Scan should detect missing bucket");
+
+    run_repair(RepairConfig::new(&src_url, &dest_url))
+        .await
+        .expect("Repair should succeed");
+
+    run_scan(ScanConfig::new(&dest_url))
+        .await
+        .expect("Scan should pass after repair");
+}
+
+#[tokio::test]
+async fn test_repair_missing_multiple_categories() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    delete_first_file(dest_dir.path(), "/ledger-");
+    delete_first_file(dest_dir.path(), "/transactions-");
+    delete_first_file(dest_dir.path(), "/bucket-");
+
+    run_repair(RepairConfig::new(&src_url, &dest_url))
+        .await
+        .expect("Repair should succeed");
+
+    run_scan(ScanConfig::new(&dest_url))
+        .await
+        .expect("Scan should pass after repairing multiple categories");
+}
+
+//=============================================================================
+// .well-known Edge Cases
+//=============================================================================
+
+#[tokio::test]
+async fn test_repair_missing_well_known() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    std::fs::remove_file(dest_dir.path().join(".well-known/stellar-history.json"))
+        .expect("Failed to delete .well-known");
+
+    run_repair(RepairConfig::new(&src_url, &dest_url))
+        .await
+        .expect("Repair should succeed with missing .well-known");
+
+    // Verify .well-known was restored
+    assert!(
+        dest_dir
+            .path()
+            .join(".well-known/stellar-history.json")
+            .exists(),
+        ".well-known should be restored"
+    );
+
+    run_scan(ScanConfig::new(&dest_url))
+        .await
+        .expect("Scan should pass after repair");
+}
+
+#[tokio::test]
+async fn test_repair_corrupt_well_known() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    std::fs::write(
+        dest_dir.path().join(".well-known/stellar-history.json"),
+        "{ invalid json }}",
+    )
+    .unwrap();
+
+    run_repair(RepairConfig::new(&src_url, &dest_url))
+        .await
+        .expect("Repair should succeed with corrupt .well-known");
+
+    run_scan(ScanConfig::new(&dest_url))
+        .await
+        .expect("Scan should pass after repair");
+}
+
+#[tokio::test]
+async fn test_repair_does_not_update_well_known() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    // Record the .well-known content before repair
+    let wk_path = dest_dir.path().join(".well-known/stellar-history.json");
+    let before = std::fs::read_to_string(&wk_path).unwrap();
+
+    // Delete a non-.well-known file and repair
+    delete_first_file(dest_dir.path(), "/ledger-");
+    run_repair(RepairConfig::new(&src_url, &dest_url))
+        .await
+        .expect("Repair should succeed");
+
+    // .well-known should be unchanged
+    let after = std::fs::read_to_string(&wk_path).unwrap();
+    assert_eq!(
+        before, after,
+        ".well-known should not be modified by repair"
+    );
+}
+
+//=============================================================================
+// Empty File Handling
+//=============================================================================
+
+#[tokio::test]
+async fn test_repair_replaces_empty_files() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    // Truncate a ledger file to 0 bytes
+    let files = get_files_by_pattern(dest_dir.path(), "/ledger-");
+    std::fs::write(&files[0], "").unwrap();
+
+    // Scan detects empty files as corrupt (even without --verify)
+    run_scan(ScanConfig::new(&dest_url))
+        .await
+        .expect_err("Scan should detect empty ledger file");
+
+    // Repair should replace the empty file
+    run_repair(RepairConfig::new(&src_url, &dest_url))
+        .await
+        .expect("Repair should succeed");
+
+    let metadata = std::fs::metadata(&files[0]).unwrap();
+    assert!(
+        metadata.len() > 0,
+        "Empty file should be replaced by repair"
+    );
+
+    // Archive should now be valid
+    run_scan(ScanConfig::new(&dest_url))
+        .await
+        .expect("Scan should pass after repair");
+}
+
+#[tokio::test]
+async fn test_repair_verify_replaces_empty_files() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    let files = get_files_by_pattern(dest_dir.path(), "/ledger-");
+    std::fs::write(&files[0], "").unwrap();
+
+    // Repair with --verify should also replace empty files
+    run_repair(RepairConfig::new(&src_url, &dest_url).verify())
+        .await
+        .expect("Repair --verify should succeed");
+
+    let metadata = std::fs::metadata(&files[0]).unwrap();
+    assert!(
+        metadata.len() > 0,
+        "Empty file should be replaced with --verify"
+    );
+}
+
+//=============================================================================
+// Nothing to Repair
+//=============================================================================
+
+#[tokio::test]
+async fn test_repair_healthy_archive() {
+    let (src_url, _dest_dir, dest_url) = mirror_testnet_small().await;
+
+    // Repair on healthy archive = nothing to do
+    run_repair(RepairConfig::new(&src_url, &dest_url))
+        .await
+        .expect("Repair should succeed on healthy archive");
+}
+
+//=============================================================================
+// Range Constraints
+//=============================================================================
+
+#[tokio::test]
+async fn test_repair_skip_optional_skips_scp() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    // Delete both SCP and ledger files
+    delete_first_file(dest_dir.path(), "/scp-");
+    let deleted_ledger = delete_first_file(dest_dir.path(), "/ledger-");
+
+    // Repair with --skip-optional: only ledger should be fixed
+    run_repair(RepairConfig::new(&src_url, &dest_url).skip_optional())
+        .await
+        .expect("Repair should succeed");
+
+    // Ledger should be restored
+    assert!(
+        dest_dir.path().join(&deleted_ledger).exists(),
+        "Ledger should be restored"
+    );
+
+    // SCP should still be missing (scan without skip-optional should fail)
+    run_scan(ScanConfig::new(&dest_url))
+        .await
+        .expect_err("SCP file should still be missing");
+
+    // But scan with skip-optional should pass
+    run_scan(ScanConfig::new(&dest_url).skip_optional())
+        .await
+        .expect("Scan should pass with skip-optional after repair");
+}
+
+//=============================================================================
+// B. Verification Mode — Per-file corruption
+//=============================================================================
+
+#[tokio::test]
+async fn test_repair_verify_bucket_invalid_gzip() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    corrupt_bucket_invalid_gzip(dest_dir.path());
+
+    run_repair(RepairConfig::new(&src_url, &dest_url).verify())
+        .await
+        .expect("Repair --verify should fix invalid gzip bucket");
+
+    run_scan(ScanConfig::new(&dest_url).verify())
+        .await
+        .expect("Scan --verify should pass after repair");
+}
+
+#[tokio::test]
+async fn test_repair_verify_bucket_hash_mismatch() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    corrupt_bucket_hash_mismatch(dest_dir.path());
+
+    run_repair(RepairConfig::new(&src_url, &dest_url).verify())
+        .await
+        .expect("Repair --verify should fix hash-mismatched bucket");
+
+    run_scan(ScanConfig::new(&dest_url).verify())
+        .await
+        .expect("Scan --verify should pass after repair");
+}
+
+#[tokio::test]
+async fn test_repair_verify_empty_bucket() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    let files = get_files_by_pattern(dest_dir.path(), "/bucket-");
+    std::fs::write(&files[0], "").unwrap();
+
+    run_repair(RepairConfig::new(&src_url, &dest_url).verify())
+        .await
+        .expect("Repair --verify should fix empty bucket");
+
+    let metadata = std::fs::metadata(&files[0]).unwrap();
+    assert!(
+        metadata.len() > 0,
+        "Bucket should have content after repair"
+    );
+}
+
+#[rstest]
+#[case::ledger("/ledger-", "ledger")]
+#[case::transactions("/transactions-", "transactions")]
+#[case::results("/results-", "results")]
+#[tokio::test]
+async fn test_repair_verify_corrupt_xdr_invalid_gzip(
+    #[case] pattern: &str,
+    #[case] category: &str,
+) {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    corrupt_xdr_file(dest_dir.path(), pattern);
+
+    run_repair(RepairConfig::new(&src_url, &dest_url).verify())
+        .await
+        .unwrap_or_else(|e| panic!("Repair --verify should fix corrupt {category}: {e}"));
+
+    run_scan(ScanConfig::new(&dest_url).verify())
+        .await
+        .expect("Scan --verify should pass after repair");
+}
+
+#[rstest]
+#[case::ledger("/ledger-", "ledger")]
+#[case::transactions("/transactions-", "transactions")]
+#[case::results("/results-", "results")]
+#[tokio::test]
+async fn test_repair_verify_corrupt_xdr_flipped_bytes(
+    #[case] pattern: &str,
+    #[case] category: &str,
+) {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    corrupt_xdr_flip_bytes(dest_dir.path(), pattern);
+
+    run_repair(RepairConfig::new(&src_url, &dest_url).verify())
+        .await
+        .unwrap_or_else(|e| {
+            panic!("Repair --verify should fix {category} with flipped bytes: {e}")
+        });
+
+    run_scan(ScanConfig::new(&dest_url).verify())
+        .await
+        .expect("Scan --verify should pass after repair");
+}
+
+#[tokio::test]
+async fn test_repair_verify_corrupt_history_json() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    // Corrupt a history file (not .well-known)
+    let history_files: Vec<_> = get_files_by_pattern(dest_dir.path(), "/history-")
+        .into_iter()
+        .filter(|p| !p.to_string_lossy().contains(".well-known"))
+        .collect();
+    assert!(!history_files.is_empty());
+    std::fs::write(&history_files[0], "{ invalid json }}").unwrap();
+
+    run_repair(RepairConfig::new(&src_url, &dest_url).verify())
+        .await
+        .expect("Repair --verify should fix corrupt history JSON");
+
+    run_scan(ScanConfig::new(&dest_url).verify())
+        .await
+        .expect("Scan --verify should pass after repair");
+}
+
+#[tokio::test]
+async fn test_repair_verify_corrupt_scp() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    corrupt_xdr_file(dest_dir.path(), "/scp-");
+
+    // Repair with verify and skip_optional=false
+    run_repair(RepairConfig::new(&src_url, &dest_url).verify())
+        .await
+        .expect("Repair --verify should fix corrupt SCP");
+
+    run_scan(ScanConfig::new(&dest_url).verify())
+        .await
+        .expect("Scan --verify should pass after SCP repair");
+}
+
+//=============================================================================
+// Without --verify Ignores Corruption (Regression Guard)
+//=============================================================================
+
+#[tokio::test]
+async fn test_repair_no_verify_ignores_corrupt_bucket() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    corrupt_bucket_hash_mismatch(dest_dir.path());
+
+    // Repair without --verify should NOT fix this
+    run_repair(RepairConfig::new(&src_url, &dest_url))
+        .await
+        .expect("Repair should succeed (file exists, no verification)");
+
+    // The file should still be corrupt (scan --verify should fail)
+    run_scan(ScanConfig::new(&dest_url).verify())
+        .await
+        .expect_err("Scan --verify should still fail on corrupt bucket");
+}
+
+#[tokio::test]
+async fn test_repair_no_verify_ignores_corrupt_xdr() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    corrupt_xdr_flip_bytes(dest_dir.path(), "/ledger-");
+
+    run_repair(RepairConfig::new(&src_url, &dest_url))
+        .await
+        .expect("Repair should succeed (file exists, no verification)");
+
+    run_scan(ScanConfig::new(&dest_url).verify())
+        .await
+        .expect_err("Scan --verify should still fail on corrupt ledger");
+}
+
+//=============================================================================
+// D. Manual Mode
+//=============================================================================
+
+#[tokio::test]
+async fn test_repair_manual_specific_files() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    // Delete 3 files
+    let deleted_ledger = delete_first_file(dest_dir.path(), "/ledger-");
+    let deleted_tx = delete_first_file(dest_dir.path(), "/transactions-");
+    let _deleted_results = delete_first_file(dest_dir.path(), "/results-");
+
+    // Only repair 2 of the 3
+    run_repair(
+        RepairConfig::new(&src_url, &dest_url)
+            .files(vec![deleted_ledger.clone(), deleted_tx.clone()]),
+    )
+    .await
+    .expect("Manual repair should succeed");
+
+    // Ledger and transactions should be restored
+    assert!(dest_dir.path().join(&deleted_ledger).exists());
+    assert!(dest_dir.path().join(&deleted_tx).exists());
+
+    // Results should still be missing (wasn't in the repair list)
+    run_scan(ScanConfig::new(&dest_url))
+        .await
+        .expect_err("Results file should still be missing");
+}
+
+#[tokio::test]
+async fn test_repair_manual_empty_list() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    delete_first_file(dest_dir.path(), "/ledger-");
+
+    // Repair with empty file list
+    run_repair(RepairConfig::new(&src_url, &dest_url).files(vec![]))
+        .await
+        .expect("Repair with empty list should succeed (no-op)");
+
+    // File should still be missing
+    run_scan(ScanConfig::new(&dest_url))
+        .await
+        .expect_err("Deleted file should still be missing");
+}
+
+#[tokio::test]
+async fn test_repair_manual_nonexistent_source_file() {
+    let (src_url, _dest_dir, dest_url) = mirror_testnet_small().await;
+
+    // Try to repair a file that doesn't exist in source
+    let result = run_repair(RepairConfig::new(&src_url, &dest_url).files(vec![
+        "ledger/00/00/00/ledger-nonexistent.xdr.gz".to_string(),
+    ]))
+    .await;
+
+    assert!(
+        result.is_err(),
+        "Repair should fail for nonexistent source file"
+    );
+}
+
+//=============================================================================
+// E. Dry Run
+//=============================================================================
+
+#[tokio::test]
+async fn test_repair_dry_run_reports_but_no_download() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    let deleted = delete_first_file(dest_dir.path(), "/ledger-");
+
+    // Dry run should not actually download anything
+    run_repair(RepairConfig::new(&src_url, &dest_url).dry_run())
+        .await
+        .expect("Dry run should succeed");
+
+    // File should still be missing
+    assert!(
+        !dest_dir.path().join(&deleted).exists(),
+        "Dry run should not restore deleted file"
+    );
+}
+
+#[tokio::test]
+async fn test_repair_dry_run_with_verify() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    corrupt_bucket_invalid_gzip(dest_dir.path());
+
+    // Dry run with verify should detect but not fix
+    run_repair(RepairConfig::new(&src_url, &dest_url).verify().dry_run())
+        .await
+        .expect("Dry run with verify should succeed");
+
+    // Bucket should still be corrupt
+    run_scan(ScanConfig::new(&dest_url).verify())
+        .await
+        .expect_err("Bucket should still be corrupt after dry run");
+}
+
+#[tokio::test]
+async fn test_repair_dry_run_manual_mode() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    let deleted = delete_first_file(dest_dir.path(), "/ledger-");
+
+    run_repair(
+        RepairConfig::new(&src_url, &dest_url)
+            .files(vec![deleted.clone()])
+            .dry_run(),
+    )
+    .await
+    .expect("Dry run manual mode should succeed");
+
+    assert!(
+        !dest_dir.path().join(&deleted).exists(),
+        "Dry run should not download anything"
+    );
+}
+
+//=============================================================================
+// H. Idempotency and Preserving Good State
+//=============================================================================
+
+#[tokio::test]
+async fn test_repair_idempotent() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    delete_first_file(dest_dir.path(), "/ledger-");
+
+    // First repair
+    run_repair(RepairConfig::new(&src_url, &dest_url))
+        .await
+        .expect("First repair should succeed");
+
+    // Second repair (nothing to fix)
+    run_repair(RepairConfig::new(&src_url, &dest_url))
+        .await
+        .expect("Second repair should succeed (idempotent)");
+
+    run_scan(ScanConfig::new(&dest_url))
+        .await
+        .expect("Scan should pass");
+}
+
+#[tokio::test]
+async fn test_repair_preserves_good_files() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    // Record mtime of a good file
+    let good_files = get_files_by_pattern(dest_dir.path(), "/results-");
+    assert!(!good_files.is_empty());
+    let good_file_mtime = std::fs::metadata(&good_files[0])
+        .unwrap()
+        .modified()
+        .unwrap();
+
+    // Sleep briefly to ensure mtime would differ if file were rewritten
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Delete a different file and repair
+    delete_first_file(dest_dir.path(), "/ledger-");
+    run_repair(RepairConfig::new(&src_url, &dest_url))
+        .await
+        .expect("Repair should succeed");
+
+    // Good file should not have been touched
+    let after_mtime = std::fs::metadata(&good_files[0])
+        .unwrap()
+        .modified()
+        .unwrap();
+    assert_eq!(
+        good_file_mtime, after_mtime,
+        "Good files should not be modified by repair"
+    );
+}
+
+//=============================================================================
+// I. CLI Validation
+//=============================================================================
+
+#[tokio::test]
+async fn test_repair_rejects_readonly_destination() {
+    let src_url = file_url_from_path(&testnet_small_archive_path());
+
+    let result = run_repair(RepairConfig::new(&src_url, "http://example.com/archive")).await;
+    assert!(
+        result.is_err(),
+        "Repair should reject read-only destination"
+    );
+}
+
+//=============================================================================
+// J. HTTP Source Integration
+//=============================================================================
+
+#[tokio::test]
+async fn test_repair_http_source_to_filesystem() {
+    let archive_path = testnet_small_archive_path();
+    let (server_url, server_handle) = start_http_server(&archive_path).await;
+
+    // Mirror from HTTP to local
+    let dest_dir = TempDir::new().unwrap();
+    let dest_url = file_url_from_path(dest_dir.path());
+
+    run_mirror(MirrorConfig::new(&server_url, &dest_url))
+        .await
+        .expect("Mirror from HTTP should succeed");
+
+    // Delete a file
+    delete_first_file(dest_dir.path(), "/ledger-");
+
+    // Repair from HTTP source
+    run_repair(RepairConfig::new(&server_url, &dest_url))
+        .await
+        .expect("Repair from HTTP source should succeed");
+
+    run_scan(ScanConfig::new(&dest_url))
+        .await
+        .expect("Scan should pass after HTTP repair");
+
+    server_handle.abort();
+}
+
+//=============================================================================
+// G. Download Verification (Phase 2 integrity)
+//=============================================================================
+
+#[tokio::test]
+async fn test_repair_verify_validates_downloads() {
+    // Set up: destination missing a bucket, source has corrupt bucket
+    let src_dir = TempDir::new().unwrap();
+    copy_testnet_small_archive(src_dir.path()).unwrap();
+    let src_url = file_url_from_path(src_dir.path());
+
+    let dest_dir = TempDir::new().unwrap();
+    let dest_url = file_url_from_path(dest_dir.path());
+
+    // Mirror from source to destination first
+    run_mirror(MirrorConfig::new(&src_url, &dest_url))
+        .await
+        .expect("Mirror should succeed");
+
+    // Now corrupt the bucket in source AND delete it from destination
+    let bucket_files = get_files_by_pattern(src_dir.path(), "/bucket-");
+    let bucket_file = &bucket_files[0];
+    let relative = bucket_file
+        .strip_prefix(src_dir.path())
+        .unwrap()
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    // Corrupt source bucket
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(b"wrong content for hash").unwrap();
+    let compressed = encoder.finish().unwrap();
+    std::fs::write(bucket_file, compressed).unwrap();
+
+    // Delete destination bucket
+    std::fs::remove_file(dest_dir.path().join(&relative)).unwrap();
+
+    // Repair with --verify should fail (source provides corrupt data)
+    let result = run_repair(RepairConfig::new(&src_url, &dest_url).verify()).await;
+    assert!(
+        result.is_err(),
+        "Repair --verify should fail when source has corrupt data"
+    );
+}
+
+//=============================================================================
+// K. Two-Wave Bucket Discovery (history file → bucket reference)
+//=============================================================================
+
+/// Helper: parse a history file and return the bucket hashes it references
+fn buckets_from_history_file(path: &std::path::Path) -> Vec<String> {
+    let content = std::fs::read_to_string(path).expect("Failed to read history file");
+    let state: history_format::HistoryFileState =
+        serde_json::from_str(&content).expect("Failed to parse history JSON");
+    state.buckets()
+}
+
+/// Helper: find a bucket hash that is referenced ONLY by the given history file
+/// and not by any other history file in the archive. Returns the bucket hash
+/// and the bucket file's absolute path.
+fn find_bucket_unique_to_history(
+    archive_path: &std::path::Path,
+    target_history: &std::path::Path,
+) -> Option<(String, std::path::PathBuf)> {
+    use std::collections::HashMap;
+
+    // Build a map: bucket_hash → count of history files referencing it
+    let all_history_files = get_files_by_pattern(archive_path, "/history-");
+    let mut ref_counts: HashMap<String, usize> = HashMap::new();
+
+    for hf in &all_history_files {
+        for bucket in buckets_from_history_file(hf) {
+            *ref_counts.entry(bucket).or_insert(0) += 1;
+        }
+    }
+
+    // Find a bucket referenced by target_history that has ref_count == 1
+    let target_buckets = buckets_from_history_file(target_history);
+    for hash in target_buckets {
+        if ref_counts.get(&hash) == Some(&1) {
+            // This bucket is only referenced by target_history
+            let bucket_files = get_files_by_pattern(archive_path, &format!("bucket-{hash}"));
+            if let Some(bf) = bucket_files.into_iter().next() {
+                return Some((hash, bf));
+            }
+        }
+    }
+
+    None
+}
+
+/// Test that repair correctly handles the case where a missing history file
+/// hides bucket references. The two-wave approach should:
+/// 1. Wave 1: repair the history file
+/// 2. Re-scan: discover the now-visible bucket references
+/// 3. Wave 2: repair the missing bucket
+#[tokio::test]
+async fn test_repair_missing_history_discovers_newly_visible_buckets() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    // Find a non-.well-known history file that has a uniquely-referenced bucket
+    let history_files: Vec<_> = get_files_by_pattern(dest_dir.path(), "/history-")
+        .into_iter()
+        .filter(|p| !p.to_string_lossy().contains(".well-known"))
+        .collect();
+
+    let mut target_history = None;
+    let mut unique_bucket_path = None;
+
+    for hf in &history_files {
+        if let Some((_hash, bucket_path)) = find_bucket_unique_to_history(dest_dir.path(), hf) {
+            target_history = Some(hf.clone());
+            unique_bucket_path = Some(bucket_path);
+            break;
+        }
+    }
+
+    let target_history = target_history.expect(
+        "Test archive must have a history file with at least one uniquely-referenced bucket",
+    );
+    let unique_bucket = unique_bucket_path.unwrap();
+
+    // Delete both the history file AND the unique bucket
+    std::fs::remove_file(&target_history).expect("Failed to delete history file");
+    std::fs::remove_file(&unique_bucket).expect("Failed to delete bucket file");
+
+    // Verify scan detects failures
+    run_scan(ScanConfig::new(&dest_url))
+        .await
+        .expect_err("Scan should detect missing files");
+
+    // Repair should fix BOTH: history in Wave 1, bucket discovered via re-scan in Wave 2
+    run_repair(RepairConfig::new(&src_url, &dest_url))
+        .await
+        .expect("Repair should succeed (two-wave)");
+
+    // Both files should be restored
+    assert!(
+        target_history.exists(),
+        "History file should be restored in Wave 1"
+    );
+    assert!(
+        unique_bucket.exists(),
+        "Bucket file should be restored in Wave 2 (discovered after history repair)"
+    );
+
+    // Full scan should pass
+    run_scan(ScanConfig::new(&dest_url))
+        .await
+        .expect("Scan should pass after two-wave repair");
+}
+
+/// Simpler test: delete a history file and a bucket it references (not necessarily unique).
+/// Repair should restore both.
+#[tokio::test]
+async fn test_repair_missing_history_also_repairs_its_buckets() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    // Pick a non-.well-known history file and one of its referenced buckets
+    let history_files: Vec<_> = get_files_by_pattern(dest_dir.path(), "/history-")
+        .into_iter()
+        .filter(|p| !p.to_string_lossy().contains(".well-known"))
+        .collect();
+    let target_history = &history_files[0];
+    let bucket_hashes = buckets_from_history_file(target_history);
+    assert!(
+        !bucket_hashes.is_empty(),
+        "History file must reference at least one bucket"
+    );
+
+    // Find the actual bucket file on disk
+    let bucket_hash = &bucket_hashes[0];
+    let bucket_files = get_files_by_pattern(dest_dir.path(), &format!("bucket-{bucket_hash}"));
+    assert!(!bucket_files.is_empty(), "Bucket file must exist on disk");
+    let target_bucket = &bucket_files[0];
+
+    // Delete both
+    std::fs::remove_file(target_history).expect("Failed to delete history file");
+    std::fs::remove_file(target_bucket).expect("Failed to delete bucket file");
+
+    // Repair
+    run_repair(RepairConfig::new(&src_url, &dest_url))
+        .await
+        .expect("Repair should succeed");
+
+    // Both should be restored
+    assert!(target_history.exists(), "History file should be restored");
+    assert!(target_bucket.exists(), "Bucket file should be restored");
+
+    // Scan should pass
+    run_scan(ScanConfig::new(&dest_url))
+        .await
+        .expect("Scan should pass after repair");
+}
+
+//=============================================================================
+// L. Wave 1 partial failure doesn't block Wave 2
+//=============================================================================
+
+/// Test that if Wave 1 has some download failures (e.g., source missing a file),
+/// Wave 2 (bucket repair) still proceeds. This matches Go's behavior of counting
+/// errors and continuing rather than aborting on first failure.
+#[tokio::test]
+async fn test_repair_wave1_failure_does_not_block_wave2() {
+    // Set up: separate source directory so we can corrupt the source
+    let src_dir = TempDir::new().unwrap();
+    copy_testnet_small_archive(src_dir.path()).unwrap();
+    let src_url = file_url_from_path(src_dir.path());
+
+    let dest_dir = TempDir::new().unwrap();
+    let dest_url = file_url_from_path(dest_dir.path());
+
+    // Mirror from source to destination
+    run_mirror(MirrorConfig::new(&src_url, &dest_url))
+        .await
+        .expect("Mirror should succeed");
+
+    // Delete a ledger file from destination (Wave 1 target)
+    let deleted_ledger = delete_first_file(dest_dir.path(), "/ledger-");
+
+    // Delete a bucket file from destination (Wave 2 target)
+    let bucket_files = get_files_by_pattern(dest_dir.path(), "/bucket-");
+    let deleted_bucket = bucket_files[0]
+        .strip_prefix(dest_dir.path())
+        .unwrap()
+        .to_string_lossy()
+        .replace('\\', "/");
+    std::fs::remove_file(&bucket_files[0]).expect("Failed to delete bucket");
+
+    // NOW corrupt the source's ledger file so Wave 1 download will fail
+    let src_ledger = src_dir.path().join(&deleted_ledger);
+    std::fs::remove_file(&src_ledger).expect("Failed to remove source ledger");
+
+    // Repair should fail overall (ledger can't be fixed) but Wave 2 should still run
+    let result = run_repair(RepairConfig::new(&src_url, &dest_url)).await;
+    assert!(
+        result.is_err(),
+        "Repair should report failure (ledger unfixable)"
+    );
+
+    // The bucket should still have been repaired despite Wave 1 failure
+    assert!(
+        dest_dir.path().join(&deleted_bucket).exists(),
+        "Bucket should be repaired even when Wave 1 has failures"
+    );
+
+    // The ledger should still be missing (source doesn't have it)
+    assert!(
+        !dest_dir.path().join(&deleted_ledger).exists(),
+        "Ledger should still be missing (source doesn't have it)"
+    );
+}

--- a/src/tests/repair_op_test.rs
+++ b/src/tests/repair_op_test.rs
@@ -14,6 +14,7 @@ use crate::test_helpers::{
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use rstest::rstest;
+use std::collections::BTreeSet;
 use std::io::Write;
 use std::path::Path;
 use tempfile::TempDir;
@@ -835,8 +836,8 @@ async fn test_repair_verify_validates_downloads() {
 // K. Two-Wave Bucket Discovery (history file → bucket reference)
 //=============================================================================
 
-/// Helper: parse a history file and return the bucket hashes it references
-fn buckets_from_history_file(path: &std::path::Path) -> Vec<String> {
+/// Helper: parse a history file and return the bucket hashes it references.
+fn buckets_from_history_file(path: &std::path::Path) -> BTreeSet<String> {
     let content = std::fs::read_to_string(path).expect("Failed to read history file");
     let state: history_format::HistoryFileState =
         serde_json::from_str(&content).expect("Failed to parse history JSON");
@@ -957,7 +958,7 @@ async fn test_repair_missing_history_also_repairs_its_buckets() {
     );
 
     // Find the actual bucket file on disk
-    let bucket_hash = &bucket_hashes[0];
+    let bucket_hash = bucket_hashes.iter().next().unwrap();
     let bucket_files = get_files_by_pattern(dest_dir.path(), &format!("bucket-{bucket_hash}"));
     assert!(!bucket_files.is_empty(), "Bucket file must exist on disk");
     let target_bucket = &bucket_files[0];

--- a/src/tests/repair_op_test.rs
+++ b/src/tests/repair_op_test.rs
@@ -599,15 +599,49 @@ async fn test_repair_dry_run_reports_but_no_download() {
 
     let deleted = delete_first_file(dest_dir.path(), "/ledger-");
 
+    // History files: dry-run must not write history-*.json regardless of
+    // whether dst is missing or corrupt (Pipeline used to write the src
+    // buffer back via process_buffer even in dry-run).
+    let history_files = get_files_by_pattern(dest_dir.path(), "/history-");
+    assert!(
+        history_files.len() >= 2,
+        "Need at least two history files to exercise both missing and corrupt cases"
+    );
+
+    let deleted_history = history_files[0].clone();
+    let deleted_history_relative = deleted_history
+        .strip_prefix(dest_dir.path())
+        .unwrap()
+        .to_string_lossy()
+        .replace('\\', "/");
+    std::fs::remove_file(&deleted_history).unwrap();
+
+    let corrupted_history = history_files[1].clone();
+    let corrupted_content: &[u8] = b"{ invalid json garbage }}";
+    std::fs::write(&corrupted_history, corrupted_content).unwrap();
+
     // Dry run should not actually download anything
     run_repair(RepairConfig::new(&src_url, &dest_url).dry_run())
         .await
         .expect("Dry run should succeed");
 
-    // File should still be missing
+    // Ledger file should still be missing
     assert!(
         !dest_dir.path().join(&deleted).exists(),
         "Dry run should not restore deleted file"
+    );
+
+    // Deleted history file should still be missing
+    assert!(
+        !dest_dir.path().join(&deleted_history_relative).exists(),
+        "Dry run should not restore deleted history file"
+    );
+
+    // Corrupted history file should still have its corrupt content
+    assert_eq!(
+        std::fs::read(&corrupted_history).unwrap(),
+        corrupted_content,
+        "Dry run should not overwrite corrupted history file"
     );
 }
 

--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -5,13 +5,20 @@
 //! - HTTP server helpers (axum-based and raw TCP)
 //! - Flaky server for testing retry/failure behavior
 //! - HTTP retry test helpers for parameterized testing
+//! - XDR parsing wrappers (range-validation off) for `xdr_verify` tests
 
 #![allow(dead_code)] // Test utilities may not all be used in every test run
 
+use crate::storage::Error as StorageError;
 use crate::utils::{NON_STANDARD_RETRYABLE_HTTP_ERRORS, STANDARD_RETRYABLE_HTTP_ERRORS};
+use crate::xdr_verify::{
+    parse_ledger_entries_for_checkpoint, parse_result_entries_for_checkpoint,
+    parse_transaction_entries_for_checkpoint, LedgerVerificationData,
+};
 use axum::{routing::get_service, Router};
 use normalize_path::NormalizePath;
 use path_slash::PathExt;
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -453,4 +460,29 @@ pub fn transient_http_errors() -> Vec<(u16, &'static str)> {
         .chain(NON_STANDARD_RETRYABLE_HTTP_ERRORS.iter())
         .copied()
         .collect()
+}
+
+//=============================================================================
+// XDR parser wrappers (range-validation off)
+//
+// Thin sugar over the `_for_checkpoint` parsers, used only by xdr_verify
+// tests when feeding hand-constructed XDR (no real ledger range to enforce).
+//=============================================================================
+
+pub fn parse_ledger_entries(
+    decompressed_data: &[u8],
+) -> Result<BTreeMap<u32, LedgerVerificationData>, StorageError> {
+    parse_ledger_entries_for_checkpoint(decompressed_data, None)
+}
+
+pub fn parse_result_entries(
+    decompressed_data: &[u8],
+) -> Result<HashMap<u32, [u8; 32]>, StorageError> {
+    parse_result_entries_for_checkpoint(decompressed_data, None)
+}
+
+pub fn parse_transaction_entries(
+    decompressed_data: &[u8],
+) -> Result<HashMap<u32, [u8; 32]>, StorageError> {
+    parse_transaction_entries_for_checkpoint(decompressed_data, None)
 }

--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -12,8 +12,8 @@
 use crate::storage::Error as StorageError;
 use crate::utils::{NON_STANDARD_RETRYABLE_HTTP_ERRORS, STANDARD_RETRYABLE_HTTP_ERRORS};
 use crate::xdr_verify::{
-    parse_ledger_entries_for_checkpoint, parse_result_entries_for_checkpoint,
-    parse_transaction_entries_for_checkpoint, LedgerVerificationData,
+    parse_ledger_header_entries_for_checkpoint, parse_result_entries_for_checkpoint,
+    parse_transaction_entries_for_checkpoint, LedgerHeaderVerificationData,
 };
 use axum::{routing::get_service, Router};
 use normalize_path::NormalizePath;
@@ -469,10 +469,10 @@ pub fn transient_http_errors() -> Vec<(u16, &'static str)> {
 // tests when feeding hand-constructed XDR (no real ledger range to enforce).
 //=============================================================================
 
-pub fn parse_ledger_entries(
+pub fn parse_ledger_header_entries(
     decompressed_data: &[u8],
-) -> Result<BTreeMap<u32, LedgerVerificationData>, StorageError> {
-    parse_ledger_entries_for_checkpoint(decompressed_data, None)
+) -> Result<BTreeMap<u32, LedgerHeaderVerificationData>, StorageError> {
+    parse_ledger_header_entries_for_checkpoint(decompressed_data, None)
 }
 
 pub fn parse_result_entries(

--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -23,6 +23,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
+use stellar_xdr::curr::Hash;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tower_http::services::ServeDir;
@@ -475,14 +476,12 @@ pub fn parse_ledger_header_entries(
     parse_ledger_header_entries_for_checkpoint(decompressed_data, None)
 }
 
-pub fn parse_result_entries(
-    decompressed_data: &[u8],
-) -> Result<HashMap<u32, [u8; 32]>, StorageError> {
+pub fn parse_result_entries(decompressed_data: &[u8]) -> Result<BTreeMap<u32, Hash>, StorageError> {
     parse_result_entries_for_checkpoint(decompressed_data, None)
 }
 
 pub fn parse_transaction_entries(
     decompressed_data: &[u8],
-) -> Result<HashMap<u32, [u8; 32]>, StorageError> {
+) -> Result<BTreeMap<u32, Hash>, StorageError> {
     parse_transaction_entries_for_checkpoint(decompressed_data, None)
 }

--- a/src/tests/xdr_verification_e2e_test.rs
+++ b/src/tests/xdr_verification_e2e_test.rs
@@ -915,7 +915,7 @@ fn read_and_parse_ledger_file(path: &Path) -> Vec<LedgerHeaderHistoryEntry> {
     let mut limited = Limited::new(cursor, Limits::none());
 
     Frame::<LedgerHeaderHistoryEntry>::read_xdr_iter(&mut limited)
-        .map(|r| r.expect("Failed to parse ledger entry").0)
+        .map(|r| r.expect("Failed to parse ledger-header entry").0)
         .collect()
 }
 
@@ -927,7 +927,7 @@ fn recompute_entry_hash(entry: &mut LedgerHeaderHistoryEntry) {
     entry.hash = Hash(Sha256::digest(&header_xdr).into());
 }
 
-fn write_ledger_entries_to_file(path: &Path, entries: &[LedgerHeaderHistoryEntry]) {
+fn write_ledger_header_entries_to_file(path: &Path, entries: &[LedgerHeaderHistoryEntry]) {
     let mut data = Vec::new();
     for entry in entries {
         let entry_xdr = entry
@@ -970,7 +970,7 @@ fn corrupt_ledger_hash_field_preserving_entry_hash(
         recompute_entry_hash(&mut entries[i]);
     }
 
-    write_ledger_entries_to_file(&ledger_file, &entries);
+    write_ledger_header_entries_to_file(&ledger_file, &entries);
 }
 
 /// Corrupt the first ledger of the second checkpoint file by changing its
@@ -996,7 +996,7 @@ fn corrupt_cross_checkpoint_boundary(archive_path: &Path, archive_type: ArchiveT
         recompute_entry_hash(&mut entries[i]);
     }
 
-    write_ledger_entries_to_file(second_file, &entries);
+    write_ledger_header_entries_to_file(second_file, &entries);
 }
 
 //=============================================================================

--- a/src/tests/xdr_verify_test.rs
+++ b/src/tests/xdr_verify_test.rs
@@ -1,9 +1,10 @@
+use super::utils::{parse_ledger_entries, parse_result_entries, parse_transaction_entries};
 use crate::xdr_verify::{
     compute_empty_v0_tx_set_hash, compute_empty_v1_tx_set_hash, compute_v0_tx_set_hash,
-    compute_v1_tx_set_hash, expected_ledger_range, is_empty_tx_set_hash, parse_ledger_entries,
-    parse_ledger_entries_for_checkpoint, parse_result_entries, parse_result_entries_for_checkpoint,
-    parse_scp_entries, parse_transaction_entries, parse_transaction_entries_for_checkpoint,
-    LedgerVerificationData, XdrVerificationManager, EMPTY_XDR_ARRAY_HASH,
+    compute_v1_tx_set_hash, expected_ledger_range, is_empty_tx_set_hash,
+    parse_ledger_entries_for_checkpoint, parse_result_entries_for_checkpoint, parse_scp_entries,
+    parse_transaction_entries_for_checkpoint, LedgerVerificationData, XdrVerificationManager,
+    EMPTY_XDR_ARRAY_HASH,
 };
 use rstest::rstest;
 use sha2::{Digest, Sha256};

--- a/src/tests/xdr_verify_test.rs
+++ b/src/tests/xdr_verify_test.rs
@@ -1,10 +1,10 @@
-use super::utils::{parse_ledger_entries, parse_result_entries, parse_transaction_entries};
+use super::utils::{parse_ledger_header_entries, parse_result_entries, parse_transaction_entries};
 use crate::xdr_verify::{
     compute_empty_v0_tx_set_hash, compute_empty_v1_tx_set_hash, compute_v0_tx_set_hash,
     compute_v1_tx_set_hash, expected_ledger_range, is_empty_tx_set_hash,
-    parse_ledger_entries_for_checkpoint, parse_result_entries_for_checkpoint, parse_scp_entries,
-    parse_transaction_entries_for_checkpoint, LedgerVerificationData, XdrVerificationManager,
-    EMPTY_XDR_ARRAY_HASH,
+    parse_ledger_header_entries_for_checkpoint, parse_result_entries_for_checkpoint,
+    parse_scp_entries, parse_transaction_entries_for_checkpoint, LedgerHeaderVerificationData,
+    XdrVerificationManager, EMPTY_XDR_ARRAY_HASH,
 };
 use rstest::rstest;
 use sha2::{Digest, Sha256};
@@ -187,7 +187,7 @@ fn create_minimal_ledger_header(
     }
 }
 
-fn create_valid_ledger_entry(
+fn create_valid_ledger_header_entry(
     seq: u32,
     prev_hash: [u8; 32],
     tx_set_hash: [u8; 32],
@@ -207,16 +207,16 @@ fn create_valid_ledger_entry(
 fn create_complete_checkpoint_data(
     checkpoint: u32,
     initial_prev_hash: [u8; 32],
-) -> BTreeMap<u32, LedgerVerificationData> {
+) -> BTreeMap<u32, LedgerHeaderVerificationData> {
     let (first_ledger, last_ledger) = expected_ledger_range(checkpoint);
-    let mut ledger_data = BTreeMap::new();
+    let mut header_data = BTreeMap::new();
     let mut prev_hash = initial_prev_hash;
 
     for seq in first_ledger..=last_ledger {
         let computed_hash: [u8; 32] = Sha256::digest(format!("ledger{}", seq).as_bytes()).into();
-        ledger_data.insert(
+        header_data.insert(
             seq,
-            LedgerVerificationData {
+            LedgerHeaderVerificationData {
                 computed_hash,
                 prev_hash,
                 expected_tx_set_hash: [0; 32],
@@ -226,13 +226,13 @@ fn create_complete_checkpoint_data(
         prev_hash = computed_hash;
     }
 
-    ledger_data
+    header_data
 }
 
 fn create_checkpoint_data_missing(
     checkpoint: u32,
     missing: &[u32],
-) -> BTreeMap<u32, LedgerVerificationData> {
+) -> BTreeMap<u32, LedgerHeaderVerificationData> {
     let mut data = create_complete_checkpoint_data(checkpoint, [0; 32]);
     for seq in missing {
         data.remove(seq);
@@ -240,14 +240,14 @@ fn create_checkpoint_data_missing(
     data
 }
 
-fn single_ledger_data(
+fn single_ledger_header_data(
     seq: u32,
     computed_hash: [u8; 32],
     prev_hash: [u8; 32],
-) -> BTreeMap<u32, LedgerVerificationData> {
+) -> BTreeMap<u32, LedgerHeaderVerificationData> {
     BTreeMap::from([(
         seq,
-        LedgerVerificationData {
+        LedgerHeaderVerificationData {
             computed_hash,
             prev_hash,
             expected_tx_set_hash: [0; 32],
@@ -289,15 +289,15 @@ fn assert_no_errors_matching(manager: &XdrVerificationManager, substring: &str) 
 }
 
 #[test]
-fn test_parse_ledger_entries_empty_input() {
-    let parsed = parse_ledger_entries(&[]).unwrap();
+fn test_parse_ledger_header_entries_empty_input() {
+    let parsed = parse_ledger_header_entries(&[]).unwrap();
     assert!(parsed.is_empty());
 }
 
 #[test]
-fn test_parse_ledger_entries_single_entry() {
-    let entry = create_valid_ledger_entry(100, [1; 32], [2; 32], [3; 32]);
-    let parsed = parse_ledger_entries(&frame_xdr(&entry)).unwrap();
+fn test_parse_ledger_header_entries_single_entry() {
+    let entry = create_valid_ledger_header_entry(100, [1; 32], [2; 32], [3; 32]);
+    let parsed = parse_ledger_header_entries(&frame_xdr(&entry)).unwrap();
 
     assert_eq!(parsed.len(), 1);
     let actual = parsed.get(&100).unwrap();
@@ -307,24 +307,26 @@ fn test_parse_ledger_entries_single_entry() {
 }
 
 #[test]
-fn test_parse_ledger_entries_hash_mismatch() {
+fn test_parse_ledger_header_entries_hash_mismatch() {
     let entry = LedgerHeaderHistoryEntry {
         hash: Hash([0xff; 32]),
         header: create_minimal_ledger_header(100, [0; 32], [0; 32], [0; 32]),
         ext: LedgerHeaderHistoryEntryExt::V0,
     };
 
-    let err = parse_ledger_entries(&frame_xdr(&entry)).unwrap_err();
+    let err = parse_ledger_header_entries(&frame_xdr(&entry)).unwrap_err();
     assert!(err.message.contains("hash mismatch"));
 }
 
 #[rstest]
-#[case::ledger("ledger")]
+#[case::ledger_header("ledger")]
 #[case::transaction("transaction")]
 #[case::result("result")]
 fn test_parse_rejects_duplicate_sequence(#[case] file_type: &str) {
     let frame = match file_type {
-        "ledger" => frame_xdr(&create_valid_ledger_entry(100, [0; 32], [0; 32], [0; 32])),
+        "ledger" => frame_xdr(&create_valid_ledger_header_entry(
+            100, [0; 32], [0; 32], [0; 32],
+        )),
         "transaction" => frame_xdr(&v0_history_entry(100, [0; 32], vec![tx_v0_envelope(1)])),
         "result" => frame_xdr(&result_entry(100, &[1])),
         _ => unreachable!(),
@@ -332,7 +334,7 @@ fn test_parse_rejects_duplicate_sequence(#[case] file_type: &str) {
     let mut data = frame.clone();
     data.extend(frame);
     let err = match file_type {
-        "ledger" => parse_ledger_entries(&data).unwrap_err(),
+        "ledger" => parse_ledger_header_entries(&data).unwrap_err(),
         "transaction" => parse_transaction_entries(&data).unwrap_err(),
         "result" => parse_result_entries(&data).unwrap_err(),
         _ => unreachable!(),
@@ -341,19 +343,21 @@ fn test_parse_rejects_duplicate_sequence(#[case] file_type: &str) {
 }
 
 #[rstest]
-#[case::ledger("ledger")]
+#[case::ledger_header("ledger")]
 #[case::transaction("transaction")]
 #[case::result("result")]
 fn test_parse_rejects_malformed_frame(#[case] file_type: &str) {
     let valid = match file_type {
-        "ledger" => frame_xdr(&create_valid_ledger_entry(100, [0; 32], [0; 32], [0; 32])),
+        "ledger" => frame_xdr(&create_valid_ledger_header_entry(
+            100, [0; 32], [0; 32], [0; 32],
+        )),
         "transaction" => frame_xdr(&v0_history_entry(100, [0; 32], vec![tx_v0_envelope(1)])),
         "result" => frame_xdr(&result_entry(100, &[1])),
         _ => unreachable!(),
     };
     let truncated = &valid[..valid.len() / 2];
     let err = match file_type {
-        "ledger" => parse_ledger_entries(truncated).unwrap_err(),
+        "ledger" => parse_ledger_header_entries(truncated).unwrap_err(),
         "transaction" => parse_transaction_entries(truncated).unwrap_err(),
         "result" => parse_result_entries(truncated).unwrap_err(),
         _ => unreachable!(),
@@ -519,15 +523,15 @@ fn test_manager_records_and_verifies_checkpoint() {
     let checkpoint = 63;
     let result_hash = hash_of("result");
 
-    let mut ledger_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
-    for data in ledger_data.values_mut() {
+    let mut header_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
+    for data in header_data.values_mut() {
         data.expected_result_hash = result_hash;
     }
 
     let result_hashes: HashMap<u32, [u8; 32]> =
-        ledger_data.keys().map(|&seq| (seq, result_hash)).collect();
+        header_data.keys().map(|&seq| (seq, result_hash)).collect();
 
-    manager.record_ledger_data(checkpoint, ledger_data);
+    manager.record_header_data(checkpoint, header_data);
     manager.record_result_hashes(checkpoint, result_hashes);
     manager.verify_and_release(checkpoint);
 
@@ -542,10 +546,10 @@ fn test_manager_records_and_verifies_checkpoint() {
 fn test_chain_break_within_ledger_file(#[case] checkpoint: u32, #[case] corrupted_ledger: u32) {
     let manager = XdrVerificationManager::new();
 
-    let mut ledger_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
-    ledger_data.get_mut(&corrupted_ledger).unwrap().prev_hash = [0xff; 32];
+    let mut header_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
+    header_data.get_mut(&corrupted_ledger).unwrap().prev_hash = [0xff; 32];
 
-    manager.record_ledger_data(checkpoint, ledger_data);
+    manager.record_header_data(checkpoint, header_data);
     manager.verify_and_release(checkpoint);
 
     assert!(manager
@@ -559,10 +563,10 @@ fn test_chain_break_within_ledger_file(#[case] checkpoint: u32, #[case] corrupte
 #[case::regular(127, 64)]
 fn test_complete_checkpoint_passes(#[case] checkpoint: u32, #[case] expected_count: usize) {
     let manager = XdrVerificationManager::new();
-    let ledger_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
-    assert_eq!(ledger_data.len(), expected_count);
+    let header_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
+    assert_eq!(header_data.len(), expected_count);
 
-    manager.record_ledger_data(checkpoint, ledger_data);
+    manager.record_header_data(checkpoint, header_data);
     manager.verify_and_release(checkpoint);
 
     assert!(manager.get_errors().is_empty());
@@ -575,9 +579,9 @@ fn test_complete_checkpoint_passes(#[case] checkpoint: u32, #[case] expected_cou
 #[case::multiple_ledgers(127, vec![66, 67])]
 #[case::genesis_first(63, vec![1])]
 #[case::all_missing(127, (64..=127).collect())]
-fn test_missing_ledger_entries(#[case] checkpoint: u32, #[case] missing: Vec<u32>) {
+fn test_missing_ledger_header_entries(#[case] checkpoint: u32, #[case] missing: Vec<u32>) {
     let manager = XdrVerificationManager::new();
-    manager.record_ledger_data(
+    manager.record_header_data(
         checkpoint,
         create_checkpoint_data_missing(checkpoint, &missing),
     );
@@ -589,10 +593,10 @@ fn test_missing_ledger_entries(#[case] checkpoint: u32, #[case] missing: Vec<u32
 #[test]
 fn test_ledger_outside_expected_checkpoint_range() {
     let manager = XdrVerificationManager::new();
-    let mut ledger_data = create_complete_checkpoint_data(127, [0; 32]);
-    ledger_data.insert(
+    let mut header_data = create_complete_checkpoint_data(127, [0; 32]);
+    header_data.insert(
         200,
-        LedgerVerificationData {
+        LedgerHeaderVerificationData {
             computed_hash: [0xaa; 32],
             prev_hash: [0xbb; 32],
             expected_tx_set_hash: [0; 32],
@@ -600,10 +604,10 @@ fn test_ledger_outside_expected_checkpoint_range() {
         },
     );
 
-    manager.record_ledger_data(127, ledger_data);
+    manager.record_header_data(127, header_data);
     manager.verify_and_release(127);
 
-    assert_has_error(&manager, "unexpected ledger entries outside range");
+    assert_has_error(&manager, "unexpected ledger-header entries outside range");
 }
 
 #[rstest]
@@ -611,16 +615,16 @@ fn test_ledger_outside_expected_checkpoint_range() {
 #[case::broken_chain(true)]
 fn test_cross_checkpoint_chain(#[case] break_chain: bool) {
     let manager = XdrVerificationManager::new();
-    let ledger_data_63 = single_ledger_data(63, hash_of("ledger63"), [0; 32]);
+    let header_data_63 = single_ledger_header_data(63, hash_of("ledger63"), [0; 32]);
     let prev_hash = if break_chain {
         [0xff; 32]
     } else {
         hash_of("ledger63")
     };
-    let ledger_data_127 = single_ledger_data(64, hash_of("ledger127"), prev_hash);
+    let header_data_127 = single_ledger_header_data(64, hash_of("ledger127"), prev_hash);
 
-    manager.record_ledger_data(63, ledger_data_63);
-    manager.record_ledger_data(127, ledger_data_127);
+    manager.record_header_data(63, header_data_63);
+    manager.record_header_data(127, header_data_127);
     manager.verify_and_release(63);
     manager.verify_and_release(127);
 
@@ -637,10 +641,10 @@ fn test_cross_checkpoint_chain(#[case] break_chain: bool) {
 #[case::broken(true)]
 fn test_consecutive_checkpoints_full(#[case] break_chain: bool) {
     let manager = XdrVerificationManager::new();
-    let ledger_data_63 = create_complete_checkpoint_data(63, [0; 32]);
-    let last_hash_of_63 = ledger_data_63.get(&63).unwrap().computed_hash;
+    let header_data_63 = create_complete_checkpoint_data(63, [0; 32]);
+    let last_hash_of_63 = header_data_63.get(&63).unwrap().computed_hash;
 
-    let mut ledger_data_127 = BTreeMap::new();
+    let mut header_data_127 = BTreeMap::new();
     let mut prev_hash = if break_chain {
         [0xff; 32]
     } else {
@@ -648,9 +652,9 @@ fn test_consecutive_checkpoints_full(#[case] break_chain: bool) {
     };
     for seq in 64_u32..=127 {
         let computed_hash: [u8; 32] = Sha256::digest(seq.to_le_bytes()).into();
-        ledger_data_127.insert(
+        header_data_127.insert(
             seq,
-            LedgerVerificationData {
+            LedgerHeaderVerificationData {
                 computed_hash,
                 prev_hash,
                 expected_tx_set_hash: [0; 32],
@@ -660,8 +664,8 @@ fn test_consecutive_checkpoints_full(#[case] break_chain: bool) {
         prev_hash = computed_hash;
     }
 
-    manager.record_ledger_data(63, ledger_data_63);
-    manager.record_ledger_data(127, ledger_data_127);
+    manager.record_header_data(63, header_data_63);
+    manager.record_header_data(127, header_data_127);
     manager.verify_and_release(63);
     manager.verify_and_release(127);
 
@@ -677,8 +681,8 @@ fn test_consecutive_checkpoints_full(#[case] break_chain: bool) {
 #[test]
 fn test_non_consecutive_checkpoint_scanning() {
     let manager = XdrVerificationManager::new();
-    manager.record_ledger_data(63, create_complete_checkpoint_data(63, [0; 32]));
-    manager.record_ledger_data(191, create_complete_checkpoint_data(191, [0; 32]));
+    manager.record_header_data(63, create_complete_checkpoint_data(63, [0; 32]));
+    manager.record_header_data(191, create_complete_checkpoint_data(191, [0; 32]));
     manager.verify_and_release(63);
     manager.verify_and_release(191);
 
@@ -689,11 +693,11 @@ fn test_non_consecutive_checkpoint_scanning() {
 #[test]
 fn test_cross_checkpoint_missing_last_ledger_breaks_chain() {
     let manager = XdrVerificationManager::new();
-    let mut ledger_data_63 = create_complete_checkpoint_data(63, [0; 32]);
-    ledger_data_63.remove(&63);
+    let mut header_data_63 = create_complete_checkpoint_data(63, [0; 32]);
+    header_data_63.remove(&63);
 
-    manager.record_ledger_data(63, ledger_data_63);
-    manager.record_ledger_data(127, create_complete_checkpoint_data(127, [0; 32]));
+    manager.record_header_data(63, header_data_63);
+    manager.record_header_data(127, create_complete_checkpoint_data(127, [0; 32]));
     manager.verify_and_release(63);
     manager.verify_and_release(127);
 
@@ -705,11 +709,11 @@ fn test_cross_checkpoint_missing_last_ledger_breaks_chain() {
 fn test_manager_memory_freed_after_verification() {
     let manager = XdrVerificationManager::new();
     let checkpoint = 63;
-    let ledger_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
+    let header_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
 
-    manager.record_ledger_data(checkpoint, ledger_data.clone());
+    manager.record_header_data(checkpoint, header_data.clone());
     manager.verify_and_release(checkpoint);
-    manager.record_ledger_data(checkpoint, ledger_data);
+    manager.record_header_data(checkpoint, header_data);
     manager.verify_and_release(checkpoint);
 
     assert!(manager.get_errors().is_empty());
@@ -741,15 +745,15 @@ fn test_verify_and_release_with_only_result_hashes_records_error() {
 #[test]
 fn test_verify_checkpoint_chain_with_three_consecutive_checkpoints() {
     let manager = XdrVerificationManager::new();
-    let ledger_data_63 = create_complete_checkpoint_data(63, [0; 32]);
-    let hash_63 = ledger_data_63.get(&63).unwrap().computed_hash;
-    let ledger_data_127 = create_complete_checkpoint_data(127, hash_63);
-    let hash_127 = ledger_data_127.get(&127).unwrap().computed_hash;
-    let ledger_data_191 = create_complete_checkpoint_data(191, hash_127);
+    let header_data_63 = create_complete_checkpoint_data(63, [0; 32]);
+    let hash_63 = header_data_63.get(&63).unwrap().computed_hash;
+    let header_data_127 = create_complete_checkpoint_data(127, hash_63);
+    let hash_127 = header_data_127.get(&127).unwrap().computed_hash;
+    let header_data_191 = create_complete_checkpoint_data(191, hash_127);
 
-    manager.record_ledger_data(63, ledger_data_63);
-    manager.record_ledger_data(127, ledger_data_127);
-    manager.record_ledger_data(191, ledger_data_191);
+    manager.record_header_data(63, header_data_63);
+    manager.record_header_data(127, header_data_127);
+    manager.record_header_data(191, header_data_191);
     manager.verify_and_release(63);
     manager.verify_and_release(127);
     manager.verify_and_release(191);
@@ -780,8 +784,8 @@ fn test_manager_detects_hash_mismatch(#[case] hash_type: &str) {
     let expected = hash_of("expected");
     let wrong = hash_of("wrong");
 
-    let mut ledger_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
-    for data in ledger_data.values_mut() {
+    let mut header_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
+    for data in header_data.values_mut() {
         match hash_type {
             "tx set" => data.expected_tx_set_hash = expected,
             "result set" => data.expected_result_hash = expected,
@@ -790,9 +794,9 @@ fn test_manager_detects_hash_mismatch(#[case] hash_type: &str) {
     }
 
     let wrong_hashes: HashMap<u32, [u8; 32]> =
-        ledger_data.keys().map(|&seq| (seq, wrong)).collect();
+        header_data.keys().map(|&seq| (seq, wrong)).collect();
 
-    manager.record_ledger_data(checkpoint, ledger_data);
+    manager.record_header_data(checkpoint, header_data);
     match hash_type {
         "tx set" => manager.record_tx_set_hashes(checkpoint, wrong_hashes),
         "result set" => manager.record_result_hashes(checkpoint, wrong_hashes),
@@ -811,15 +815,15 @@ fn test_manager_detects_missing_entry_for_non_empty_hash(#[case] hash_type: &str
     let checkpoint = 127;
     let non_empty_hash = hash_of("non_empty");
 
-    let mut ledger_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
-    for data in ledger_data.values_mut() {
+    let mut header_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
+    for data in header_data.values_mut() {
         // tx set missing-entry detection requires expected_result_hash != EMPTY_XDR_ARRAY_HASH,
         // so both cases set non-empty hashes for both fields.
         data.expected_tx_set_hash = non_empty_hash;
         data.expected_result_hash = non_empty_hash;
     }
 
-    manager.record_ledger_data(checkpoint, ledger_data);
+    manager.record_header_data(checkpoint, header_data);
     match hash_type {
         "tx set" => manager.record_tx_set_hashes(checkpoint, HashMap::new()),
         "result" => manager.record_result_hashes(checkpoint, HashMap::new()),
@@ -846,8 +850,8 @@ fn test_manager_allows_missing_entry_for_empty_hash(
     let manager = XdrVerificationManager::new();
     let checkpoint = 127;
 
-    let mut ledger_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
-    for data in ledger_data.values_mut() {
+    let mut header_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
+    for data in header_data.values_mut() {
         match (hash_type, empty_variant) {
             ("tx set", "empty_v0") => {
                 data.expected_tx_set_hash = compute_empty_v0_tx_set_hash(&data.prev_hash);
@@ -866,7 +870,7 @@ fn test_manager_allows_missing_entry_for_empty_hash(
         }
     }
 
-    manager.record_ledger_data(checkpoint, ledger_data);
+    manager.record_header_data(checkpoint, header_data);
     match hash_type {
         "tx set" => manager.record_tx_set_hashes(checkpoint, HashMap::new()),
         "result" => manager.record_result_hashes(checkpoint, HashMap::new()),
@@ -888,13 +892,13 @@ fn test_manager_still_flags_missing_tx_set_when_result_hash_is_empty_array_hash(
     let checkpoint = 127;
     let non_empty_tx_hash = hash_of("non_empty_tx_set");
 
-    let mut ledger_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
-    for data in ledger_data.values_mut() {
+    let mut header_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
+    for data in header_data.values_mut() {
         data.expected_tx_set_hash = non_empty_tx_hash;
         data.expected_result_hash = EMPTY_XDR_ARRAY_HASH;
     }
 
-    manager.record_ledger_data(checkpoint, ledger_data);
+    manager.record_header_data(checkpoint, header_data);
     manager.record_tx_set_hashes(checkpoint, HashMap::new());
     manager.verify_and_release(checkpoint);
 
@@ -904,18 +908,20 @@ fn test_manager_still_flags_missing_tx_set_when_result_hash_is_empty_array_hash(
 }
 
 #[rstest]
-#[case::ledger("ledger")]
+#[case::ledger_header("ledger")]
 #[case::transaction("transaction")]
 #[case::result("result")]
 fn test_parse_rejects_ledger_outside_checkpoint_range(#[case] file_type: &str) {
     let data = match file_type {
-        "ledger" => frame_xdr(&create_valid_ledger_entry(200, [0; 32], [0; 32], [0; 32])),
+        "ledger" => frame_xdr(&create_valid_ledger_header_entry(
+            200, [0; 32], [0; 32], [0; 32],
+        )),
         "transaction" => frame_xdr(&v0_history_entry(200, [0; 32], vec![tx_v0_envelope(1)])),
         "result" => frame_xdr(&result_entry(200, &[1])),
         _ => unreachable!(),
     };
     let err = match file_type {
-        "ledger" => parse_ledger_entries_for_checkpoint(&data, Some(127)).unwrap_err(),
+        "ledger" => parse_ledger_header_entries_for_checkpoint(&data, Some(127)).unwrap_err(),
         "transaction" => parse_transaction_entries_for_checkpoint(&data, Some(127)).unwrap_err(),
         "result" => parse_result_entries_for_checkpoint(&data, Some(127)).unwrap_err(),
         _ => unreachable!(),

--- a/src/tests/xdr_verify_test.rs
+++ b/src/tests/xdr_verify_test.rs
@@ -8,7 +8,7 @@ use crate::xdr_verify::{
 };
 use rstest::rstest;
 use sha2::{Digest, Sha256};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use stellar_xdr::curr::{
     AccountId, CreateAccountOp, GeneralizedTransactionSet, Hash, LedgerHeader, LedgerHeaderExt,
     LedgerHeaderHistoryEntry, LedgerHeaderHistoryEntryExt, LedgerScpMessages, Limits, Memo,
@@ -217,10 +217,10 @@ fn create_complete_checkpoint_data(
         header_data.insert(
             seq,
             LedgerHeaderVerificationData {
-                computed_hash,
-                prev_hash,
-                expected_tx_set_hash: [0; 32],
-                expected_result_hash: [0; 32],
+                computed_hash: Hash(computed_hash),
+                prev_hash: Hash(prev_hash),
+                expected_tx_set_hash: Hash([0; 32]),
+                expected_result_hash: Hash([0; 32]),
             },
         );
         prev_hash = computed_hash;
@@ -248,10 +248,10 @@ fn single_ledger_header_data(
     BTreeMap::from([(
         seq,
         LedgerHeaderVerificationData {
-            computed_hash,
-            prev_hash,
-            expected_tx_set_hash: [0; 32],
-            expected_result_hash: [0; 32],
+            computed_hash: Hash(computed_hash),
+            prev_hash: Hash(prev_hash),
+            expected_tx_set_hash: Hash([0; 32]),
+            expected_result_hash: Hash([0; 32]),
         },
     )])
 }
@@ -301,9 +301,9 @@ fn test_parse_ledger_header_entries_single_entry() {
 
     assert_eq!(parsed.len(), 1);
     let actual = parsed.get(&100).unwrap();
-    assert_eq!(actual.prev_hash, [1; 32]);
-    assert_eq!(actual.expected_tx_set_hash, [2; 32]);
-    assert_eq!(actual.expected_result_hash, [3; 32]);
+    assert_eq!(actual.prev_hash, Hash([1; 32]));
+    assert_eq!(actual.expected_tx_set_hash, Hash([2; 32]));
+    assert_eq!(actual.expected_result_hash, Hash([3; 32]));
 }
 
 #[test]
@@ -379,7 +379,7 @@ fn test_parse_result_entries_single_entry() {
     let expected: [u8; 32] =
         Sha256::digest(entry.tx_result_set.to_xdr(Limits::none()).unwrap()).into();
 
-    assert_eq!(parsed, HashMap::from([(100, expected)]));
+    assert_eq!(parsed, BTreeMap::from([(100u32, Hash(expected))]));
 }
 
 #[test]
@@ -391,7 +391,7 @@ fn test_parse_transaction_entries_v0_non_empty() {
 
     assert_eq!(parsed.len(), 1);
     assert_eq!(parsed[&100], compute_v0_tx_set_hash(&entry.tx_set).unwrap());
-    assert!(!is_empty_tx_set_hash(&parsed[&100], &prev_hash));
+    assert!(!is_empty_tx_set_hash(&parsed[&100], &Hash(prev_hash)));
 }
 
 #[test]
@@ -405,7 +405,7 @@ fn test_parse_transaction_entries_v1_non_empty() {
     };
 
     assert_eq!(parsed[&100], compute_v1_tx_set_hash(generalized).unwrap());
-    assert!(!is_empty_tx_set_hash(&parsed[&100], &prev_hash));
+    assert!(!is_empty_tx_set_hash(&parsed[&100], &Hash(prev_hash)));
 }
 
 #[test]
@@ -424,7 +424,7 @@ fn test_compute_v0_tx_set_hash_matches_manual_hash() {
     }
 
     let expected: [u8; 32] = hasher.finalize().into();
-    assert_eq!(compute_v0_tx_set_hash(&tx_set).unwrap(), expected);
+    assert_eq!(compute_v0_tx_set_hash(&tx_set).unwrap(), Hash(expected));
 }
 
 #[test]
@@ -466,21 +466,24 @@ fn test_compute_v1_tx_set_hash_matches_manual_hash() {
     });
     let expected: [u8; 32] = Sha256::digest(generalized.to_xdr(Limits::none()).unwrap()).into();
 
-    assert_eq!(compute_v1_tx_set_hash(&generalized).unwrap(), expected);
+    assert_eq!(
+        compute_v1_tx_set_hash(&generalized).unwrap(),
+        Hash(expected)
+    );
 }
 
 #[test]
 fn test_is_empty_tx_set_hash_direct_hashes() {
-    let prev_hash = [0x55; 32];
-    let expected_v0: [u8; 32] = Sha256::digest(prev_hash).into();
-    assert_eq!(compute_empty_v0_tx_set_hash(&prev_hash), expected_v0);
+    let prev_hash = Hash([0x55; 32]);
+    let expected_v0: [u8; 32] = Sha256::digest(prev_hash.0).into();
+    assert_eq!(compute_empty_v0_tx_set_hash(&prev_hash), Hash(expected_v0));
 
     let empty_v1 = GeneralizedTransactionSet::V1(TransactionSetV1 {
-        previous_ledger_hash: Hash(prev_hash),
+        previous_ledger_hash: prev_hash.clone(),
         phases: VecM::default(),
     });
     let expected_v1: [u8; 32] = Sha256::digest(empty_v1.to_xdr(Limits::none()).unwrap()).into();
-    assert_eq!(compute_empty_v1_tx_set_hash(&prev_hash), expected_v1);
+    assert_eq!(compute_empty_v1_tx_set_hash(&prev_hash), Hash(expected_v1));
 
     assert!(is_empty_tx_set_hash(
         &compute_empty_v0_tx_set_hash(&prev_hash),
@@ -495,7 +498,7 @@ fn test_is_empty_tx_set_hash_direct_hashes() {
 #[test]
 fn test_empty_xdr_array_hash_constant_matches_hash() {
     let expected: [u8; 32] = Sha256::digest([0_u8, 0, 0, 0]).into();
-    assert_eq!(EMPTY_XDR_ARRAY_HASH, expected);
+    assert_eq!(EMPTY_XDR_ARRAY_HASH, Hash(expected));
 }
 
 #[test]
@@ -525,11 +528,13 @@ fn test_manager_records_and_verifies_checkpoint() {
 
     let mut header_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
     for data in header_data.values_mut() {
-        data.expected_result_hash = result_hash;
+        data.expected_result_hash = Hash(result_hash);
     }
 
-    let result_hashes: HashMap<u32, [u8; 32]> =
-        header_data.keys().map(|&seq| (seq, result_hash)).collect();
+    let result_hashes: BTreeMap<u32, Hash> = header_data
+        .keys()
+        .map(|&seq| (seq, Hash(result_hash)))
+        .collect();
 
     manager.record_header_data(checkpoint, header_data);
     manager.record_result_hashes(checkpoint, result_hashes);
@@ -547,7 +552,7 @@ fn test_chain_break_within_ledger_file(#[case] checkpoint: u32, #[case] corrupte
     let manager = XdrVerificationManager::new();
 
     let mut header_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
-    header_data.get_mut(&corrupted_ledger).unwrap().prev_hash = [0xff; 32];
+    header_data.get_mut(&corrupted_ledger).unwrap().prev_hash = Hash([0xff; 32]);
 
     manager.record_header_data(checkpoint, header_data);
     manager.verify_and_release(checkpoint);
@@ -597,10 +602,10 @@ fn test_ledger_outside_expected_checkpoint_range() {
     header_data.insert(
         200,
         LedgerHeaderVerificationData {
-            computed_hash: [0xaa; 32],
-            prev_hash: [0xbb; 32],
-            expected_tx_set_hash: [0; 32],
-            expected_result_hash: [0; 32],
+            computed_hash: Hash([0xaa; 32]),
+            prev_hash: Hash([0xbb; 32]),
+            expected_tx_set_hash: Hash([0; 32]),
+            expected_result_hash: Hash([0; 32]),
         },
     );
 
@@ -642,23 +647,23 @@ fn test_cross_checkpoint_chain(#[case] break_chain: bool) {
 fn test_consecutive_checkpoints_full(#[case] break_chain: bool) {
     let manager = XdrVerificationManager::new();
     let header_data_63 = create_complete_checkpoint_data(63, [0; 32]);
-    let last_hash_of_63 = header_data_63.get(&63).unwrap().computed_hash;
+    let last_hash_of_63 = header_data_63.get(&63).unwrap().computed_hash.clone();
 
     let mut header_data_127 = BTreeMap::new();
     let mut prev_hash = if break_chain {
-        [0xff; 32]
+        Hash([0xff; 32])
     } else {
         last_hash_of_63
     };
     for seq in 64_u32..=127 {
-        let computed_hash: [u8; 32] = Sha256::digest(seq.to_le_bytes()).into();
+        let computed_hash = Hash(Sha256::digest(seq.to_le_bytes()).into());
         header_data_127.insert(
             seq,
             LedgerHeaderVerificationData {
-                computed_hash,
-                prev_hash,
-                expected_tx_set_hash: [0; 32],
-                expected_result_hash: [0; 32],
+                computed_hash: computed_hash.clone(),
+                prev_hash: prev_hash.clone(),
+                expected_tx_set_hash: Hash([0; 32]),
+                expected_result_hash: Hash([0; 32]),
             },
         );
         prev_hash = computed_hash;
@@ -722,7 +727,7 @@ fn test_manager_memory_freed_after_verification() {
 #[test]
 fn test_verify_and_release_with_only_tx_hashes_records_error_and_is_idempotent() {
     let manager = XdrVerificationManager::new();
-    manager.record_tx_set_hashes(127, HashMap::from([(100, [1; 32])]));
+    manager.record_tx_set_hashes(127, BTreeMap::from([(100u32, Hash([1; 32]))]));
     manager.verify_and_release(127);
     let first_errors = manager.get_errors();
     manager.verify_and_release(127);
@@ -736,7 +741,7 @@ fn test_verify_and_release_with_only_tx_hashes_records_error_and_is_idempotent()
 #[test]
 fn test_verify_and_release_with_only_result_hashes_records_error() {
     let manager = XdrVerificationManager::new();
-    manager.record_result_hashes(127, HashMap::from([(100, [1; 32])]));
+    manager.record_result_hashes(127, BTreeMap::from([(100u32, Hash([1; 32]))]));
     manager.verify_and_release(127);
 
     assert_has_error(&manager, "missing ledger verification data");
@@ -746,10 +751,10 @@ fn test_verify_and_release_with_only_result_hashes_records_error() {
 fn test_verify_checkpoint_chain_with_three_consecutive_checkpoints() {
     let manager = XdrVerificationManager::new();
     let header_data_63 = create_complete_checkpoint_data(63, [0; 32]);
-    let hash_63 = header_data_63.get(&63).unwrap().computed_hash;
-    let header_data_127 = create_complete_checkpoint_data(127, hash_63);
-    let hash_127 = header_data_127.get(&127).unwrap().computed_hash;
-    let header_data_191 = create_complete_checkpoint_data(191, hash_127);
+    let hash_63 = header_data_63.get(&63).unwrap().computed_hash.clone();
+    let header_data_127 = create_complete_checkpoint_data(127, hash_63.0);
+    let hash_127 = header_data_127.get(&127).unwrap().computed_hash.clone();
+    let header_data_191 = create_complete_checkpoint_data(191, hash_127.0);
 
     manager.record_header_data(63, header_data_63);
     manager.record_header_data(127, header_data_127);
@@ -787,14 +792,14 @@ fn test_manager_detects_hash_mismatch(#[case] hash_type: &str) {
     let mut header_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
     for data in header_data.values_mut() {
         match hash_type {
-            "tx set" => data.expected_tx_set_hash = expected,
-            "result set" => data.expected_result_hash = expected,
+            "tx set" => data.expected_tx_set_hash = Hash(expected),
+            "result set" => data.expected_result_hash = Hash(expected),
             _ => unreachable!(),
         }
     }
 
-    let wrong_hashes: HashMap<u32, [u8; 32]> =
-        header_data.keys().map(|&seq| (seq, wrong)).collect();
+    let wrong_hashes: BTreeMap<u32, Hash> =
+        header_data.keys().map(|&seq| (seq, Hash(wrong))).collect();
 
     manager.record_header_data(checkpoint, header_data);
     match hash_type {
@@ -819,14 +824,14 @@ fn test_manager_detects_missing_entry_for_non_empty_hash(#[case] hash_type: &str
     for data in header_data.values_mut() {
         // tx set missing-entry detection requires expected_result_hash != EMPTY_XDR_ARRAY_HASH,
         // so both cases set non-empty hashes for both fields.
-        data.expected_tx_set_hash = non_empty_hash;
-        data.expected_result_hash = non_empty_hash;
+        data.expected_tx_set_hash = Hash(non_empty_hash);
+        data.expected_result_hash = Hash(non_empty_hash);
     }
 
     manager.record_header_data(checkpoint, header_data);
     match hash_type {
-        "tx set" => manager.record_tx_set_hashes(checkpoint, HashMap::new()),
-        "result" => manager.record_result_hashes(checkpoint, HashMap::new()),
+        "tx set" => manager.record_tx_set_hashes(checkpoint, BTreeMap::new()),
+        "result" => manager.record_result_hashes(checkpoint, BTreeMap::new()),
         _ => unreachable!(),
     }
     manager.verify_and_release(checkpoint);
@@ -855,25 +860,25 @@ fn test_manager_allows_missing_entry_for_empty_hash(
         match (hash_type, empty_variant) {
             ("tx set", "empty_v0") => {
                 data.expected_tx_set_hash = compute_empty_v0_tx_set_hash(&data.prev_hash);
-                data.expected_result_hash = hash_of("some_result");
+                data.expected_result_hash = Hash(hash_of("some_result"));
             }
             ("tx set", "empty_v1") => {
                 data.expected_tx_set_hash = compute_empty_v1_tx_set_hash(&data.prev_hash);
-                data.expected_result_hash = hash_of("some_result");
+                data.expected_result_hash = Hash(hash_of("some_result"));
             }
-            ("tx set", "zero") => {} // defaults are already [0; 32]
+            ("tx set", "zero") => {} // defaults are already Hash([0; 32])
             ("result", "empty_xdr_array") => {
                 data.expected_result_hash = EMPTY_XDR_ARRAY_HASH;
             }
-            ("result", "zero") => {} // defaults are already [0; 32]
+            ("result", "zero") => {} // defaults are already Hash([0; 32])
             _ => unreachable!(),
         }
     }
 
     manager.record_header_data(checkpoint, header_data);
     match hash_type {
-        "tx set" => manager.record_tx_set_hashes(checkpoint, HashMap::new()),
-        "result" => manager.record_result_hashes(checkpoint, HashMap::new()),
+        "tx set" => manager.record_tx_set_hashes(checkpoint, BTreeMap::new()),
+        "result" => manager.record_result_hashes(checkpoint, BTreeMap::new()),
         _ => unreachable!(),
     }
     manager.verify_and_release(checkpoint);
@@ -894,12 +899,12 @@ fn test_manager_still_flags_missing_tx_set_when_result_hash_is_empty_array_hash(
 
     let mut header_data = create_complete_checkpoint_data(checkpoint, [0; 32]);
     for data in header_data.values_mut() {
-        data.expected_tx_set_hash = non_empty_tx_hash;
+        data.expected_tx_set_hash = Hash(non_empty_tx_hash);
         data.expected_result_hash = EMPTY_XDR_ARRAY_HASH;
     }
 
     manager.record_header_data(checkpoint, header_data);
-    manager.record_tx_set_hashes(checkpoint, HashMap::new());
+    manager.record_tx_set_hashes(checkpoint, BTreeMap::new());
     manager.verify_and_release(checkpoint);
 
     // The EMPTY_XDR_ARRAY_HASH result hash suppresses the missing tx set error

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -77,6 +77,7 @@ pub fn map_pipeline_error(err: pipeline::Error) -> crate::Error {
     match err {
         pipeline::Error::ScanOperation(scan_err) => crate::Error::ScanOperation(scan_err),
         pipeline::Error::MirrorOperation(mirror_err) => crate::Error::MirrorOperation(mirror_err),
+        pipeline::Error::RepairOperation(repair_err) => crate::Error::RepairOperation(repair_err),
         pipeline::Error::Io(io_err) => crate::Error::Io(io_err),
         other => crate::Error::Other(other.to_string()),
     }
@@ -184,6 +185,11 @@ impl ArchiveStats {
             info!(
                 "Mirror completed: {} files copied, {} failed, {} skipped",
                 successful, failed, skipped
+            );
+        } else if operation == "repair" {
+            info!(
+                "Repair completed: {} files downloaded, {} failed",
+                successful, failed
             );
         } else {
             let missing_required = self.missing_required.load(Ordering::Relaxed);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,5 @@
 use bytes::Buf;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
 use thiserror::Error;
 use tracing::{debug, error, info, warn};
 
@@ -107,7 +106,7 @@ pub struct ArchiveStats {
     pub missing_scp: AtomicU64,
 
     // List of all failed/missing files for detailed reporting
-    pub failed_list: Arc<tokio::sync::Mutex<Vec<String>>>,
+    pub failed_list: tokio::sync::Mutex<Vec<String>>,
 }
 
 impl Default for ArchiveStats {
@@ -131,7 +130,7 @@ impl ArchiveStats {
             missing_results: AtomicU64::new(0),
             missing_buckets: AtomicU64::new(0),
             missing_scp: AtomicU64::new(0),
-            failed_list: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+            failed_list: tokio::sync::Mutex::new(Vec::new()),
         }
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -187,7 +187,7 @@ impl ArchiveStats {
             );
         } else if operation == "repair" {
             info!(
-                "Repair completed: {} files downloaded, {} failed",
+                "Repair completed: {} files processed, {} failed",
                 successful, failed
             );
         } else {

--- a/src/xdr_verify.rs
+++ b/src/xdr_verify.rs
@@ -59,11 +59,14 @@ pub(crate) fn expected_ledger_range(checkpoint: u32) -> (u32, u32) {
     }
 }
 
-/// Hashes extracted from a single ledger header entry, keyed by ledger sequence.
-/// Produced by [`parse_ledger_entries`], consumed by [`XdrVerificationManager`] for
-/// cross-file and hash-chain verification.
+/// Hashes extracted from a single `LedgerHeaderHistoryEntry`, keyed by
+/// ledger sequence. Produced by [`parse_ledger_header_entries_for_checkpoint`],
+/// consumed by [`XdrVerificationManager`] for cross-file and hash-chain
+/// verification.
+///
+/// Note: this is about *ledger headers*, not bucket-resident `LedgerEntry`s.
 #[derive(Debug, Clone)]
-pub struct LedgerVerificationData {
+pub struct LedgerHeaderVerificationData {
     /// `SHA256(entry.header.to_xdr())` — verified to equal `entry.hash` at parse time.
     pub computed_hash: [u8; 32],
     /// `entry.header.previous_ledger_hash` — checked against prior ledger's `computed_hash`
@@ -79,7 +82,7 @@ pub struct LedgerVerificationData {
 
 #[derive(Default)]
 struct PendingCheckpoint {
-    ledger_data: Option<BTreeMap<u32, LedgerVerificationData>>,
+    header_data: Option<BTreeMap<u32, LedgerHeaderVerificationData>>,
     tx_set_hashes: Option<HashMap<u32, [u8; 32]>>,
     result_hashes: Option<HashMap<u32, [u8; 32]>>,
 }
@@ -105,7 +108,7 @@ pub struct VerificationError {
 /// Coordinates cross-file XDR verification across concurrent checkpoint processing.
 ///
 /// **Usage flow:**
-/// 1. For each checkpoint, record parsed data via `record_ledger_data`,
+/// 1. For each checkpoint, record parsed data via `record_header_data`,
 ///    `record_tx_set_hashes`, and `record_result_hashes` (order doesn't matter,
 ///    can be called from different tasks concurrently).
 /// 2. Call [`verify_and_release`](Self::verify_and_release) once all three files
@@ -137,14 +140,18 @@ impl XdrVerificationManager {
     /// Overwrites any previously recorded ledger data for the same checkpoint.
     /// Pair with `record_tx_set_hashes` and `record_result_hashes`, then call
     /// [`verify_and_release`](Self::verify_and_release) once all three are in.
-    pub fn record_ledger_data(&self, checkpoint: u32, data: BTreeMap<u32, LedgerVerificationData>) {
+    pub fn record_header_data(
+        &self,
+        checkpoint: u32,
+        data: BTreeMap<u32, LedgerHeaderVerificationData>,
+    ) {
         let mut pending = self.pending.lock().unwrap();
         let entry = pending.entry(checkpoint).or_default();
-        entry.ledger_data = Some(data);
+        entry.header_data = Some(data);
     }
 
     /// Record per-ledger transaction-set hashes parsed from the **transactions**
-    /// file of a checkpoint. See [`record_ledger_data`](Self::record_ledger_data).
+    /// file of a checkpoint. See [`record_header_data`](Self::record_header_data).
     pub fn record_tx_set_hashes(&self, checkpoint: u32, hashes: HashMap<u32, [u8; 32]>) {
         let mut pending = self.pending.lock().unwrap();
         let entry = pending.entry(checkpoint).or_default();
@@ -152,7 +159,7 @@ impl XdrVerificationManager {
     }
 
     /// Record per-ledger result-set hashes parsed from the **results** file of
-    /// a checkpoint. See [`record_ledger_data`](Self::record_ledger_data).
+    /// a checkpoint. See [`record_header_data`](Self::record_header_data).
     pub fn record_result_hashes(&self, checkpoint: u32, hashes: HashMap<u32, [u8; 32]>) {
         let mut pending = self.pending.lock().unwrap();
         let entry = pending.entry(checkpoint).or_default();
@@ -180,7 +187,7 @@ impl XdrVerificationManager {
             return Vec::new();
         };
 
-        let Some(ledger_data) = data.ledger_data else {
+        let Some(header_data) = data.header_data else {
             let err_msg = "missing ledger verification data for checkpoint";
             warn!("Checkpoint {checkpoint}: skipping cross-verification because {err_msg}");
             let err = VerificationError {
@@ -195,13 +202,13 @@ impl XdrVerificationManager {
         let mut errors = Vec::new();
         errors.extend(Self::verify_checkpoint_completeness(
             checkpoint,
-            &ledger_data,
+            &header_data,
         ));
 
         if let Some(tx_set_hashes) = data.tx_set_hashes {
             errors.extend(Self::verify_tx_set_hashes_internal(
                 checkpoint,
-                &ledger_data,
+                &header_data,
                 &tx_set_hashes,
             ));
         }
@@ -209,13 +216,13 @@ impl XdrVerificationManager {
         if let Some(result_hashes) = data.result_hashes {
             errors.extend(Self::verify_result_hashes_internal(
                 checkpoint,
-                &ledger_data,
+                &header_data,
                 &result_hashes,
             ));
         }
 
-        errors.extend(Self::verify_internal_chain(checkpoint, &ledger_data));
-        self.store_boundary(checkpoint, &ledger_data);
+        errors.extend(Self::verify_internal_chain(checkpoint, &header_data));
+        self.store_boundary(checkpoint, &header_data);
 
         if !errors.is_empty() {
             self.errors.lock().unwrap().extend(errors.iter().cloned());
@@ -223,16 +230,16 @@ impl XdrVerificationManager {
         errors
     }
 
-    /// Verify that `ledger_data` covers exactly the ledger sequences expected
+    /// Verify that `header_data` covers exactly the ledger sequences expected
     /// for this checkpoint (per [`expected_ledger_range`]).
     ///
     /// Returns two error kinds:
-    /// - **Unexpected**: ledger entries with sequences outside the expected range
-    /// - **Missing**: ledger sequences in the expected range with no entry
+    /// - **Unexpected**: ledger-header entries with sequences outside the expected range
+    /// - **Missing**: ledger sequences in the expected range with no header entry
     ///   (truncated to the first 5 + a count when more than 10 are missing)
     fn verify_checkpoint_completeness(
         checkpoint: u32,
-        ledger_data: &BTreeMap<u32, LedgerVerificationData>,
+        header_data: &BTreeMap<u32, LedgerHeaderVerificationData>,
     ) -> Vec<VerificationError> {
         let mut errors = Vec::new();
         let (first_ledger, last_ledger) = expected_ledger_range(checkpoint);
@@ -244,7 +251,7 @@ impl XdrVerificationManager {
                 .join(", ")
         };
 
-        let unexpected: Vec<u32> = ledger_data
+        let unexpected: Vec<u32> = header_data
             .keys()
             .copied()
             .filter(|seq| !range.contains(seq))
@@ -252,7 +259,7 @@ impl XdrVerificationManager {
 
         if !unexpected.is_empty() {
             let err_msg = format!(
-                "unexpected ledger entries outside range {first_ledger}-{last_ledger}: {}",
+                "unexpected ledger-header entries outside range {first_ledger}-{last_ledger}: {}",
                 fmt_list(&unexpected),
             );
             error!("Checkpoint {checkpoint}: {err_msg}");
@@ -263,7 +270,7 @@ impl XdrVerificationManager {
             });
         }
 
-        let missing: Vec<u32> = range.filter(|seq| !ledger_data.contains_key(seq)).collect();
+        let missing: Vec<u32> = range.filter(|seq| !header_data.contains_key(seq)).collect();
 
         if !missing.is_empty() {
             let list_str = if missing.len() <= 10 {
@@ -276,7 +283,7 @@ impl XdrVerificationManager {
                 )
             };
             let err_msg = format!(
-                "missing {} of {} ledger entries (ledgers {first_ledger}-{last_ledger}): {list_str}",
+                "missing {} of {} ledger-header entries (ledgers {first_ledger}-{last_ledger}): {list_str}",
                 missing.len(),
                 last_ledger - first_ledger + 1,
             );
@@ -293,7 +300,7 @@ impl XdrVerificationManager {
     /// Cross-verify per-ledger tx-set hashes from the **transactions** file
     /// against the `expected_tx_set_hash` field embedded in the ledger header.
     ///
-    /// For each ledger sequence in `ledger_data`:
+    /// For each ledger sequence in `header_data`:
     /// - **Mismatch**: actual tx-set hash differs from `expected_tx_set_hash`
     /// - **Missing**: no entry in `tx_set_hashes`, *and* the ledger isn't
     ///   genuinely empty. A missing entry is acceptable only when both the
@@ -303,11 +310,11 @@ impl XdrVerificationManager {
     ///   tx-set entries from the transactions file.
     fn verify_tx_set_hashes_internal(
         checkpoint: u32,
-        ledger_data: &BTreeMap<u32, LedgerVerificationData>,
+        header_data: &BTreeMap<u32, LedgerHeaderVerificationData>,
         tx_set_hashes: &HashMap<u32, [u8; 32]>,
     ) -> Vec<VerificationError> {
         let mut errors = Vec::new();
-        for (&seq, data) in ledger_data {
+        for (&seq, data) in header_data {
             let expected = data.expected_tx_set_hash;
 
             let err_msg = if let Some(&actual) = tx_set_hashes.get(&seq) {
@@ -346,18 +353,18 @@ impl XdrVerificationManager {
     /// Cross-verify per-ledger result-set hashes from the **results** file
     /// against the `expected_result_hash` field embedded in the ledger header.
     ///
-    /// For each ledger sequence in `ledger_data`:
+    /// For each ledger sequence in `header_data`:
     /// - **Mismatch**: actual result-set hash differs from `expected_result_hash`
     /// - **Missing**: no entry in `result_hashes` *and* `expected_result_hash`
     ///   is non-zero and not [`EMPTY_XDR_ARRAY_HASH`] (those two values mark
     ///   "no result entry expected" and are tolerated as missing).
     fn verify_result_hashes_internal(
         checkpoint: u32,
-        ledger_data: &BTreeMap<u32, LedgerVerificationData>,
+        header_data: &BTreeMap<u32, LedgerHeaderVerificationData>,
         result_hashes: &HashMap<u32, [u8; 32]>,
     ) -> Vec<VerificationError> {
         let mut errors = Vec::new();
-        for (&seq, data) in ledger_data {
+        for (&seq, data) in header_data {
             let expected = data.expected_result_hash;
 
             let err_msg = if let Some(&actual) = result_hashes.get(&seq) {
@@ -393,7 +400,7 @@ impl XdrVerificationManager {
 
     /// Verify the hash chain *within* a single checkpoint.
     ///
-    /// For each adjacent ledger pair `(prev, curr)` in `ledger_data`:
+    /// For each adjacent ledger pair `(prev, curr)` in `header_data`:
     /// - **Consecutive**: `curr.seq == prev.seq + 1` (else "missing predecessor")
     /// - **Linked**: `curr.prev_hash == prev.computed_hash` (else "hash chain break")
     ///
@@ -402,10 +409,10 @@ impl XdrVerificationManager {
     /// [`verify_checkpoint_chain`](Self::verify_checkpoint_chain).
     fn verify_internal_chain(
         checkpoint: u32,
-        ledger_data: &BTreeMap<u32, LedgerVerificationData>,
+        header_data: &BTreeMap<u32, LedgerHeaderVerificationData>,
     ) -> Vec<VerificationError> {
         let mut errors = Vec::new();
-        let entries: Vec<_> = ledger_data.iter().collect();
+        let entries: Vec<_> = header_data.iter().collect();
 
         for pair in entries.windows(2) {
             let mut err_msg: Option<String> = None;
@@ -455,10 +462,14 @@ impl XdrVerificationManager {
     /// - `last_computed_hash` = last entry's `computed_hash` (the SHA-256 of
     ///   that ledger's header, which the next checkpoint will reference)
     ///
-    /// No-op when `ledger_data` is empty (nothing to bracket).
-    fn store_boundary(&self, checkpoint: u32, ledger_data: &BTreeMap<u32, LedgerVerificationData>) {
+    /// No-op when `header_data` is empty (nothing to bracket).
+    fn store_boundary(
+        &self,
+        checkpoint: u32,
+        header_data: &BTreeMap<u32, LedgerHeaderVerificationData>,
+    ) {
         let (Some((_, first_data)), Some((_, last_data))) =
-            (ledger_data.first_key_value(), ledger_data.last_key_value())
+            (header_data.first_key_value(), header_data.last_key_value())
         else {
             return;
         };
@@ -534,10 +545,10 @@ impl Default for XdrVerificationManager {
 ///
 /// Returns a fatal error on hash mismatch, duplicate sequence, or malformed XDR.
 /// Empty input returns an empty map (valid for checkpoints with no ledger file).
-pub(crate) fn parse_ledger_entries_for_checkpoint(
+pub(crate) fn parse_ledger_header_entries_for_checkpoint(
     decompressed_data: &[u8],
     checkpoint: Option<u32>,
-) -> Result<BTreeMap<u32, LedgerVerificationData>, StorageError> {
+) -> Result<BTreeMap<u32, LedgerHeaderVerificationData>, StorageError> {
     let cursor = Cursor::new(decompressed_data);
     let mut limited = Limited::new(cursor, Limits::none());
     let mut data = BTreeMap::new();
@@ -562,7 +573,7 @@ pub(crate) fn parse_ledger_entries_for_checkpoint(
 
         if data.contains_key(&seq) {
             return Err(StorageError::fatal(format!(
-                "duplicate ledger entry for seq {}",
+                "duplicate ledger-header entry for seq {}",
                 seq
             )));
         }
@@ -598,7 +609,7 @@ pub(crate) fn parse_ledger_entries_for_checkpoint(
 
         data.insert(
             seq,
-            LedgerVerificationData {
+            LedgerHeaderVerificationData {
                 computed_hash,
                 prev_hash,
                 expected_tx_set_hash: tx_set_hash,
@@ -768,12 +779,15 @@ async fn decompress_to_buffer(path: &str, reader: Reader) -> Result<Vec<u8>, Sto
 
 /// Decompress a gzipped ledger file from a reader and parse it.
 /// Infers the checkpoint number from the file path for range validation.
-pub async fn parse_ledger_stream(
+pub async fn parse_ledger_header_stream(
     path: &str,
     reader: Reader,
-) -> Result<BTreeMap<u32, LedgerVerificationData>, StorageError> {
+) -> Result<BTreeMap<u32, LedgerHeaderVerificationData>, StorageError> {
     let decompressed = decompress_to_buffer(path, reader).await?;
-    parse_ledger_entries_for_checkpoint(&decompressed, history_format::checkpoint_from_path(path))
+    parse_ledger_header_entries_for_checkpoint(
+        &decompressed,
+        history_format::checkpoint_from_path(path),
+    )
 }
 
 /// Decompress a gzipped result file from a reader and parse it.
@@ -883,7 +897,7 @@ pub async fn parse_scp_stream(path: &str, reader: Reader) -> Result<(), StorageE
 /// Carries computed hashes for the caller to feed into [`XdrVerificationManager`].
 /// `None` is returned for SCP files and unrecognized file types.
 pub enum XdrParseResult {
-    Ledger(BTreeMap<u32, LedgerVerificationData>),
+    Ledger(BTreeMap<u32, LedgerHeaderVerificationData>),
     Transactions(HashMap<u32, [u8; 32]>),
     Results(HashMap<u32, [u8; 32]>),
     None,
@@ -1078,8 +1092,8 @@ pub async fn verify_and_write_xdr(
             }
         };
 
-    let parse_result = if crate::history_format::is_ledger_file(path) {
-        parse_ledger_entries_for_checkpoint(
+    let parse_result = if crate::history_format::is_ledger_header_file(path) {
+        parse_ledger_header_entries_for_checkpoint(
             &decompressed,
             history_format::checkpoint_from_path(path),
         )

--- a/src/xdr_verify.rs
+++ b/src/xdr_verify.rs
@@ -529,17 +529,11 @@ impl Default for XdrVerificationManager {
 ///
 /// For each frame, verifies `SHA256(header.to_xdr()) == entry.hash` and extracts
 /// the `prev_hash`, `tx_set_hash`, and `result_hash` fields for cross-file checks.
+/// When `checkpoint` is `Some`, also rejects ledger sequences outside the
+/// expected range.
 ///
 /// Returns a fatal error on hash mismatch, duplicate sequence, or malformed XDR.
 /// Empty input returns an empty map (valid for checkpoints with no ledger file).
-pub fn parse_ledger_entries(
-    decompressed_data: &[u8],
-) -> Result<BTreeMap<u32, LedgerVerificationData>, StorageError> {
-    parse_ledger_entries_for_checkpoint(decompressed_data, None)
-}
-
-/// Same as [`parse_ledger_entries`] but additionally rejects ledger sequences
-/// outside the expected range when `checkpoint` is provided.
 pub(crate) fn parse_ledger_entries_for_checkpoint(
     decompressed_data: &[u8],
     checkpoint: Option<u32>,
@@ -702,17 +696,10 @@ pub(crate) fn compute_v1_tx_set_hash(
 
 /// Parse decompressed result XDR data, computing `SHA256(tx_result_set.to_xdr())`
 /// per ledger. These hashes are cross-verified against `expected_result_hash` from
-/// the ledger headers.
+/// the ledger headers. When `checkpoint` is `Some`, rejects ledger sequences
+/// outside the expected range.
 ///
 /// Returns a fatal error on duplicate sequence, out-of-range sequence, or malformed XDR.
-pub fn parse_result_entries(
-    decompressed_data: &[u8],
-) -> Result<HashMap<u32, [u8; 32]>, StorageError> {
-    parse_result_entries_for_checkpoint(decompressed_data, None)
-}
-
-/// Same as [`parse_result_entries`] but additionally rejects ledger sequences
-/// outside the expected range when `checkpoint` is provided.
 pub(crate) fn parse_result_entries_for_checkpoint(
     decompressed_data: &[u8],
     checkpoint: Option<u32>,
@@ -772,10 +759,7 @@ pub(crate) fn parse_result_entries_for_checkpoint(
 
 /// Decompress a gzipped reader into an in-memory `Vec<u8>`. No write side —
 /// thin wrapper over [`decompress_and_write_internal`] with `writer = None`.
-pub(crate) async fn decompress_to_buffer(
-    path: &str,
-    reader: Reader,
-) -> Result<Vec<u8>, StorageError> {
+async fn decompress_to_buffer(path: &str, reader: Reader) -> Result<Vec<u8>, StorageError> {
     // the writer is None, thus the return sink is also None, which is safe to
     // be discarded
     let (decompressed, _) = decompress_and_write_internal(path, reader, None).await?;
@@ -806,17 +790,10 @@ pub async fn parse_results_stream(
 /// V0 entries: `SHA256(prev_hash || tx1_xdr || ... || txN_xdr)`.
 /// V1 entries: `SHA256(GeneralizedTransactionSet.to_xdr())`.
 /// These hashes are cross-verified against `expected_tx_set_hash` from the ledger headers.
+/// When `checkpoint` is `Some`, rejects ledger sequences outside the expected range.
 ///
 /// Returns a fatal error on duplicate sequence, out-of-range sequence, malformed XDR,
 /// or V0 transactions not in hash-sorted order.
-pub fn parse_transaction_entries(
-    decompressed_data: &[u8],
-) -> Result<HashMap<u32, [u8; 32]>, StorageError> {
-    parse_transaction_entries_for_checkpoint(decompressed_data, None)
-}
-
-/// Same as [`parse_transaction_entries`] but additionally rejects ledger
-/// sequences outside the expected range when `checkpoint` is provided.
 pub(crate) fn parse_transaction_entries_for_checkpoint(
     decompressed_data: &[u8],
     checkpoint: Option<u32>,

--- a/src/xdr_verify.rs
+++ b/src/xdr_verify.rs
@@ -36,10 +36,31 @@ use tokio_util::io::StreamReader;
 use tracing::{debug, error, warn};
 
 /// SHA256 hash of empty XDR array \[0,0,0,0\] used for ledgers with no transactions.
-pub(crate) const EMPTY_XDR_ARRAY_HASH: [u8; 32] = [
+pub(crate) const EMPTY_XDR_ARRAY_HASH: Hash = Hash([
     0xdf, 0x3f, 0x61, 0x98, 0x04, 0xa9, 0x2f, 0xdb, 0x40, 0x57, 0x19, 0x2d, 0xc4, 0x3d, 0xd7, 0x48,
     0xea, 0x77, 0x8a, 0xdc, 0x52, 0xbc, 0x49, 0x8c, 0xe8, 0x05, 0x24, 0xc0, 0x14, 0xb8, 0x11, 0x19,
-];
+]);
+
+/// All-zero hash. Used as a sentinel for "no result entry expected."
+const ZERO_HASH: Hash = Hash([0; 32]);
+
+/// SHA-256 of `data` returned as a `stellar_xdr::curr::Hash` (the same newtype
+/// used by ledger headers, tx-set hashes, etc.).
+fn sha256(data: &[u8]) -> Hash {
+    Hash(Sha256::digest(data).into())
+}
+
+/// Extension methods for `stellar_xdr::curr::Hash`.
+pub(crate) trait HashExt {
+    /// Hex-encode the 32 bytes (lowercase, no prefix).
+    fn to_hex(&self) -> String;
+}
+
+impl HashExt for Hash {
+    fn to_hex(&self) -> String {
+        hex::encode(self.0)
+    }
+}
 
 const DECOMPRESS_BUFFER_SIZE: usize = 64 * 1024;
 const CHANNEL_CAPACITY: usize = 64;
@@ -68,29 +89,29 @@ pub(crate) fn expected_ledger_range(checkpoint: u32) -> (u32, u32) {
 #[derive(Debug, Clone)]
 pub struct LedgerHeaderVerificationData {
     /// `SHA256(entry.header.to_xdr())` — verified to equal `entry.hash` at parse time.
-    pub computed_hash: [u8; 32],
+    pub computed_hash: Hash,
     /// `entry.header.previous_ledger_hash` — checked against prior ledger's `computed_hash`
     /// during intra-checkpoint and cross-checkpoint chain verification.
-    pub prev_hash: [u8; 32],
+    pub prev_hash: Hash,
     /// `entry.header.scp_value.tx_set_hash` — cross-verified against the hash computed
     /// from the transaction file for the same ledger sequence.
-    pub expected_tx_set_hash: [u8; 32],
+    pub expected_tx_set_hash: Hash,
     /// `entry.header.tx_set_result_hash` — cross-verified against the hash computed
     /// from the result file for the same ledger sequence.
-    pub expected_result_hash: [u8; 32],
+    pub expected_result_hash: Hash,
 }
 
 #[derive(Default)]
 struct PendingCheckpoint {
     header_data: Option<BTreeMap<u32, LedgerHeaderVerificationData>>,
-    tx_set_hashes: Option<HashMap<u32, [u8; 32]>>,
-    result_hashes: Option<HashMap<u32, [u8; 32]>>,
+    tx_set_hashes: Option<BTreeMap<u32, Hash>>,
+    result_hashes: Option<BTreeMap<u32, Hash>>,
 }
 
 #[derive(Debug, Clone)]
 struct CheckpointBoundary {
-    first_prev_hash: [u8; 32],
-    last_computed_hash: [u8; 32],
+    first_prev_hash: Hash,
+    last_computed_hash: Hash,
 }
 
 /// A verification failure detected during cross-file or chain validation.
@@ -152,7 +173,7 @@ impl XdrVerificationManager {
 
     /// Record per-ledger transaction-set hashes parsed from the **transactions**
     /// file of a checkpoint. See [`record_header_data`](Self::record_header_data).
-    pub fn record_tx_set_hashes(&self, checkpoint: u32, hashes: HashMap<u32, [u8; 32]>) {
+    pub fn record_tx_set_hashes(&self, checkpoint: u32, hashes: BTreeMap<u32, Hash>) {
         let mut pending = self.pending.lock().unwrap();
         let entry = pending.entry(checkpoint).or_default();
         entry.tx_set_hashes = Some(hashes);
@@ -160,7 +181,7 @@ impl XdrVerificationManager {
 
     /// Record per-ledger result-set hashes parsed from the **results** file of
     /// a checkpoint. See [`record_header_data`](Self::record_header_data).
-    pub fn record_result_hashes(&self, checkpoint: u32, hashes: HashMap<u32, [u8; 32]>) {
+    pub fn record_result_hashes(&self, checkpoint: u32, hashes: BTreeMap<u32, Hash>) {
         let mut pending = self.pending.lock().unwrap();
         let entry = pending.entry(checkpoint).or_default();
         entry.result_hashes = Some(hashes);
@@ -311,28 +332,28 @@ impl XdrVerificationManager {
     fn verify_tx_set_hashes_internal(
         checkpoint: u32,
         header_data: &BTreeMap<u32, LedgerHeaderVerificationData>,
-        tx_set_hashes: &HashMap<u32, [u8; 32]>,
+        tx_set_hashes: &BTreeMap<u32, Hash>,
     ) -> Vec<VerificationError> {
         let mut errors = Vec::new();
         for (&seq, data) in header_data {
-            let expected = data.expected_tx_set_hash;
+            let expected = &data.expected_tx_set_hash;
 
-            let err_msg = if let Some(&actual) = tx_set_hashes.get(&seq) {
+            let err_msg = if let Some(actual) = tx_set_hashes.get(&seq) {
                 if actual == expected {
                     None
                 } else {
                     Some(format!(
                         "tx set hash mismatch: expected {}, got {}",
-                        hex::encode(expected),
-                        hex::encode(actual),
+                        expected.to_hex(),
+                        actual.to_hex(),
                     ))
                 }
             } else if data.expected_result_hash != EMPTY_XDR_ARRAY_HASH
-                && !is_empty_tx_set_hash(&expected, &data.prev_hash)
+                && !is_empty_tx_set_hash(expected, &data.prev_hash)
             {
                 Some(format!(
                     "missing tx set entry, expected hash {}",
-                    hex::encode(expected),
+                    expected.to_hex(),
                 ))
             } else {
                 None
@@ -361,26 +382,26 @@ impl XdrVerificationManager {
     fn verify_result_hashes_internal(
         checkpoint: u32,
         header_data: &BTreeMap<u32, LedgerHeaderVerificationData>,
-        result_hashes: &HashMap<u32, [u8; 32]>,
+        result_hashes: &BTreeMap<u32, Hash>,
     ) -> Vec<VerificationError> {
         let mut errors = Vec::new();
         for (&seq, data) in header_data {
-            let expected = data.expected_result_hash;
+            let expected = &data.expected_result_hash;
 
-            let err_msg = if let Some(&actual) = result_hashes.get(&seq) {
+            let err_msg = if let Some(actual) = result_hashes.get(&seq) {
                 if actual == expected {
                     None
                 } else {
                     Some(format!(
                         "result set hash mismatch: expected {}, got {}",
-                        hex::encode(expected),
-                        hex::encode(actual),
+                        expected.to_hex(),
+                        actual.to_hex(),
                     ))
                 }
-            } else if expected != EMPTY_XDR_ARRAY_HASH && expected != [0; 32] {
+            } else if *expected != EMPTY_XDR_ARRAY_HASH && *expected != ZERO_HASH {
                 Some(format!(
                     "missing result entry, expected hash {}",
-                    hex::encode(expected),
+                    expected.to_hex(),
                 ))
             } else {
                 None
@@ -428,9 +449,9 @@ impl XdrVerificationManager {
                 } else if prev_data.computed_hash != data.prev_hash {
                     err_msg = Some(format!(
                         "hash chain break: previous_ledger_hash {} != computed hash of ledger {} ({})",
-                        hex::encode(data.prev_hash),
+                        data.prev_hash.to_hex(),
                         prev_seq,
-                        hex::encode(prev_data.computed_hash),
+                        prev_data.computed_hash.to_hex(),
                     ));
                     ledger_seq = Some(seq);
                 }
@@ -477,8 +498,8 @@ impl XdrVerificationManager {
         self.boundaries.lock().unwrap().insert(
             checkpoint,
             CheckpointBoundary {
-                first_prev_hash: first_data.prev_hash,
-                last_computed_hash: last_data.computed_hash,
+                first_prev_hash: first_data.prev_hash.clone(),
+                last_computed_hash: last_data.computed_hash.clone(),
             },
         );
     }
@@ -508,8 +529,8 @@ impl XdrVerificationManager {
                 let err_msg = format!(
                     "hash chain break between checkpoints {prev_checkpoint} and {curr_checkpoint}: \
                      ledger {first_ledger} prev_hash {} != checkpoint {prev_checkpoint} last hash {}",
-                    hex::encode(curr_boundary.first_prev_hash),
-                    hex::encode(prev_boundary.last_computed_hash),
+                    curr_boundary.first_prev_hash.to_hex(),
+                    prev_boundary.last_computed_hash.to_hex(),
                 );
                 error!("{err_msg}");
                 chain_errors.push(VerificationError {
@@ -585,35 +606,27 @@ pub(crate) fn parse_ledger_header_entries_for_checkpoint(
             ))
         })?;
 
-        let computed_hash: [u8; 32] = Sha256::digest(&header_xdr).into();
-        let expected_hash: [u8; 32] = entry.hash.0;
+        let computed_hash = sha256(&header_xdr);
+        let expected_hash = entry.hash;
 
         if computed_hash != expected_hash {
             return Err(StorageError::fatal(format!(
                 "ledger header hash mismatch at seq {}: expected {}, computed {}",
                 seq,
-                hex::encode(expected_hash),
-                hex::encode(computed_hash)
+                expected_hash.to_hex(),
+                computed_hash.to_hex()
             )));
         }
 
-        debug!(
-            "Verified ledger {} hash: {}",
-            seq,
-            hex::encode(computed_hash)
-        );
-
-        let prev_hash: [u8; 32] = entry.header.previous_ledger_hash.0;
-        let tx_set_hash: [u8; 32] = entry.header.scp_value.tx_set_hash.0;
-        let result_hash: [u8; 32] = entry.header.tx_set_result_hash.0;
+        debug!("Verified ledger {} hash: {}", seq, computed_hash.to_hex());
 
         data.insert(
             seq,
             LedgerHeaderVerificationData {
                 computed_hash,
-                prev_hash,
-                expected_tx_set_hash: tx_set_hash,
-                expected_result_hash: result_hash,
+                prev_hash: entry.header.previous_ledger_hash,
+                expected_tx_set_hash: entry.header.scp_value.tx_set_hash,
+                expected_result_hash: entry.header.tx_set_result_hash,
             },
         );
     }
@@ -623,35 +636,35 @@ pub(crate) fn parse_ledger_header_entries_for_checkpoint(
 
 /// Hash of an empty V0 `TransactionSet`: `SHA256(previous_ledger_hash)` —
 /// equivalent to the V0 hash recipe with zero transactions concatenated.
-pub(crate) fn compute_empty_v0_tx_set_hash(previous_ledger_hash: &[u8; 32]) -> [u8; 32] {
-    Sha256::digest(previous_ledger_hash).into()
+pub(crate) fn compute_empty_v0_tx_set_hash(previous_ledger_hash: &Hash) -> Hash {
+    sha256(&previous_ledger_hash.0)
 }
 
 /// Hash of an empty V1 `GeneralizedTransactionSet`: SHA-256 of the
 /// XDR-serialized struct with `previous_ledger_hash` set and no phases.
-pub(crate) fn compute_empty_v1_tx_set_hash(previous_ledger_hash: &[u8; 32]) -> [u8; 32] {
+pub(crate) fn compute_empty_v1_tx_set_hash(previous_ledger_hash: &Hash) -> Hash {
     let empty_v1 = GeneralizedTransactionSet::V1(TransactionSetV1 {
-        previous_ledger_hash: Hash(*previous_ledger_hash),
+        previous_ledger_hash: previous_ledger_hash.clone(),
         phases: VecM::default(),
     });
     let xdr = empty_v1
         .to_xdr(Limits::none())
         .expect("serializing empty GeneralizedTransactionSet should not fail");
-    Sha256::digest(&xdr).into()
+    sha256(&xdr)
 }
 
 /// Whether `expected` is one of the recognized "no transactions in this ledger"
 /// markers, given the ledger's `prev_hash`.
 ///
 /// Treated as empty if `expected` matches any of:
-/// - all-zero hash (`[0; 32]`)
+/// - all-zero hash ([`ZERO_HASH`])
 /// - [`compute_empty_v0_tx_set_hash`]`(prev_hash)` — empty V0 set
 /// - [`compute_empty_v1_tx_set_hash`]`(prev_hash)` — empty V1 set
 ///
 /// Used by [`verify_tx_set_hashes_internal`](XdrVerificationManager::verify_tx_set_hashes_internal)
 /// to decide whether a missing transactions-file entry is acceptable.
-pub(crate) fn is_empty_tx_set_hash(expected: &[u8; 32], prev_hash: &[u8; 32]) -> bool {
-    *expected == [0; 32]
+pub(crate) fn is_empty_tx_set_hash(expected: &Hash, prev_hash: &Hash) -> bool {
+    *expected == ZERO_HASH
         || *expected == compute_empty_v0_tx_set_hash(prev_hash)
         || *expected == compute_empty_v1_tx_set_hash(prev_hash)
 }
@@ -664,13 +677,13 @@ pub(crate) fn is_empty_tx_set_hash(expected: &[u8; 32], prev_hash: &[u8; 32]) ->
 /// This matches stellar-core's `computeNonGeneralizedTxSetContentsHash()`.
 pub(crate) fn compute_v0_tx_set_hash(
     tx_set: &stellar_xdr::curr::TransactionSet,
-) -> Result<[u8; 32], StorageError> {
+) -> Result<Hash, StorageError> {
     let mut serialized_txs = Vec::with_capacity(tx_set.txs.len());
     for tx in tx_set.txs.iter() {
         let tx_xdr = tx.to_xdr(Limits::none()).map_err(|e| {
             StorageError::fatal(format!("failed to serialize TransactionEnvelope: {}", e))
         })?;
-        let tx_hash: [u8; 32] = Sha256::digest(&tx_xdr).into();
+        let tx_hash = sha256(&tx_xdr);
         serialized_txs.push((tx_hash, tx_xdr));
     }
 
@@ -685,7 +698,7 @@ pub(crate) fn compute_v0_tx_set_hash(
     for (_, tx_xdr) in serialized_txs {
         hasher.update(&tx_xdr);
     }
-    Ok(hasher.finalize().into())
+    Ok(Hash(hasher.finalize().into()))
 }
 
 /// Compute the hash of a V1 GeneralizedTransactionSet.
@@ -694,7 +707,7 @@ pub(crate) fn compute_v0_tx_set_hash(
 /// This matches stellar-core's `xdrSha256(xdrTxSet)`.
 pub(crate) fn compute_v1_tx_set_hash(
     generalized_tx_set: &stellar_xdr::curr::GeneralizedTransactionSet,
-) -> Result<[u8; 32], StorageError> {
+) -> Result<Hash, StorageError> {
     let xdr = generalized_tx_set.to_xdr(Limits::none()).map_err(|e| {
         StorageError::fatal(format!(
             "failed to serialize GeneralizedTransactionSet: {}",
@@ -702,7 +715,7 @@ pub(crate) fn compute_v1_tx_set_hash(
         ))
     })?;
 
-    Ok(Sha256::digest(&xdr).into())
+    Ok(sha256(&xdr))
 }
 
 /// Parse decompressed result XDR data, computing `SHA256(tx_result_set.to_xdr())`
@@ -714,10 +727,10 @@ pub(crate) fn compute_v1_tx_set_hash(
 pub(crate) fn parse_result_entries_for_checkpoint(
     decompressed_data: &[u8],
     checkpoint: Option<u32>,
-) -> Result<HashMap<u32, [u8; 32]>, StorageError> {
+) -> Result<BTreeMap<u32, Hash>, StorageError> {
     let cursor = Cursor::new(decompressed_data);
     let mut limited = Limited::new(cursor, Limits::none());
-    let mut hashes = HashMap::new();
+    let mut hashes = BTreeMap::new();
 
     let expected_range = checkpoint.map(expected_ledger_range);
 
@@ -754,12 +767,12 @@ pub(crate) fn parse_result_entries_for_checkpoint(
             ))
         })?;
 
-        let computed_hash: [u8; 32] = Sha256::digest(&result_xdr).into();
+        let computed_hash = sha256(&result_xdr);
 
         debug!(
             "Computed result hash for ledger {}: {}",
             seq,
-            hex::encode(computed_hash)
+            computed_hash.to_hex()
         );
 
         hashes.insert(seq, computed_hash);
@@ -795,7 +808,7 @@ pub async fn parse_ledger_header_stream(
 pub async fn parse_results_stream(
     path: &str,
     reader: Reader,
-) -> Result<HashMap<u32, [u8; 32]>, StorageError> {
+) -> Result<BTreeMap<u32, Hash>, StorageError> {
     let decompressed = decompress_to_buffer(path, reader).await?;
     parse_result_entries_for_checkpoint(&decompressed, history_format::checkpoint_from_path(path))
 }
@@ -811,10 +824,10 @@ pub async fn parse_results_stream(
 pub(crate) fn parse_transaction_entries_for_checkpoint(
     decompressed_data: &[u8],
     checkpoint: Option<u32>,
-) -> Result<HashMap<u32, [u8; 32]>, StorageError> {
+) -> Result<BTreeMap<u32, Hash>, StorageError> {
     let cursor = Cursor::new(decompressed_data);
     let mut limited = Limited::new(cursor, Limits::none());
-    let mut hashes = HashMap::new();
+    let mut hashes = BTreeMap::new();
 
     let expected_range = checkpoint.map(expected_ledger_range);
 
@@ -851,7 +864,7 @@ pub(crate) fn parse_transaction_entries_for_checkpoint(
         debug!(
             "Computed tx set hash for ledger {}: {}",
             seq,
-            hex::encode(computed_hash)
+            computed_hash.to_hex()
         );
 
         hashes.insert(seq, computed_hash);
@@ -879,7 +892,7 @@ pub fn parse_scp_entries(decompressed_data: &[u8]) -> Result<(), StorageError> {
 pub async fn parse_transactions_stream(
     path: &str,
     reader: Reader,
-) -> Result<HashMap<u32, [u8; 32]>, StorageError> {
+) -> Result<BTreeMap<u32, Hash>, StorageError> {
     let decompressed = decompress_to_buffer(path, reader).await?;
     parse_transaction_entries_for_checkpoint(
         &decompressed,
@@ -898,8 +911,8 @@ pub async fn parse_scp_stream(path: &str, reader: Reader) -> Result<(), StorageE
 /// `None` is returned for SCP files and unrecognized file types.
 pub enum XdrParseResult {
     Ledger(BTreeMap<u32, LedgerHeaderVerificationData>),
-    Transactions(HashMap<u32, [u8; 32]>),
-    Results(HashMap<u32, [u8; 32]>),
+    Transactions(BTreeMap<u32, Hash>),
+    Results(BTreeMap<u32, Hash>),
     None,
 }
 


### PR DESCRIPTION
resolves #11. the repair mode change is in the last commit. rest is cleanup and refactor change in https://github.com/stellar/rs-stellar-archivist/pull/19 (to be merged first). splitting them up for easier review.

### What 

Adds a repair mode that detects and fixes corrupted or missing files in a local Stellar History Archive by re-fetching from a known-good source.
                                                                                             
  `stellar-archivist repair [--low N] [--high N] [--verify] [--dry-run] [--files list.json]`
                                                                                             
### How it works

Adds a new `RepairOperation` that extends the `Operation` trait. 
Repair mode is driven by the standard `Pipeline`. 
-  Per-file (`process_object`): try dst first — open reader, parse XDR or verify bucket hash. If missing or corrupt, fetch from src.
- Cross-file / cross-checkpoint (only with `--verify`):
  - `finalize_checkpoint` runs per-checkpoint cross-file checks, and queues failing checkpoints for retry
  - `finalize` runs `verify_checkpoint_chain`; any chain break queues **both ends** for retry
- Retry phase (`run_retry`): concurrently process all queued checkpoints, using `pipeline::process_checkpoint` with `MirrorOperation` ( pure copy from src as canonical)
- `.well-known` repair**: if dst's `.well-known/stellar-history.json` is unreadable, fall back to src for bounds; after retry, copy the highest checkpoint's `history-*.json` back into place.                                                                                
                  
**Manual mode** (`--files list.json`): download a JSON array of paths directly, bypassing checkpoint iteration, bucket discovery, the manager, and retry.

**Dry-run** (`--dry-run`): count files that would be fetched and checkpoints that would retry; output them, no writes.



