### PR TITLE
Repair mode follow-up: structured failure tracking, JSON plan/report, and plan-driven repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,86 @@ stellar-archivist mirror https://history.stellar.org/prd/core-testnet/core_testn
 stellar-archivist mirror https://history.stellar.org/prd/core-testnet/core_testnet_001 file:///local/mirror --skip-optional
 ```
 
+### Which mode should I use?
+
+Three subcommands, three jobs:
+
+- **`scan`** — *audit* an archive. Read-only: checks every expected file is
+  present and, with `--verify`, internally valid (XDR structure;
+  ledger/transaction/result hashes; hash-chain continuity; bucket SHA-256).
+  Never writes.
+- **`mirror`** — *build or sync* a local copy of an archive. Copies
+  source → destination, incrementally.
+- **`repair`** — *fix* a damaged local archive against a known-good source.
+  Re-fetches only the broken files.
+
+#### `mirror`: existence, `--overwrite`, and `--verify`
+
+These interact, and the order matters:
+
+1. **Existence + `--overwrite`** decide *whether mirror touches a file at all*.
+   A file already on the destination is **skipped** unless `--overwrite` is set;
+   a missing file is always fetched.
+2. **`--verify`** decides *how* mirror copies a file it does fetch: it validates
+   the **source** content as it streams it to the destination.
+
+| Destination has the file? | `--overwrite` | mirror does | `--verify` validates |
+|---|---|---|---|
+| yes | no (default) | **skips it** | nothing — the file is left untouched |
+| yes | yes | re-fetches and overwrites | the source content |
+| no | either | fetches | the source content |
+
+**`mirror --verify` validates the source bytes it copies, never the files
+already on the destination.** Under the default (`--overwrite` off), a
+corrupt-but-present file on the destination is skipped and never checked — so
+`mirror --verify` is *not* a way to audit a destination's health.
+
+**`mirror --verify --overwrite` is a brute-force *resync*, not an audit or a
+dry-run.** It re-fetches the whole range and overwrites the destination
+(validating the *source* as it copies), so its report reflects source/write
+failures, never destination health — a corrupt-but-present file on the
+destination is silently overwritten, not reported. To *inspect* a destination,
+use `scan`/`repair` (below); to *fix* one surgically, use `repair`.
+
+#### Auditing a destination's health: use `scan` or `repair`, not `mirror`
+
+To answer "is my local archive complete and valid?":
+
+- `scan --verify <local>` — read-only audit; reports missing and corrupt files.
+  (Requires the archive's `.well-known` to be intact, since it derives the
+  checkpoint range from it.)
+- `repair --verify --dry-run <src> <local> --report plan.json` — the same audit,
+  but it also tolerates a **damaged `.well-known`** (it falls back to the source
+  for the range and flags `.well-known` for restoration), and the report doubles
+  as a repair plan.
+
+Use these — not `mirror --verify` — because mirror skips, and so never checks,
+files already present on the destination.
+
+#### Recommended workflows
+
+- **Build or sync a mirror:** `mirror <src> <dst>` — add `--overwrite` to
+  force-refresh existing files, `--verify` to validate as you copy.
+- **Fix a damaged archive (one shot):** `repair --verify <src> <dst>`.
+- **Inspect, then fix:** `repair --verify --dry-run <src> <dst> --report plan.json`
+  → review `plan.json` → `repair --verify <src> <dst> --plan plan.json`.
+- **Audit with scan, fix with repair:**
+  `scan --verify <dst> --report findings.json` → `repair --verify <src> <dst> --plan findings.json`.
+- **Retry a failed mirror:** `mirror <src> <dst> --report mirror.json`
+  → `repair --plan mirror.json` (optionally against a better source).
+
+A `--report` from any of `scan`, `mirror`, or `repair --dry-run` is a valid
+`repair --plan` input — they share one schema. `--verify` works exactly as in a
+regular repair (it validates the downloaded content and content-checks files
+discovered during the repair).
+
 ### Repair an archive
 
 Repair fixes a **local** archive in place by re-fetching broken or
 missing files from a **known-good source** archive. It tries the local
-copy first and only fetches from the source what is actually broken.
+copy first and only fetches from the source what is actually broken
+(when applying a plan, listed items are re-fetched directly — see
+"Dry-run and plans" below).
 
 ```bash
 # Repair a local archive against a source (existence-only: restores missing files)
@@ -71,15 +146,26 @@ then apply it:
 # 1. Inspect: write a plan of what is broken (no writes)
 stellar-archivist repair https://src/... file:///local/archive --verify --dry-run --report plan.json
 
-# 2. Apply the plan verbatim
-stellar-archivist repair https://src/... file:///local/archive --plan plan.json
+# 2. Apply the plan verbatim (--verify validates the downloads, same as in a regular repair)
+stellar-archivist repair https://src/... file:///local/archive --verify --plan plan.json
 ```
 
 `--plan` cannot be combined with `--low`, `--high`, or `--dry-run` — the
 plan already defines the scope.
 
+Applying a plan re-fetches every listed item from the source
+unconditionally**: the plan is trusted, and the destination is not
+re-audited (no per-item existence check or content re-verification). A
+stale plan therefore re-downloads items that have since been fixed — and
+fails if the source no longer has them. Items not listed in the plan are
+left untouched, except that buckets referenced by a listed history file
+are checked on the destination and fetched only if missing or invalid. To
+re-audit the destination instead of trusting an old plan, generate a
+fresh one with `--dry-run`.
+
 **Status reports.** `--report <file>` writes a JSON status file for any
-operation (scan, mirror, or repair), not just dry-runs.
+operation (scan, mirror, or repair). Any such report is also a valid
+`repair --plan` input — see "Which mode should I use?" above.
 
 ```bash
 stellar-archivist scan https://history.stellar.org/... --verify --report status.json
@@ -121,17 +207,28 @@ stellar-archivist scan https://history.stellar.org/... --verify --report status.
 
 #### Verification scope
 
-With `--verify`, every re-fetched file is checked to the same standard as
-`scan --verify` (XDR structure, ledger/transaction/result hashes,
-hash-chain continuity, and bucket SHA-256) **before** it is committed, so
-corrupt source content is rejected rather than written. Two limitations
-remain:
+With `--verify`, content is checked in two tiers, which commit at different
+times:
 
-1. Without `--verify`, repair only checks that files *exist* — it cannot
-   detect a file that is present but corrupt.
-2. Even with `--verify`, repair trusts a source that passes verification
-   as canonical; it validates internal integrity but does not
-   independently re-verify its own writes after the run.
+- **Per-file, before writing.** Each file's own content — XDR structure, its
+  self-hash, bucket SHA-256 — is validated as it streams from the source, so a
+  file that is corrupt *in itself* is rejected and never written.
+- **Cross-file and cross-checkpoint, after writing.** Whether individually-valid
+  files *agree* — a ledger's transaction-set / result hash matching the
+  transactions / results file, and hash-chain continuity across ledgers and
+  checkpoints — is checked only *after* those files have been written. So a
+  cross-file/chain failure means files that each passed their own check were
+  committed but are mutually inconsistent. The run reports failure, and (for
+  `mirror`) the destination is left holding those inconsistent files — re-run
+  `repair --verify` against a known-good source to reconcile them.
+
+Two further limitations:
+
+1. Without `--verify`, scan/mirror/repair only check that files *exist* — they
+   cannot detect a file that is present but corrupt.
+2. Even with `--verify`, repair trusts a source that passes verification as
+   canonical; it validates internal integrity but does not independently
+   re-verify its own writes after the run.
 
 ### Command-line options
 
@@ -143,7 +240,7 @@ remain:
 - `--report <file>`: Write a JSON status report (or, for `repair --dry-run`, a plan)
 - `--overwrite`: Overwrite existing files when mirroring
 - `--allow-mirror-gaps`: Allow creating gaps in destination archive
-- `--plan <file>` (repair only): Apply a JSON plan from a prior `--dry-run`; mutually exclusive with `--low`/`--high`/`--dry-run`
+- `--plan <file>` (repair only): Apply a JSON plan from a prior `--dry-run`, or any `scan`/`mirror` `--report`. Every listed item is re-fetched unconditionally; `--verify` works as in a regular repair (validates downloaded content). Mutually exclusive with `--low`/`--high`/`--dry-run`
 - `--dry-run` (repair only): Report what would be repaired without writing
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Rust implementation of tools for working with Stellar History Archives.
 
 ## Description
 
-Stellar Archivist provides utilities to scan and mirror Stellar History Archives. It supports both HTTP/HTTPS and filesystem sources, allowing you to verify archive integrity and create local mirrors of remote archives.
+Stellar Archivist provides utilities to scan, mirror, and repair Stellar History Archives. It supports both HTTP/HTTPS and filesystem sources, allowing you to verify archive integrity, create local mirrors of remote archives, and repair a local archive against a known-good source.
 
 ## Usage
 
@@ -46,14 +46,105 @@ stellar-archivist mirror https://history.stellar.org/prd/core-testnet/core_testn
 stellar-archivist mirror https://history.stellar.org/prd/core-testnet/core_testnet_001 file:///local/mirror --skip-optional
 ```
 
+### Repair an archive
+
+Repair fixes a **local** archive in place by re-fetching broken or
+missing files from a **known-good source** archive. It tries the local
+copy first and only fetches from the source what is actually broken.
+
+```bash
+# Repair a local archive against a source (existence-only: restores missing files)
+stellar-archivist repair https://history.stellar.org/prd/core-testnet/core_testnet_001 file:///local/archive
+
+# Repair with full verification (detects corrupt-but-present files, not just missing ones)
+stellar-archivist repair https://history.stellar.org/... file:///local/archive --verify
+
+# Repair only a range
+stellar-archivist repair https://history.stellar.org/... file:///local/archive --low 1000 --high 5000
+```
+
+**Dry-run and plans.** A dry-run writes a JSON **plan** of everything it
+would repair, without touching the archive. You can review the plan and
+then apply it:
+
+```bash
+# 1. Inspect: write a plan of what is broken (no writes)
+stellar-archivist repair https://src/... file:///local/archive --verify --dry-run --report plan.json
+
+# 2. Apply the plan verbatim
+stellar-archivist repair https://src/... file:///local/archive --plan plan.json
+```
+
+`--plan` cannot be combined with `--low`, `--high`, or `--dry-run` — the
+plan already defines the scope.
+
+**Status reports.** `--report <file>` writes a JSON status file for any
+operation (scan, mirror, or repair), not just dry-runs.
+
+```bash
+stellar-archivist scan https://history.stellar.org/... --verify --report status.json
+```
+
+#### Plan / report JSON
+
+```jsonc
+{
+  "version": 1,
+  "well_known": 16383,                              // see below; null when healthy
+  "files": { "127": ["ledger", "transactions"] },   // checkpoint -> broken file types
+  "buckets": ["ab…ef"],                             // bucket content hashes (64 hex)
+  "checkpoints": [191],                              // cross-file / chain failures
+  "summary": { "succeeded": 0, "skipped": 0, "failed": 3, "retries": 0 }
+}
+```
+
+- **`version`** — schema version (currently `1`).
+- **`well_known`** — the checkpoint number that
+  `.well-known/stellar-history.json` should be restored from when that
+  root file is missing or corrupt; `null` when it is healthy.
+- **`files`** — a map from **checkpoint number** (as a string) to that
+  checkpoint's broken per-checkpoint file types (`history`, `ledger`,
+  `transactions`, `results`, `scp`). For example `"127": ["ledger"]`
+  means the ledger file at checkpoint 127 is missing or corrupt.
+- **`buckets`** — content hashes (64-hex) of bucket files that are
+  missing or fail their SHA-256 check.
+- **`checkpoints`** — checkpoints whose files each parse individually but
+  fail *cross-file* checks (a ledger's transaction-set or result hash not
+  matching the transactions/results file) or *hash-chain* checks (a break
+  in the ledger-to-ledger chain). Unlike `files` (individually broken
+  files), these are re-fetched whole. A checkpoint here means "the pieces
+  look individually valid but don't agree with each other."
+- **`summary`** — outcome counters (`succeeded` / `skipped` / `failed` =
+  file + bucket failures / `retries`). A non-dry-run repair instead emits
+  a multi-section report keyed by stage (`main_pass`, `file_retry`,
+  `checkpoint_retry`), each section having this same shape.
+
+#### Verification scope
+
+With `--verify`, every re-fetched file is checked to the same standard as
+`scan --verify` (XDR structure, ledger/transaction/result hashes,
+hash-chain continuity, and bucket SHA-256) **before** it is committed, so
+corrupt source content is rejected rather than written. Two limitations
+remain:
+
+1. Without `--verify`, repair only checks that files *exist* — it cannot
+   detect a file that is present but corrupt.
+2. Even with `--verify`, repair trusts a source that passes verification
+   as canonical; it validates internal integrity but does not
+   independently re-verify its own writes after the run.
+
 ### Command-line options
 
 - `-c, --concurrency N`: Number of concurrent workers (default: 32)
 - `--skip-optional`: Skip optional files (scp)
 - `--low N`: Start from ledger N
 - `--high N`: Stop at checkpoint N
+- `--verify`: Verify content (XDR structure, hashes, chain continuity, bucket SHA-256), not just existence
+- `--report <file>`: Write a JSON status report (or, for `repair --dry-run`, a plan)
 - `--overwrite`: Overwrite existing files when mirroring
 - `--allow-mirror-gaps`: Allow creating gaps in destination archive
+- `--plan <file>` (repair only): Apply a JSON plan from a prior `--dry-run`; mutually exclusive with `--low`/`--high`/`--dry-run`
+- `--dry-run` (repair only): Report what would be repaired without writing
 
 ## Architecture
 
@@ -79,9 +170,10 @@ Operations implement the `Operation` trait (`pipeline.rs:48-102`) and define wha
 - `record_success/failure/retry/skipped()`: Track statistics
 - `finalize()`: Complete the operation and report results
 
-Two operations are implemented:
-- **ScanOperation** (`scan_operation.rs`): Validates that files exist in the archive
+Three operations are implemented:
+- **ScanOperation** (`scan_operation.rs`): Validates that files exist in the archive (optionally verifying content)
 - **MirrorOperation** (`mirror_operation.rs`): Copies files from source to destination
+- **RepairOperation** (`repair_operation.rs`): Fixes a local archive in place by re-fetching broken/missing files from a known-good source
 
 ### Storage
 

--- a/src/cli/mirror.rs
+++ b/src/cli/mirror.rs
@@ -70,7 +70,13 @@ impl MirrorCmd {
             storage_config: args.storage_config,
         };
 
-        let pipeline = Pipeline::new(operation, pipeline_config, src_store, Some(dst_store));
+        let pipeline = Pipeline::new(
+            operation,
+            pipeline_config,
+            src_store,
+            Some(dst_store),
+            args.report_path,
+        );
 
         pipeline.run().await.map_err(utils::map_pipeline_error)?;
 

--- a/src/cli/mirror.rs
+++ b/src/cli/mirror.rs
@@ -61,7 +61,8 @@ impl MirrorCmd {
         };
 
         let operation = MirrorOperation::new(
-            dst_store.clone(),
+            src_store,
+            dst_store,
             self.overwrite,
             self.low,
             self.high,
@@ -70,13 +71,7 @@ impl MirrorCmd {
             /*update_well_known=*/ true,
         );
 
-        let pipeline = Pipeline::new(
-            operation,
-            pipeline_config,
-            src_store,
-            Some(dst_store),
-            args.report_path,
-        );
+        let pipeline = Pipeline::new(operation, pipeline_config, args.report_path);
 
         pipeline.run().await.map_err(utils::map_pipeline_error)?;
 

--- a/src/cli/mirror.rs
+++ b/src/cli/mirror.rs
@@ -52,16 +52,6 @@ impl MirrorCmd {
             )));
         }
 
-        let operation = MirrorOperation::new(
-            dst_store.clone(),
-            self.overwrite,
-            self.low,
-            self.high,
-            self.allow_mirror_gaps,
-            &args.storage_config,
-            /*update_well_known=*/ true,
-        );
-
         let pipeline_config = PipelineConfig {
             concurrency: args.concurrency,
             skip_optional: args.skip_optional,
@@ -69,6 +59,16 @@ impl MirrorCmd {
             verify: args.verify,
             storage_config: args.storage_config,
         };
+
+        let operation = MirrorOperation::new(
+            dst_store.clone(),
+            self.overwrite,
+            self.low,
+            self.high,
+            self.allow_mirror_gaps,
+            pipeline_config.clone(),
+            /*update_well_known=*/ true,
+        );
 
         let pipeline = Pipeline::new(
             operation,

--- a/src/cli/mirror.rs
+++ b/src/cli/mirror.rs
@@ -65,6 +65,7 @@ impl MirrorCmd {
         let pipeline_config = PipelineConfig {
             concurrency: args.concurrency,
             skip_optional: args.skip_optional,
+            skip_history_and_buckets: false,
             verify: args.verify,
             storage_config: args.storage_config,
         };

--- a/src/cli/mirror.rs
+++ b/src/cli/mirror.rs
@@ -59,12 +59,13 @@ impl MirrorCmd {
             self.high,
             self.allow_mirror_gaps,
             &args.storage_config,
-            args.verify,
+            /*update_well_known=*/ true,
         );
 
         let pipeline_config = PipelineConfig {
             concurrency: args.concurrency,
             skip_optional: args.skip_optional,
+            verify: args.verify,
             storage_config: args.storage_config,
         };
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -103,6 +103,10 @@ struct Cli {
     /// Verify SHA256 hash of bucket files by decompressing and hashing content
     #[arg(long, global = true)]
     verify: bool,
+
+    /// Write a JSON status report to this local path
+    #[arg(long, global = true)]
+    report: Option<std::path::PathBuf>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -122,6 +126,7 @@ pub struct GlobalArgs {
     pub skip_optional: bool,
     pub storage_config: StorageConfig,
     pub verify: bool,
+    pub report_path: Option<std::path::PathBuf>,
 }
 
 /// Run the CLI with the given arguments
@@ -167,6 +172,7 @@ where
             cli.atomic_file_writes,
         ),
         verify: cli.verify,
+        report_path: cli.report,
     };
 
     match cli.command {

--- a/src/cli/repair.rs
+++ b/src/cli/repair.rs
@@ -24,9 +24,10 @@ pub struct RepairCmd {
     #[arg(long)]
     pub high: Option<u32>,
 
-    /// JSON file listing specific file paths to repair (manual mode)
+    /// JSON plan (from a prior --dry-run) listing the broken files, buckets,
+    /// and checkpoints to repair. Cannot be combined with --low/--high/--dry-run.
     #[arg(long)]
-    pub files: Option<PathBuf>,
+    pub plan: Option<PathBuf>,
 
     /// Show what would be repaired without downloading
     #[arg(long)]
@@ -40,25 +41,11 @@ impl RepairCmd {
             self.src, self.dst, args.concurrency
         );
 
-        // Parse manual file list if provided
-        let file_list = if let Some(ref path) = self.files {
-            let content = std::fs::read_to_string(path).map_err(|e| {
-                Error::Other(format!(
-                    "Failed to read file list from {}: {}",
-                    path.display(),
-                    e
-                ))
-            })?;
-            let list = crate::repair_operation::parse_file_list_json(&content)?;
-            info!(
-                "Manual mode: {} files to repair from {}",
-                list.len(),
-                path.display()
-            );
-            Some(list)
-        } else {
-            None
-        };
+        if self.plan.is_some() && (self.low.is_some() || self.high.is_some() || self.dry_run) {
+            return Err(Error::Other(
+                "--plan cannot be combined with --low/--high/--dry-run".to_string(),
+            ));
+        }
 
         let src_store = storage::from_url_with_config(&self.src, &args.storage_config)
             .map_err(|e| Error::Other(format!("Failed to create source backend: {e}")))?;
@@ -89,8 +76,18 @@ impl RepairCmd {
             pipeline_config.clone(),
         );
 
-        if let Some(files) = file_list {
-            operation.run_manual(&files).await?;
+        if let Some(ref plan_path) = self.plan {
+            let report = crate::report::read_from_path(plan_path).map_err(|e| {
+                Error::Other(format!(
+                    "Failed to read plan from {}: {}",
+                    plan_path.display(),
+                    e
+                ))
+            })?;
+            info!("Plan mode: applying {}", plan_path.display());
+            operation
+                .run_manual(report, args.report_path.as_deref())
+                .await?;
             return Ok(());
         }
 

--- a/src/cli/repair.rs
+++ b/src/cli/repair.rs
@@ -73,29 +73,25 @@ impl RepairCmd {
             )));
         }
 
-        let operation = RepairOperation::new(
-            src_store.clone(),
-            dst_store.clone(),
-            self.low,
-            self.high,
-            args.verify,
-            self.dry_run,
-            args.concurrency,
-            args.skip_optional,
-            &args.storage_config,
-        );
-
-        if let Some(files) = file_list {
-            operation.run_manual(&files).await?;
-            return Ok(());
-        }
-
         let pipeline_config = PipelineConfig {
             concurrency: args.concurrency,
             skip_optional: args.skip_optional,
             verify: args.verify,
             storage_config: args.storage_config,
         };
+        let operation = RepairOperation::new(
+            src_store.clone(),
+            dst_store.clone(),
+            self.low,
+            self.high,
+            self.dry_run,
+            pipeline_config.clone(),
+        );
+
+        if let Some(files) = file_list {
+            operation.run_manual(&files).await?;
+            return Ok(());
+        }
 
         let pipeline = Pipeline::new(operation, pipeline_config, src_store, Some(dst_store));
 

--- a/src/cli/repair.rs
+++ b/src/cli/repair.rs
@@ -94,7 +94,13 @@ impl RepairCmd {
             return Ok(());
         }
 
-        let pipeline = Pipeline::new(operation, pipeline_config, src_store, Some(dst_store));
+        let pipeline = Pipeline::new(
+            operation,
+            pipeline_config,
+            src_store,
+            Some(dst_store),
+            args.report_path,
+        );
 
         pipeline.run().await.map_err(utils::map_pipeline_error)?;
 

--- a/src/cli/repair.rs
+++ b/src/cli/repair.rs
@@ -76,6 +76,7 @@ impl RepairCmd {
         let pipeline_config = PipelineConfig {
             concurrency: args.concurrency,
             skip_optional: args.skip_optional,
+            skip_history_and_buckets: false,
             verify: args.verify,
             storage_config: args.storage_config,
         };

--- a/src/cli/repair.rs
+++ b/src/cli/repair.rs
@@ -89,8 +89,8 @@ impl RepairCmd {
         // Build the operation once; the pipeline path reuses the stores/config,
         // so the operation takes clones.
         let operation = RepairOperation::new(
-            src_store.clone(),
-            dst_store.clone(),
+            src_store,
+            dst_store,
             self.low,
             self.high,
             self.dry_run,
@@ -102,13 +102,7 @@ impl RepairCmd {
                 .run_manual(plan, args.report_path.as_deref())
                 .await?;
         } else {
-            let pipeline = Pipeline::new(
-                operation,
-                pipeline_config,
-                src_store,
-                Some(dst_store),
-                args.report_path,
-            );
+            let pipeline = Pipeline::new(operation, pipeline_config, args.report_path);
             pipeline.run().await.map_err(utils::map_pipeline_error)?;
         }
 

--- a/src/cli/repair.rs
+++ b/src/cli/repair.rs
@@ -93,6 +93,7 @@ impl RepairCmd {
         let pipeline_config = PipelineConfig {
             concurrency: args.concurrency,
             skip_optional: args.skip_optional,
+            verify: args.verify,
             storage_config: args.storage_config,
         };
 

--- a/src/cli/repair.rs
+++ b/src/cli/repair.rs
@@ -67,6 +67,27 @@ impl RepairCmd {
             verify: args.verify,
             storage_config: args.storage_config,
         };
+
+        // Read the plan up front (if any); the `Option` doubles as the mode flag
+        // below. `--verify` works exactly as in regular repair: it governs
+        // validation of downloaded content and the dst probing of discovered
+        // files (listed items are re-fetched unconditionally either way).
+        let plan = if let Some(ref plan_path) = self.plan {
+            info!("Plan mode: applying {}", plan_path.display());
+            let plan = crate::report::read_from_path(plan_path).map_err(|e| {
+                Error::Other(format!(
+                    "Failed to read plan from {}: {}",
+                    plan_path.display(),
+                    e
+                ))
+            })?;
+            Some(plan)
+        } else {
+            None
+        };
+
+        // Build the operation once; the pipeline path reuses the stores/config,
+        // so the operation takes clones.
         let operation = RepairOperation::new(
             src_store.clone(),
             dst_store.clone(),
@@ -76,30 +97,20 @@ impl RepairCmd {
             pipeline_config.clone(),
         );
 
-        if let Some(ref plan_path) = self.plan {
-            let report = crate::report::read_from_path(plan_path).map_err(|e| {
-                Error::Other(format!(
-                    "Failed to read plan from {}: {}",
-                    plan_path.display(),
-                    e
-                ))
-            })?;
-            info!("Plan mode: applying {}", plan_path.display());
+        if let Some(plan) = plan {
             operation
-                .run_manual(report, args.report_path.as_deref())
+                .run_manual(plan, args.report_path.as_deref())
                 .await?;
-            return Ok(());
+        } else {
+            let pipeline = Pipeline::new(
+                operation,
+                pipeline_config,
+                src_store,
+                Some(dst_store),
+                args.report_path,
+            );
+            pipeline.run().await.map_err(utils::map_pipeline_error)?;
         }
-
-        let pipeline = Pipeline::new(
-            operation,
-            pipeline_config,
-            src_store,
-            Some(dst_store),
-            args.report_path,
-        );
-
-        pipeline.run().await.map_err(utils::map_pipeline_error)?;
 
         Ok(())
     }

--- a/src/cli/scan.rs
+++ b/src/cli/scan.rs
@@ -44,15 +44,9 @@ impl ScanCmd {
         };
 
         // Create the scan operation
-        let operation = ScanOperation::new(self.low, self.high, pipeline_config.clone());
+        let operation = ScanOperation::new(src_store, self.low, self.high, pipeline_config.clone());
 
-        let pipeline = Pipeline::new(
-            operation,
-            pipeline_config,
-            src_store,
-            None,
-            args.report_path,
-        );
+        let pipeline = Pipeline::new(operation, pipeline_config, args.report_path);
 
         pipeline.run().await.map_err(utils::map_pipeline_error)?;
 

--- a/src/cli/scan.rs
+++ b/src/cli/scan.rs
@@ -33,7 +33,7 @@ impl ScanCmd {
         }
 
         // Create the scan operation
-        let operation = ScanOperation::new(self.low, self.high, &args.storage_config, args.verify);
+        let operation = ScanOperation::new(self.low, self.high, &args.storage_config);
 
         let src_store = storage::from_url_with_config(&self.archive, &args.storage_config)
             .map_err(|e| Error::Other(format!("Failed to create source backend: {e}")))?;
@@ -41,6 +41,7 @@ impl ScanCmd {
         let pipeline_config = PipelineConfig {
             concurrency: args.concurrency,
             skip_optional: args.skip_optional,
+            verify: args.verify,
             storage_config: args.storage_config,
         };
 

--- a/src/cli/scan.rs
+++ b/src/cli/scan.rs
@@ -46,7 +46,13 @@ impl ScanCmd {
             storage_config: args.storage_config,
         };
 
-        let pipeline = Pipeline::new(operation, pipeline_config, src_store, None);
+        let pipeline = Pipeline::new(
+            operation,
+            pipeline_config,
+            src_store,
+            None,
+            args.report_path,
+        );
 
         pipeline.run().await.map_err(utils::map_pipeline_error)?;
 

--- a/src/cli/scan.rs
+++ b/src/cli/scan.rs
@@ -41,6 +41,7 @@ impl ScanCmd {
         let pipeline_config = PipelineConfig {
             concurrency: args.concurrency,
             skip_optional: args.skip_optional,
+            skip_history_and_buckets: false,
             verify: args.verify,
             storage_config: args.storage_config,
         };

--- a/src/cli/scan.rs
+++ b/src/cli/scan.rs
@@ -32,9 +32,6 @@ impl ScanCmd {
             info!("Scanning up to checkpoint {}", high);
         }
 
-        // Create the scan operation
-        let operation = ScanOperation::new(self.low, self.high, &args.storage_config);
-
         let src_store = storage::from_url_with_config(&self.archive, &args.storage_config)
             .map_err(|e| Error::Other(format!("Failed to create source backend: {e}")))?;
 
@@ -45,6 +42,9 @@ impl ScanCmd {
             verify: args.verify,
             storage_config: args.storage_config,
         };
+
+        // Create the scan operation
+        let operation = ScanOperation::new(self.low, self.high, pipeline_config.clone());
 
         let pipeline = Pipeline::new(
             operation,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,12 +248,7 @@ pub mod test_helpers {
     }
 
     pub async fn run_scan(config: ScanConfig) -> Result<(), crate::Error> {
-        let operation = ScanOperation::new(
-            config.low,
-            config.high,
-            &config.storage_config,
-            config.verify,
-        );
+        let operation = ScanOperation::new(config.low, config.high, &config.storage_config);
 
         let src_store =
             crate::storage::from_url_with_config(&config.archive, &config.storage_config).map_err(
@@ -263,6 +258,7 @@ pub mod test_helpers {
         let pipeline_config = PipelineConfig {
             concurrency: config.concurrency,
             skip_optional: config.skip_optional,
+            verify: config.verify,
             storage_config: config.storage_config,
         };
 
@@ -298,12 +294,13 @@ pub mod test_helpers {
             config.high,
             config.allow_mirror_gaps,
             &config.storage_config,
-            config.verify,
+            /*update_well_known=*/ true,
         );
 
         let pipeline_config = PipelineConfig {
             concurrency: config.concurrency,
             skip_optional: config.skip_optional,
+            verify: config.verify,
             storage_config: config.storage_config,
         };
 
@@ -432,6 +429,7 @@ pub mod test_helpers {
         let pipeline_config = PipelineConfig {
             concurrency: config.concurrency,
             skip_optional: config.skip_optional,
+            verify: config.verify,
             storage_config: config.storage_config,
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,7 +353,7 @@ pub mod test_helpers {
         pub high: Option<u32>,
         pub verify: bool,
         pub dry_run: bool,
-        pub file_list: Option<Vec<String>>,
+        pub plan: Option<crate::report::ArchiveReport>,
         pub storage_config: StorageConfig,
         pub report_path: Option<std::path::PathBuf>,
     }
@@ -369,7 +369,7 @@ pub mod test_helpers {
                 high: None,
                 verify: false,
                 dry_run: false,
-                file_list: None,
+                plan: None,
                 storage_config: test_storage_config(),
                 report_path: None,
             }
@@ -419,8 +419,8 @@ pub mod test_helpers {
         }
 
         #[must_use]
-        pub fn files(mut self, list: Vec<String>) -> Self {
-            self.file_list = Some(list);
+        pub fn plan(mut self, plan: crate::report::ArchiveReport) -> Self {
+            self.plan = Some(plan);
             self
         }
 
@@ -465,9 +465,9 @@ pub mod test_helpers {
             pipeline_config.clone(),
         );
 
-        if let Some(files) = config.file_list {
+        if let Some(plan) = config.plan {
             return operation
-                .run_manual(&files)
+                .run_manual(plan, config.report_path.as_deref())
                 .await
                 .map_err(crate::Error::from);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,6 +258,7 @@ pub mod test_helpers {
         let pipeline_config = PipelineConfig {
             concurrency: config.concurrency,
             skip_optional: config.skip_optional,
+            skip_history_and_buckets: false,
             verify: config.verify,
             storage_config: config.storage_config,
         };
@@ -300,6 +301,7 @@ pub mod test_helpers {
         let pipeline_config = PipelineConfig {
             concurrency: config.concurrency,
             skip_optional: config.skip_optional,
+            skip_history_and_buckets: false,
             verify: config.verify,
             storage_config: config.storage_config,
         };
@@ -410,6 +412,7 @@ pub mod test_helpers {
         let pipeline_config = PipelineConfig {
             concurrency: config.concurrency,
             skip_optional: config.skip_optional,
+            skip_history_and_buckets: false,
             verify: config.verify,
             storage_config: config.storage_config,
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,8 +267,6 @@ pub mod test_helpers {
     }
 
     pub async fn run_scan(config: ScanConfig) -> Result<(), crate::Error> {
-        let operation = ScanOperation::new(config.low, config.high, &config.storage_config);
-
         let src_store =
             crate::storage::from_url_with_config(&config.archive, &config.storage_config).map_err(
                 |e| crate::Error::Other(format!("Failed to create source backend: {e}")),
@@ -281,6 +279,8 @@ pub mod test_helpers {
             verify: config.verify,
             storage_config: config.storage_config,
         };
+
+        let operation = ScanOperation::new(config.low, config.high, pipeline_config.clone());
 
         let pipeline = Pipeline::new(
             operation,
@@ -313,16 +313,6 @@ pub mod test_helpers {
             )));
         }
 
-        let operation = MirrorOperation::new(
-            dst_store.clone(),
-            config.overwrite,
-            config.low,
-            config.high,
-            config.allow_mirror_gaps,
-            &config.storage_config,
-            /*update_well_known=*/ true,
-        );
-
         let pipeline_config = PipelineConfig {
             concurrency: config.concurrency,
             skip_optional: config.skip_optional,
@@ -330,6 +320,16 @@ pub mod test_helpers {
             verify: config.verify,
             storage_config: config.storage_config,
         };
+
+        let operation = MirrorOperation::new(
+            dst_store.clone(),
+            config.overwrite,
+            config.low,
+            config.high,
+            config.allow_mirror_gaps,
+            pipeline_config.clone(),
+            /*update_well_known=*/ true,
+        );
 
         let pipeline = Pipeline::new(
             operation,
@@ -456,6 +456,22 @@ pub mod test_helpers {
             verify: config.verify,
             storage_config: config.storage_config,
         };
+
+        if let Some(plan) = config.plan {
+            let operation = RepairOperation::new(
+                src_store,
+                dst_store,
+                config.low,
+                config.high,
+                config.dry_run,
+                pipeline_config,
+            );
+            return operation
+                .run_manual(plan, config.report_path.as_deref())
+                .await
+                .map_err(crate::Error::from);
+        }
+
         let operation = RepairOperation::new(
             src_store.clone(),
             dst_store.clone(),
@@ -464,13 +480,6 @@ pub mod test_helpers {
             config.dry_run,
             pipeline_config.clone(),
         );
-
-        if let Some(plan) = config.plan {
-            return operation
-                .run_manual(plan, config.report_path.as_deref())
-                .await
-                .map_err(crate::Error::from);
-        }
 
         let pipeline = Pipeline::new(
             operation,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,15 +280,10 @@ pub mod test_helpers {
             storage_config: config.storage_config,
         };
 
-        let operation = ScanOperation::new(config.low, config.high, pipeline_config.clone());
+        let operation =
+            ScanOperation::new(src_store, config.low, config.high, pipeline_config.clone());
 
-        let pipeline = Pipeline::new(
-            operation,
-            pipeline_config,
-            src_store,
-            None,
-            config.report_path,
-        );
+        let pipeline = Pipeline::new(operation, pipeline_config, config.report_path);
         pipeline
             .run()
             .await
@@ -322,7 +317,8 @@ pub mod test_helpers {
         };
 
         let operation = MirrorOperation::new(
-            dst_store.clone(),
+            src_store,
+            dst_store,
             config.overwrite,
             config.low,
             config.high,
@@ -331,13 +327,7 @@ pub mod test_helpers {
             /*update_well_known=*/ true,
         );
 
-        let pipeline = Pipeline::new(
-            operation,
-            pipeline_config,
-            src_store,
-            Some(dst_store),
-            config.report_path,
-        );
+        let pipeline = Pipeline::new(operation, pipeline_config, config.report_path);
         pipeline
             .run()
             .await
@@ -473,21 +463,15 @@ pub mod test_helpers {
         }
 
         let operation = RepairOperation::new(
-            src_store.clone(),
-            dst_store.clone(),
+            src_store,
+            dst_store,
             config.low,
             config.high,
             config.dry_run,
             pipeline_config.clone(),
         );
 
-        let pipeline = Pipeline::new(
-            operation,
-            pipeline_config,
-            src_store,
-            Some(dst_store),
-            config.report_path,
-        );
+        let pipeline = Pipeline::new(operation, pipeline_config, config.report_path);
         pipeline
             .run()
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,7 @@ pub mod test_helpers {
         pub high: Option<u32>,
         pub storage_config: StorageConfig,
         pub verify: bool,
+        pub report_path: Option<std::path::PathBuf>,
     }
 
     impl ScanConfig {
@@ -117,7 +118,15 @@ pub mod test_helpers {
                 high: None,
                 storage_config: test_storage_config(),
                 verify: false,
+                report_path: None,
             }
+        }
+
+        /// Set a report path
+        #[must_use]
+        pub fn report(mut self, path: impl Into<std::path::PathBuf>) -> Self {
+            self.report_path = Some(path.into());
+            self
         }
 
         /// Set concurrency level
@@ -173,6 +182,7 @@ pub mod test_helpers {
         pub allow_mirror_gaps: bool,
         pub storage_config: StorageConfig,
         pub verify: bool,
+        pub report_path: Option<std::path::PathBuf>,
     }
 
     impl MirrorConfig {
@@ -189,6 +199,7 @@ pub mod test_helpers {
                 allow_mirror_gaps: false,
                 storage_config: test_storage_config(),
                 verify: false,
+                report_path: None,
             }
         }
 
@@ -246,6 +257,13 @@ pub mod test_helpers {
             self.verify = true;
             self
         }
+
+        /// Set a report path
+        #[must_use]
+        pub fn report(mut self, path: impl Into<std::path::PathBuf>) -> Self {
+            self.report_path = Some(path.into());
+            self
+        }
     }
 
     pub async fn run_scan(config: ScanConfig) -> Result<(), crate::Error> {
@@ -264,7 +282,13 @@ pub mod test_helpers {
             storage_config: config.storage_config,
         };
 
-        let pipeline = Pipeline::new(operation, pipeline_config, src_store, None);
+        let pipeline = Pipeline::new(
+            operation,
+            pipeline_config,
+            src_store,
+            None,
+            config.report_path,
+        );
         pipeline
             .run()
             .await
@@ -307,7 +331,13 @@ pub mod test_helpers {
             storage_config: config.storage_config,
         };
 
-        let pipeline = Pipeline::new(operation, pipeline_config, src_store, Some(dst_store));
+        let pipeline = Pipeline::new(
+            operation,
+            pipeline_config,
+            src_store,
+            Some(dst_store),
+            config.report_path,
+        );
         pipeline
             .run()
             .await
@@ -325,6 +355,7 @@ pub mod test_helpers {
         pub dry_run: bool,
         pub file_list: Option<Vec<String>>,
         pub storage_config: StorageConfig,
+        pub report_path: Option<std::path::PathBuf>,
     }
 
     impl RepairConfig {
@@ -340,7 +371,15 @@ pub mod test_helpers {
                 dry_run: false,
                 file_list: None,
                 storage_config: test_storage_config(),
+                report_path: None,
             }
+        }
+
+        /// Write a JSON status report (or, in dry-run, a repair plan) to this path
+        #[must_use]
+        pub fn report(mut self, path: impl Into<std::path::PathBuf>) -> Self {
+            self.report_path = Some(path.into());
+            self
         }
 
         #[must_use]
@@ -433,7 +472,13 @@ pub mod test_helpers {
                 .map_err(crate::Error::from);
         }
 
-        let pipeline = Pipeline::new(operation, pipeline_config, src_store, Some(dst_store));
+        let pipeline = Pipeline::new(
+            operation,
+            pipeline_config,
+            src_store,
+            Some(dst_store),
+            config.report_path,
+        );
         pipeline
             .run()
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub mod history_format;
 pub mod mirror_operation;
 pub mod pipeline;
 pub mod repair_operation;
+pub mod report;
 pub mod scan_operation;
 pub mod storage;
 pub mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -407,16 +407,19 @@ pub mod test_helpers {
             )));
         }
 
+        let pipeline_config = PipelineConfig {
+            concurrency: config.concurrency,
+            skip_optional: config.skip_optional,
+            verify: config.verify,
+            storage_config: config.storage_config,
+        };
         let operation = RepairOperation::new(
             src_store.clone(),
             dst_store.clone(),
             config.low,
             config.high,
-            config.verify,
             config.dry_run,
-            config.concurrency,
-            config.skip_optional,
-            &config.storage_config,
+            pipeline_config.clone(),
         );
 
         if let Some(files) = config.file_list {
@@ -425,13 +428,6 @@ pub mod test_helpers {
                 .await
                 .map_err(crate::Error::from);
         }
-
-        let pipeline_config = PipelineConfig {
-            concurrency: config.concurrency,
-            skip_optional: config.skip_optional,
-            verify: config.verify,
-            storage_config: config.storage_config,
-        };
 
         let pipeline = Pipeline::new(operation, pipeline_config, src_store, Some(dst_store));
         pipeline

--- a/src/mirror_operation.rs
+++ b/src/mirror_operation.rs
@@ -34,6 +34,9 @@ pub enum Error {
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+
+    #[error("Report error: {0}")]
+    Report(#[from] crate::report::ReportError),
 }
 
 pub struct MirrorOperation {
@@ -358,8 +361,18 @@ impl Operation for MirrorOperation {
         &self,
         highest_checkpoint: u32,
         stats: &ArchiveStats,
+        report_path: Option<&std::path::Path>,
     ) -> Result<(), crate::pipeline::Error> {
         stats.report("mirror").await;
+
+        if let Some(path) = report_path {
+            let report = crate::report::ArchiveReport {
+                version: crate::report::REPORT_VERSION,
+                section: stats.report_section().await,
+            };
+            crate::report::write_to_path(path, &report)
+                .map_err(|e| crate::pipeline::Error::MirrorOperation(Error::Report(e)))?;
+        }
 
         if stats.has_failures().await {
             return Err(Error::MirrorFailed.into());

--- a/src/mirror_operation.rs
+++ b/src/mirror_operation.rs
@@ -39,6 +39,7 @@ pub enum Error {
 }
 
 pub struct MirrorOperation {
+    src_store: StorageRef,
     dst_store: StorageRef,
     overwrite: bool,
 
@@ -64,6 +65,7 @@ pub struct MirrorOperation {
 
 impl MirrorOperation {
     pub fn new(
+        src_store: StorageRef,
         dst_store: StorageRef,
         overwrite: bool,
         low: Option<u32>,
@@ -78,6 +80,7 @@ impl MirrorOperation {
         );
 
         Self {
+            src_store,
             dst_store,
             overwrite,
             low,
@@ -210,10 +213,7 @@ impl MirrorOperation {
 
 #[async_trait]
 impl Operation for MirrorOperation {
-    async fn get_checkpoint_bounds(
-        &self,
-        source: &StorageRef,
-    ) -> Result<(u32, u32), crate::pipeline::Error> {
+    async fn get_checkpoint_bounds(&self) -> Result<(u32, u32), crate::pipeline::Error> {
         // Determine the effective low checkpoint based on destination .well-known/stellar-history.json and flags
         //
         // Starting ledger logic:
@@ -228,7 +228,7 @@ impl Operation for MirrorOperation {
 
         // First, get the source's latest checkpoint to know what's available
         let source_state = fetch_well_known_history_file(
-            source,
+            &self.src_store,
             self.pipeline_config.storage_config.max_retries as u32,
             self.pipeline_config
                 .storage_config
@@ -350,14 +350,13 @@ impl Operation for MirrorOperation {
     async fn process_object(
         &self,
         path: &str,
-        src_store: &StorageRef,
         manager: Option<&XdrVerificationManager>,
     ) -> Result<ProcessOutcome, StorageError> {
         // Skip if dst already has the file and we're not overwriting.
         if self.dst_store.exists(path).await? && !self.overwrite {
             return Ok(ProcessOutcome::Skipped);
         }
-        crate::xdr_verify::fetch_verify_and_write(src_store, &self.dst_store, path, manager)
+        crate::xdr_verify::fetch_verify_and_write(&self.src_store, &self.dst_store, path, manager)
             .await?;
         Ok(ProcessOutcome::Processed)
     }
@@ -413,11 +412,7 @@ impl Operation for MirrorOperation {
     /// the destination already holds a valid copy, keep it (`Skipped`) and walk
     /// its buckets; otherwise fetch from source, parse (before writing), write,
     /// and report `Processed`.
-    async fn process_history(
-        &self,
-        path: &str,
-        src_store: &StorageRef,
-    ) -> Result<HistoryOutcome, StorageError> {
+    async fn process_history(&self, path: &str) -> Result<HistoryOutcome, StorageError> {
         // Symmetric with process_object's `exists && !overwrite => Skipped`.
         if !self.overwrite {
             if let Ok(buffer) = storage::download_buffer(&self.dst_store, path).await {
@@ -431,7 +426,7 @@ impl Operation for MirrorOperation {
             }
         }
 
-        let buffer = storage::download_buffer(src_store, path).await?;
+        let buffer = storage::download_buffer(&self.src_store, path).await?;
         // Parse-before-write: never commit an unparseable HAS to the destination.
         let state = history_format::parse_history(&buffer, path)
             .map_err(|e| StorageError::fatal(format!("failed to parse history {path}: {e}")))?;

--- a/src/mirror_operation.rs
+++ b/src/mirror_operation.rs
@@ -1,7 +1,7 @@
 //! Mirror operation - copies files from source to destination
 
 use crate::history_format;
-use crate::pipeline::{async_trait, Operation};
+use crate::pipeline::{async_trait, Operation, ProcessOutcome};
 use crate::storage::cleanup_partial_file;
 use crate::storage::{self, Error as StorageError, StorageConfig, StorageRef};
 use crate::utils::{compute_checkpoint_bounds, fetch_well_known_history_file, ArchiveStats};
@@ -208,7 +208,9 @@ impl MirrorOperation {
         match self.dst_store.copy_from_reader(path, reader).await {
             Ok(()) => Ok(()),
             Err(e) => {
-                cleanup_partial_file(&self.dst_store, path).await?;
+                if let Err(cleanup_err) = cleanup_partial_file(&self.dst_store, path).await {
+                    error!("Failed to cleanup partial file {}: {}", path, cleanup_err);
+                }
                 Err(e)
             }
         }
@@ -356,40 +358,27 @@ impl Operation for MirrorOperation {
             .map_err(|e| crate::pipeline::Error::MirrorOperation(Error::Utils(e)))
     }
 
-    async fn pre_check(&self, path: &str) -> Option<Result<(), StorageError>> {
-        // Check destination before querying source, skip if file already exists
-        match self.dst_store.exists(path).await {
-            Ok(true) => {
-                // If file exists and we're not overwriting, skip it
-                if !self.overwrite {
-                    return Some(Ok(()));
-                }
-                // Overwrite mode - proceed to download
-                None
-            }
-            Ok(false) => {
-                // File doesn't exist - proceed to download
-                None
-            }
-            Err(e) => {
-                // Failed to check existence on destination
-                Some(Err(StorageError::fatal(format!(
-                    "Failed to check existence of destination {path}: {e}"
-                ))))
-            }
+    async fn process_object(
+        &self,
+        _checkpoint: u32,
+        path: &str,
+        src_store: &StorageRef,
+    ) -> Result<ProcessOutcome, StorageError> {
+        // Skip if dst already has the file and we're not overwriting.
+        if self.dst_store.exists(path).await? && !self.overwrite {
+            return Ok(ProcessOutcome::Skipped);
         }
-    }
 
-    async fn process_object(&self, path: &str, src_store: &StorageRef) -> Result<(), StorageError> {
         let reader = src_store.open_reader(path).await?;
         if let Some(ref manager) = self.verification_manager {
             if crate::history_format::is_bucket_file(path) {
-                match crate::verify::verify_and_write_bucket(path, reader, &self.dst_store).await {
-                    Ok(()) => Ok(()),
-                    Err(e) => {
-                        cleanup_partial_file(&self.dst_store, path).await?;
-                        Err(e)
+                if let Err(e) =
+                    crate::verify::verify_and_write_bucket(path, reader, &self.dst_store).await
+                {
+                    if let Err(cleanup_err) = cleanup_partial_file(&self.dst_store, path).await {
+                        error!("Failed to cleanup partial file {}: {}", path, cleanup_err);
                     }
+                    return Err(e);
                 }
             } else if crate::history_format::is_ledger_header_file(path)
                 || crate::history_format::is_transactions_file(path)
@@ -403,7 +392,11 @@ impl Operation for MirrorOperation {
                     {
                         Ok(result) => result,
                         Err(e) => {
-                            cleanup_partial_file(&self.dst_store, path).await?;
+                            if let Err(cleanup_err) =
+                                cleanup_partial_file(&self.dst_store, path).await
+                            {
+                                error!("Failed to cleanup partial file {}: {}", path, cleanup_err);
+                            }
                             return Err(e);
                         }
                     };
@@ -425,13 +418,13 @@ impl Operation for MirrorOperation {
                     }
                     XdrParseResult::None => {}
                 }
-                Ok(())
             } else {
-                self.copy_file(path, reader).await
+                self.copy_file(path, reader).await?;
             }
         } else {
-            self.copy_file(path, reader).await
+            self.copy_file(path, reader).await?;
         }
+        Ok(ProcessOutcome::Processed)
     }
 
     async fn finalize(
@@ -440,29 +433,23 @@ impl Operation for MirrorOperation {
         stats: &ArchiveStats,
     ) -> Result<(), crate::pipeline::Error> {
         if let Some(ref manager) = self.verification_manager {
-            let chain_errors = manager.verify_checkpoint_chain();
-            for err in &chain_errors {
-                error!("Checkpoint {}: {}", err.checkpoint, err.message);
-                stats.record_failure("xdr-chain-verification").await;
+            manager.verify_checkpoint_chain();
+            let all_errors = manager.get_errors();
+            for err in &all_errors {
+                stats.record_verification_failure(&err.kind).await;
             }
 
-            let accumulated_errors = manager.get_errors();
-            for _ in &accumulated_errors {
-                stats.record_failure("xdr-cross-verification").await;
-            }
-
-            let total_errors = chain_errors.len() + accumulated_errors.len();
-            if total_errors > 0 {
+            if !all_errors.is_empty() {
                 error!(
                     "XDR verification found {} cross-file hash mismatches",
-                    total_errors
+                    all_errors.len()
                 );
             }
         }
 
         stats.report("mirror").await;
 
-        if stats.has_failures() {
+        if stats.has_failures().await {
             return Err(Error::MirrorFailed.into());
         }
 
@@ -481,13 +468,13 @@ impl Operation for MirrorOperation {
     }
 
     /// Mirror writes the history buffer to its own dst.
-    async fn process_buffer(&self, path: &str, buffer: Buffer, stats: &ArchiveStats) {
-        match storage::write_buffer_with_cleanup(&self.dst_store, path, buffer).await {
-            Ok(()) => stats.record_success(path),
-            Err(e) => {
-                error!("Failed to write history file {}: {}", path, e);
-                stats.record_failure(path).await;
-            }
-        }
+    async fn process_buffer(
+        &self,
+        _checkpoint: u32,
+        path: &str,
+        buffer: Buffer,
+    ) -> Result<ProcessOutcome, StorageError> {
+        storage::write_buffer_with_cleanup(&self.dst_store, path, buffer).await?;
+        Ok(ProcessOutcome::Processed)
     }
 }

--- a/src/mirror_operation.rs
+++ b/src/mirror_operation.rs
@@ -1,11 +1,10 @@
 //! Mirror operation - copies files from source to destination
 
 use crate::history_format;
-use crate::pipeline::{async_trait, Operation, PipelineConfig, ProcessOutcome};
+use crate::pipeline::{async_trait, HistoryOutcome, Operation, PipelineConfig, ProcessOutcome};
 use crate::storage::{self, Error as StorageError, StorageRef};
 use crate::utils::{compute_checkpoint_bounds, fetch_well_known_history_file, ArchiveStats};
 use crate::xdr_verify::XdrVerificationManager;
-use opendal::Buffer;
 use thiserror::Error;
 use tokio::sync::OnceCell;
 use tracing::{debug, error, info, warn};
@@ -409,13 +408,37 @@ impl Operation for MirrorOperation {
         Ok(())
     }
 
-    /// Mirror writes the history buffer to its own dst.
-    async fn process_buffer(
+    /// Copy the history file from source to destination, parsing it for bucket
+    /// discovery. Symmetric with `process_object`: when `--overwrite` is off and
+    /// the destination already holds a valid copy, keep it (`Skipped`) and walk
+    /// its buckets; otherwise fetch from source, parse (before writing), write,
+    /// and report `Processed`.
+    async fn process_history(
         &self,
         path: &str,
-        buffer: Buffer,
-    ) -> Result<ProcessOutcome, StorageError> {
+        src_store: &StorageRef,
+    ) -> Result<HistoryOutcome, StorageError> {
+        // Symmetric with process_object's `exists && !overwrite => Skipped`.
+        if !self.overwrite {
+            if let Ok(buffer) = storage::download_buffer(&self.dst_store, path).await {
+                if let Ok(state) = history_format::parse_history(&buffer, path) {
+                    return Ok(HistoryOutcome {
+                        outcome: ProcessOutcome::Skipped,
+                        state: Some(state),
+                    });
+                }
+                // present but unparseable -> fall through and re-fetch from source
+            }
+        }
+
+        let buffer = storage::download_buffer(src_store, path).await?;
+        // Parse-before-write: never commit an unparseable HAS to the destination.
+        let state = history_format::parse_history(&buffer, path)
+            .map_err(|e| StorageError::fatal(format!("failed to parse history {path}: {e}")))?;
         storage::write_buffer_with_cleanup(&self.dst_store, path, buffer).await?;
-        Ok(ProcessOutcome::Processed)
+        Ok(HistoryOutcome {
+            outcome: ProcessOutcome::Processed,
+            state: Some(state),
+        })
     }
 }

--- a/src/mirror_operation.rs
+++ b/src/mirror_operation.rs
@@ -1,8 +1,8 @@
 //! Mirror operation - copies files from source to destination
 
 use crate::history_format;
-use crate::pipeline::{async_trait, Operation, ProcessOutcome};
-use crate::storage::{self, Error as StorageError, StorageConfig, StorageRef};
+use crate::pipeline::{async_trait, Operation, PipelineConfig, ProcessOutcome};
+use crate::storage::{self, Error as StorageError, StorageRef};
 use crate::utils::{compute_checkpoint_bounds, fetch_well_known_history_file, ArchiveStats};
 use crate::xdr_verify::XdrVerificationManager;
 use opendal::Buffer;
@@ -48,8 +48,8 @@ pub struct MirrorOperation {
     high: Option<u32>,
     allow_mirror_gaps: bool,
 
-    // Storage configuration (retry params for fetches live here)
-    storage_config: StorageConfig,
+    // Pipeline configuration (storage retry params + verify mode for the report)
+    pipeline_config: PipelineConfig,
 
     // Cached destination checkpoint at start of operation (or None if destination doesn't exist)
     initial_dest_checkpoint: OnceCell<Option<u32>>,
@@ -70,7 +70,7 @@ impl MirrorOperation {
         low: Option<u32>,
         high: Option<u32>,
         allow_mirror_gaps: bool,
-        storage_config: &StorageConfig,
+        pipeline_config: PipelineConfig,
         update_well_known: bool,
     ) -> Self {
         debug_assert!(
@@ -84,7 +84,7 @@ impl MirrorOperation {
             low,
             high,
             allow_mirror_gaps,
-            storage_config: storage_config.clone(),
+            pipeline_config,
             initial_dest_checkpoint: OnceCell::new(),
             update_well_known,
         }
@@ -99,8 +99,11 @@ impl MirrorOperation {
                 // Try to read the destination's .well-known file
                 match fetch_well_known_history_file(
                     &self.dst_store,
-                    self.storage_config.max_retries as u32,
-                    self.storage_config.retry_min_delay.as_millis() as u64,
+                    self.pipeline_config.storage_config.max_retries as u32,
+                    self.pipeline_config
+                        .storage_config
+                        .retry_min_delay
+                        .as_millis() as u64,
                 )
                 .await
                 {
@@ -227,8 +230,11 @@ impl Operation for MirrorOperation {
         // First, get the source's latest checkpoint to know what's available
         let source_state = fetch_well_known_history_file(
             source,
-            self.storage_config.max_retries as u32,
-            self.storage_config.retry_min_delay.as_millis() as u64,
+            self.pipeline_config.storage_config.max_retries as u32,
+            self.pipeline_config
+                .storage_config
+                .retry_min_delay
+                .as_millis() as u64,
         )
         .await
         .map_err(|e| crate::pipeline::Error::MirrorOperation(Error::Utils(e)))?;
@@ -372,6 +378,19 @@ impl Operation for MirrorOperation {
             };
             crate::report::write_to_path(path, &report)
                 .map_err(|e| crate::pipeline::Error::MirrorOperation(Error::Report(e)))?;
+        }
+
+        // Cross-file/chain checks run after the per-cp files are written, so a
+        // checkpoint flagged here means individually-valid files were already
+        // committed to the destination but are mutually inconsistent.
+        let inconsistent = stats.checkpoint_failure_count().await;
+        if inconsistent > 0 {
+            error!(
+                "{inconsistent} checkpoint(s) passed per-file verification but failed \
+                 cross-file/chain checks; their files were written to the destination but are \
+                 mutually inconsistent. Re-run `repair --verify` against a known-good source to \
+                 reconcile them."
+            );
         }
 
         if stats.has_failures().await {

--- a/src/mirror_operation.rs
+++ b/src/mirror_operation.rs
@@ -8,7 +8,6 @@ use crate::utils::{compute_checkpoint_bounds, fetch_well_known_history_file, Arc
 use crate::xdr_verify::XdrVerificationManager;
 use opendal::Buffer;
 use opendal::Reader;
-use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::OnceCell;
 use tracing::{debug, error, info, warn};
@@ -54,8 +53,13 @@ pub struct MirrorOperation {
     // Cached destination checkpoint at start of operation (or None if destination doesn't exist)
     initial_dest_checkpoint: OnceCell<Option<u32>>,
 
-    // Populated if we should verify files, otherwise None
-    verification_manager: Option<Arc<XdrVerificationManager>>,
+    // Whether finalize should update the destination's .well-known file with
+    // the highest mirrored checkpoint. The top-level mirror operation (driven
+    // by `Pipeline::run` over a contiguous range) sets this to true. Sub-uses
+    // such as repair's retry pipeline — which re-mirror a disjoint subset and
+    // therefore cannot claim a contiguous "now mirrored up to" — set it to
+    // false to avoid advertising partial coverage in the dst archive.
+    update_well_known: bool,
 }
 
 impl MirrorOperation {
@@ -66,7 +70,7 @@ impl MirrorOperation {
         high: Option<u32>,
         allow_mirror_gaps: bool,
         storage_config: &StorageConfig,
-        verify: bool,
+        update_well_known: bool,
     ) -> Self {
         debug_assert!(
             dst_store.supports_writes(),
@@ -81,11 +85,7 @@ impl MirrorOperation {
             allow_mirror_gaps,
             storage_config: storage_config.clone(),
             initial_dest_checkpoint: OnceCell::new(),
-            verification_manager: if verify {
-                Some(Arc::new(XdrVerificationManager::new()))
-            } else {
-                None
-            },
+            update_well_known,
         }
     }
 
@@ -360,9 +360,9 @@ impl Operation for MirrorOperation {
 
     async fn process_object(
         &self,
-        _checkpoint: u32,
         path: &str,
         src_store: &StorageRef,
+        manager: Option<&XdrVerificationManager>,
     ) -> Result<ProcessOutcome, StorageError> {
         // Skip if dst already has the file and we're not overwriting.
         if self.dst_store.exists(path).await? && !self.overwrite {
@@ -370,7 +370,7 @@ impl Operation for MirrorOperation {
         }
 
         let reader = src_store.open_reader(path).await?;
-        if let Some(ref manager) = self.verification_manager {
+        if let Some(manager) = manager {
             if crate::history_format::is_bucket_file(path) {
                 if let Err(e) =
                     crate::verify::verify_and_write_bucket(path, reader, &self.dst_store).await
@@ -432,25 +432,14 @@ impl Operation for MirrorOperation {
         highest_checkpoint: u32,
         stats: &ArchiveStats,
     ) -> Result<(), crate::pipeline::Error> {
-        if let Some(ref manager) = self.verification_manager {
-            manager.verify_checkpoint_chain();
-            let all_errors = manager.get_errors();
-            for err in &all_errors {
-                stats.record_verification_failure(&err.kind).await;
-            }
-
-            if !all_errors.is_empty() {
-                error!(
-                    "XDR verification found {} cross-file hash mismatches",
-                    all_errors.len()
-                );
-            }
-        }
-
         stats.report("mirror").await;
 
         if stats.has_failures().await {
             return Err(Error::MirrorFailed.into());
+        }
+
+        if !self.update_well_known {
+            return Ok(());
         }
 
         if let Err(e) = self.maybe_update_well_known(highest_checkpoint).await {
@@ -461,16 +450,9 @@ impl Operation for MirrorOperation {
         Ok(())
     }
 
-    fn finalize_checkpoint(&self, checkpoint: u32) {
-        if let Some(ref manager) = self.verification_manager {
-            manager.verify_and_release(checkpoint);
-        }
-    }
-
     /// Mirror writes the history buffer to its own dst.
     async fn process_buffer(
         &self,
-        _checkpoint: u32,
         path: &str,
         buffer: Buffer,
     ) -> Result<ProcessOutcome, StorageError> {

--- a/src/mirror_operation.rs
+++ b/src/mirror_operation.rs
@@ -2,12 +2,10 @@
 
 use crate::history_format;
 use crate::pipeline::{async_trait, Operation, ProcessOutcome};
-use crate::storage::cleanup_partial_file;
 use crate::storage::{self, Error as StorageError, StorageConfig, StorageRef};
 use crate::utils::{compute_checkpoint_bounds, fetch_well_known_history_file, ArchiveStats};
 use crate::xdr_verify::XdrVerificationManager;
 use opendal::Buffer;
-use opendal::Reader;
 use thiserror::Error;
 use tokio::sync::OnceCell;
 use tracing::{debug, error, info, warn};
@@ -203,23 +201,6 @@ impl MirrorOperation {
 
         Ok(())
     }
-
-    async fn copy_file(&self, path: &str, reader: Reader) -> Result<(), StorageError> {
-        match self.dst_store.copy_from_reader(path, reader).await {
-            Ok(()) => Ok(()),
-            Err(e) => {
-                if let Err(cleanup_err) = cleanup_partial_file(&self.dst_store, path).await {
-                    error!("Failed to cleanup partial file {}: {}", path, cleanup_err);
-                }
-                Err(e)
-            }
-        }
-    }
-
-    fn checkpoint_from_verified_path(path: &str) -> Result<u32, StorageError> {
-        crate::history_format::checkpoint_from_path(path)
-            .ok_or_else(|| StorageError::fatal(format!("invalid checkpoint path: {}", path)))
-    }
 }
 
 #[async_trait]
@@ -368,62 +349,8 @@ impl Operation for MirrorOperation {
         if self.dst_store.exists(path).await? && !self.overwrite {
             return Ok(ProcessOutcome::Skipped);
         }
-
-        let reader = src_store.open_reader(path).await?;
-        if let Some(manager) = manager {
-            if crate::history_format::is_bucket_file(path) {
-                if let Err(e) =
-                    crate::verify::verify_and_write_bucket(path, reader, &self.dst_store).await
-                {
-                    if let Err(cleanup_err) = cleanup_partial_file(&self.dst_store, path).await {
-                        error!("Failed to cleanup partial file {}: {}", path, cleanup_err);
-                    }
-                    return Err(e);
-                }
-            } else if crate::history_format::is_ledger_header_file(path)
-                || crate::history_format::is_transactions_file(path)
-                || crate::history_format::is_results_file(path)
-                || crate::history_format::is_scp_file(path)
-            {
-                use crate::xdr_verify::XdrParseResult;
-                let result =
-                    match crate::xdr_verify::verify_and_write_xdr(path, reader, &self.dst_store)
-                        .await
-                    {
-                        Ok(result) => result,
-                        Err(e) => {
-                            if let Err(cleanup_err) =
-                                cleanup_partial_file(&self.dst_store, path).await
-                            {
-                                error!("Failed to cleanup partial file {}: {}", path, cleanup_err);
-                            }
-                            return Err(e);
-                        }
-                    };
-
-                let checkpoint = if matches!(result, XdrParseResult::None) {
-                    None
-                } else {
-                    Some(Self::checkpoint_from_verified_path(path)?)
-                };
-                match result {
-                    XdrParseResult::Ledger(data) => {
-                        manager.record_header_data(checkpoint.unwrap(), data);
-                    }
-                    XdrParseResult::Transactions(hashes) => {
-                        manager.record_tx_set_hashes(checkpoint.unwrap(), hashes);
-                    }
-                    XdrParseResult::Results(hashes) => {
-                        manager.record_result_hashes(checkpoint.unwrap(), hashes);
-                    }
-                    XdrParseResult::None => {}
-                }
-            } else {
-                self.copy_file(path, reader).await?;
-            }
-        } else {
-            self.copy_file(path, reader).await?;
-        }
+        crate::xdr_verify::fetch_verify_and_write(src_store, &self.dst_store, path, manager)
+            .await?;
         Ok(ProcessOutcome::Processed)
     }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -527,6 +527,34 @@ impl<Op: Operation> Pipeline<Op> {
         }
     }
 
+    /// Record the result of processing a single object/buffer into `stats`,
+    /// using the shared `ProcessOutcome` → recorder mapping. Used by both
+    /// `process_file` and `process_history_and_buckets`.
+    async fn record_outcome(
+        &self,
+        checkpoint: u32,
+        path: &str,
+        result: Result<ProcessOutcome, crate::storage::Error>,
+    ) {
+        match result {
+            Ok(ProcessOutcome::Processed) => {
+                debug!("Processed: {}", path);
+                self.stats.record_success(path);
+            }
+            Ok(ProcessOutcome::Skipped) => {
+                debug!("Skipped: {}", path);
+                self.stats.record_skipped(path);
+            }
+            Ok(ProcessOutcome::NeedsRepair) => {
+                debug!("Needs repair: {}", path);
+                self.stats.record_failure(checkpoint, path).await;
+            }
+            Err(_) => {
+                self.stats.record_failure(checkpoint, path).await;
+            }
+        }
+    }
+
     /// Process a single file (bucket, ledger, transactions, results, scp).
     /// `checkpoint` is the cp context (for buckets, the discovering cp).
     pub(crate) async fn process_file(&self, checkpoint: u32, path: String) {
@@ -544,24 +572,7 @@ impl<Op: Operation> Pipeline<Op> {
             },
         )
         .await;
-
-        match result {
-            Ok(ProcessOutcome::Processed) => {
-                debug!("Processed: {}", path);
-                self.stats.record_success(&path);
-            }
-            Ok(ProcessOutcome::Skipped) => {
-                debug!("Skipped: {}", path);
-                self.stats.record_skipped(&path);
-            }
-            Ok(ProcessOutcome::NeedsRepair) => {
-                debug!("Needs repair: {}", path);
-                self.stats.record_failure(checkpoint, &path).await;
-            }
-            Err(_) => {
-                self.stats.record_failure(checkpoint, &path).await;
-            }
-        }
+        self.record_outcome(checkpoint, &path, result).await;
     }
 }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -134,10 +134,7 @@ pub trait Operation: Send + Sync + 'static {
     ///
     /// The HAS is parsed unconditionally (needed for bucket discovery), so there
     /// is no verification-manager parameter.
-    async fn process_history(
-        &self,
-        path: &str,
-    ) -> Result<HistoryOutcome, crate::storage::Error>;
+    async fn process_history(&self, path: &str) -> Result<HistoryOutcome, crate::storage::Error>;
 
     /// Called by `Pipeline::finish` after the manager (if any) has been
     /// drained into `stats.failures`. The operation is responsible for
@@ -400,7 +397,10 @@ impl<Op: Operation> Pipeline<Op> {
         // `is_bucket_file` (which requires `bucket_hash_from_path` to be `Some`).
         // A missing hash here is a routing bug, not a runtime condition.
         let Some(bucket_hash) = history_format::bucket_hash_from_path(&path) else {
-            debug_assert!(false, "process_bucket_file requires a bucket path, got {path}");
+            debug_assert!(
+                false,
+                "process_bucket_file requires a bucket path, got {path}"
+            );
             error!("process_bucket_file got a non-bucket path, skipping: {path}");
             return;
         };

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -153,7 +153,12 @@ pub trait Operation: Send + Sync + 'static {
     /// Called by `Pipeline::finish` after the manager (if any) has been
     /// drained into `stats.failures`. The operation is responsible for
     /// reporting and deciding `has_failures`-gated success.
-    async fn finalize(&self, highest_checkpoint: u32, stats: &ArchiveStats) -> Result<(), Error>;
+    async fn finalize(
+        &self,
+        highest_checkpoint: u32,
+        stats: &ArchiveStats,
+        report_path: Option<&std::path::Path>,
+    ) -> Result<(), Error>;
 
     /// Fetch the history buffer for a checkpoint.
     ///
@@ -229,6 +234,10 @@ pub struct Pipeline<Op: Operation> {
     /// `process_checkpoint`, `verify_checkpoint_chain` + `record_all_errors`
     /// drain at the end of `run_checkpoints`).
     verification_manager: Option<XdrVerificationManager>,
+    /// Optional local path for the JSON status report, passed to
+    /// `operation.finalize`. Owned solely by the pipeline (not per-stats) so
+    /// sub-stats can't disagree about where the report goes.
+    report_path: Option<std::path::PathBuf>,
 }
 
 impl<Op: Operation> Pipeline<Op> {
@@ -239,6 +248,7 @@ impl<Op: Operation> Pipeline<Op> {
         config: PipelineConfig,
         src_store: StorageRef,
         dst_store: Option<StorageRef>,
+        report_path: Option<std::path::PathBuf>,
     ) -> Self {
         let verification_manager = config.verify.then(XdrVerificationManager::new);
         let bucket_lru = Mutex::new(LruCache::new(
@@ -253,6 +263,7 @@ impl<Op: Operation> Pipeline<Op> {
             stats: ArchiveStats::new(),
             bucket_lru,
             verification_manager,
+            report_path,
         }
     }
 
@@ -330,9 +341,14 @@ impl<Op: Operation> Pipeline<Op> {
     /// side effects like well-known update.
     pub async fn finish(self, highest_checkpoint: u32) -> Result<(), Error> {
         let Self {
-            operation, stats, ..
+            operation,
+            stats,
+            report_path,
+            ..
         } = self;
-        operation.finalize(highest_checkpoint, &stats).await
+        operation
+            .finalize(highest_checkpoint, &stats, report_path.as_deref())
+            .await
     }
 
     /// Consume the pipeline and return its `ArchiveStats`

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -58,9 +58,9 @@ const PROGRESS_REPORTING_FREQUENCY: usize = 100;
 ///
 /// Returned inside `Ok(_)`; the pipeline maps it to the matching
 /// `ArchiveStats` recorder: `Processed` → `record_success`,
-/// `Skipped` → `record_skipped`. Errors are signaled via `Err(_)` in the
-/// surrounding `Result` and recorded by the pipeline as `record_failure`
-/// (after retries exhaust).
+/// `Skipped` → `record_skipped`, `NeedsRepair` → `record_failure`. Errors are
+/// signaled via `Err(_)` in the surrounding `Result` and recorded by the
+/// pipeline as `record_failure` (after retries exhaust).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProcessOutcome {
     /// The operation did its work successfully.
@@ -68,6 +68,55 @@ pub enum ProcessOutcome {
     /// The operation deliberately did no work (e.g. mirror found the file
     /// already present at dst).
     Skipped,
+    /// The operation determined this object needs repair but performed no work
+    /// (e.g. repair dry-run). Recorded as a failure so it appears in
+    /// stats/report, without being an error. Scan/mirror never return this.
+    NeedsRepair,
+}
+
+/// Success outcome of [`Operation::fetch_history_buffer`].
+///
+/// `NeedsRepair` rides on the `Ok` side (not the error channel) so the retry
+/// layer never acts on it: repair uses it to signal "record this checkpoint's
+/// history and skip its bucket discovery" (dry-run), while genuine fetch
+/// failures stay in `Err(StorageError)`.
+pub enum HistoryFetch {
+    /// History downloaded and ready to parse/process.
+    Available(Buffer),
+    /// History needs repair; record it and skip bucket discovery for this cp.
+    NeedsRepair,
+}
+
+impl HistoryFetch {
+    /// Interpret a history-fetch result for checkpoint `cp`: return the buffer
+    /// to process, or `None` (logging why) when the history should be recorded
+    /// as a HISTORY failure and its buckets skipped. The caller does the
+    /// recording, since that needs async stats access.
+    fn buffer_or_skip(
+        result: Result<Self, crate::storage::Error>,
+        cp: u32,
+        history_path: &str,
+    ) -> Option<Buffer> {
+        match result {
+            Ok(HistoryFetch::Available(buf)) => Some(buf),
+            Ok(HistoryFetch::NeedsRepair) => {
+                // Not an error: repair signaled this history needs repair
+                // (dry-run). The actual repair re-fetches history + buckets.
+                debug!(
+                    "History for checkpoint {cp} (0x{cp:08x}) recorded for repair; \
+                     skipping bucket discovery"
+                );
+                None
+            }
+            Err(e) => {
+                warn!(
+                    "Bucket references for checkpoint {cp} (0x{cp:08x}) were not checked \
+                     because {history_path} could not be downloaded: {e}"
+                );
+                None
+            }
+        }
+    }
 }
 
 /// Operation trait for scan, mirror, and repair.
@@ -108,15 +157,21 @@ pub trait Operation: Send + Sync + 'static {
 
     /// Fetch the history buffer for a checkpoint.
     ///
-    /// Default implementation downloads from `src_store` (scan/mirror behavior).
-    /// Repair overrides this to read from destination first, falling back to source.
+    /// Returns `Ok(HistoryFetch::Available(buf))` to process the buffer,
+    /// `Ok(HistoryFetch::NeedsRepair)` to record the history as needing repair
+    /// and skip its bucket discovery (repair dry-run), or `Err(_)` on a genuine
+    /// fetch error. Default implementation downloads from `src_store`
+    /// (scan/mirror behavior). Repair overrides this to read from destination
+    /// first, falling back to source.
     async fn fetch_history_buffer(
         &self,
         history_path: &str,
         src_store: &StorageRef,
         _dst_store: Option<&StorageRef>,
-    ) -> Result<Buffer, crate::storage::Error> {
-        download_buffer(src_store, history_path).await
+    ) -> Result<HistoryFetch, crate::storage::Error> {
+        Ok(HistoryFetch::Available(
+            download_buffer(src_store, history_path).await?,
+        ))
     }
 
     /// Write a fetched buffer (currently the history file) to the operation's
@@ -349,7 +404,7 @@ impl<Op: Operation> Pipeline<Op> {
     ) -> Option<(HistoryFileState, Buffer)> {
         let history_path = checkpoint_path("history", checkpoint);
 
-        let Ok(buffer) = utils::with_retries(
+        let fetched = utils::with_retries(
             self.config.storage_config.max_retries as u32,
             self.config.storage_config.retry_min_delay.as_millis() as u64,
             "download history",
@@ -362,13 +417,11 @@ impl<Op: Operation> Pipeline<Op> {
                 )
             },
         )
-        .await
-        else {
-            warn!(
-                "Bucket references for checkpoint {} (0x{:08x}) were not checked \
-                 because {} could not be downloaded",
-                checkpoint, checkpoint, history_path
-            );
+        .await;
+
+        // `buffer_or_skip` classifies + logs; both skip cases (needs-repair and
+        // fetch error) record the HISTORY failure here and stop bucket discovery.
+        let Some(buffer) = HistoryFetch::buffer_or_skip(fetched, checkpoint, &history_path) else {
             self.stats.record_failure(checkpoint, &history_path).await;
             return None;
         };
@@ -441,6 +494,10 @@ impl<Op: Operation> Pipeline<Op> {
                 debug!("Skipped: {}", path);
                 self.stats.record_skipped(path);
             }
+            Ok(ProcessOutcome::NeedsRepair) => {
+                debug!("Needs repair: {}", path);
+                self.stats.record_failure(checkpoint, path).await;
+            }
             Err(_) => {
                 self.stats.record_failure(checkpoint, path).await;
             }
@@ -473,6 +530,10 @@ impl<Op: Operation> Pipeline<Op> {
             Ok(ProcessOutcome::Skipped) => {
                 debug!("Skipped: {}", path);
                 self.stats.record_skipped(&path);
+            }
+            Ok(ProcessOutcome::NeedsRepair) => {
+                debug!("Needs repair: {}", path);
+                self.stats.record_failure(checkpoint, &path).await;
             }
             Err(_) => {
                 self.stats.record_failure(checkpoint, &path).await;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -6,19 +6,18 @@
 
 use crate::{
     history_format::{self, bucket_path, checkpoint_path, HistoryFileState},
-    storage::{download_buffer, StorageConfig, StorageRef},
+    storage::{StorageConfig, StorageRef},
     utils::{self, ArchiveStats},
     xdr_verify::XdrVerificationManager,
 };
 use futures_util::{
-    future::{join, join3, join_all, OptionFuture},
+    future::{join3, join_all, OptionFuture},
     stream, StreamExt,
 };
 use lru::LruCache;
-use opendal::Buffer;
 use std::sync::Mutex;
 use thiserror::Error;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info};
 
 /// Pipeline errors
 #[derive(Error, Debug)]
@@ -54,7 +53,7 @@ const PROGRESS_REPORTING_FREQUENCY: usize = 100;
 // Operation trait
 // ============================================================================
 
-/// Non-error outcome of `Operation::process_object` / `process_buffer`.
+/// Non-error outcome of `Operation::process_object` / `process_history`.
 ///
 /// Returned inside `Ok(_)`; the pipeline maps it to the matching
 /// `ArchiveStats` recorder: `Processed` → `record_success`,
@@ -74,49 +73,15 @@ pub enum ProcessOutcome {
     NeedsRepair,
 }
 
-/// Success outcome of [`Operation::fetch_history_buffer`].
+/// Result of [`Operation::process_history`].
 ///
-/// `NeedsRepair` rides on the `Ok` side (not the error channel) so the retry
-/// layer never acts on it: repair uses it to signal "record this checkpoint's
-/// history and skip its bucket discovery" (dry-run), while genuine fetch
-/// failures stay in `Err(StorageError)`.
-pub enum HistoryFetch {
-    /// History downloaded and ready to parse/process.
-    Available(Buffer),
-    /// History needs repair; record it and skip bucket discovery for this cp.
-    NeedsRepair,
-}
-
-impl HistoryFetch {
-    /// Interpret a history-fetch result for checkpoint `cp`: return the buffer
-    /// to process, or `None` (logging why) when the history should be recorded
-    /// as a HISTORY failure and its buckets skipped. The caller does the
-    /// recording, since that needs async stats access.
-    fn buffer_or_skip(
-        result: Result<Self, crate::storage::Error>,
-        cp: u32,
-        history_path: &str,
-    ) -> Option<Buffer> {
-        match result {
-            Ok(HistoryFetch::Available(buf)) => Some(buf),
-            Ok(HistoryFetch::NeedsRepair) => {
-                // Not an error: repair signaled this history needs repair
-                // (dry-run). The actual repair re-fetches history + buckets.
-                debug!(
-                    "History for checkpoint {cp} (0x{cp:08x}) recorded for repair; \
-                     skipping bucket discovery"
-                );
-                None
-            }
-            Err(e) => {
-                warn!(
-                    "Bucket references for checkpoint {cp} (0x{cp:08x}) were not checked \
-                     because {history_path} could not be downloaded: {e}"
-                );
-                None
-            }
-        }
-    }
+/// `outcome` is recorded into `ArchiveStats` exactly like `process_object`'s
+/// (`Processed` → success, `Skipped` → skipped, `NeedsRepair` → failure).
+/// `state` carries the parsed HAS for bucket discovery; it is `Some` for
+/// `Processed`/`Skipped` and `None` only for `NeedsRepair`.
+pub struct HistoryOutcome {
+    pub outcome: ProcessOutcome,
+    pub state: Option<HistoryFileState>,
 }
 
 /// Operation trait for scan, mirror, and repair.
@@ -150,6 +115,31 @@ pub trait Operation: Send + Sync + 'static {
         manager: Option<&XdrVerificationManager>,
     ) -> Result<ProcessOutcome, crate::storage::Error>;
 
+    /// Process a checkpoint's history (HAS) file end-to-end, returning its
+    /// parsed state so the pipeline can walk the bucket references it lists.
+    ///
+    /// The history-file analogue of [`Operation::process_object`]: the operation
+    /// owns the full decision (probe destination, fetch from source, write,
+    /// skip) and reports a [`ProcessOutcome`]. `HistoryOutcome::state` is `Some`
+    /// whenever a good HAS was obtained (so its buckets should be walked) and
+    /// `None` only for `ProcessOutcome::NeedsRepair` (repair dry-run on a
+    /// missing/corrupt destination), where bucket discovery is skipped.
+    ///
+    /// - scan: download from `src_store`, parse, never write → `Processed`.
+    /// - mirror: keep a valid dst copy when not overwriting (`Skipped`), else
+    ///   copy from source (`Processed`).
+    /// - repair: keep a valid dst copy (`Processed`, no write); fetch + write
+    ///   from source when missing/corrupt or known-broken; `NeedsRepair` under
+    ///   dry-run.
+    ///
+    /// The HAS is parsed unconditionally (needed for bucket discovery), so there
+    /// is no verification-manager parameter.
+    async fn process_history(
+        &self,
+        path: &str,
+        src_store: &StorageRef,
+    ) -> Result<HistoryOutcome, crate::storage::Error>;
+
     /// Called by `Pipeline::finish` after the manager (if any) has been
     /// drained into `stats.failures`. The operation is responsible for
     /// reporting and deciding `has_failures`-gated success.
@@ -159,37 +149,6 @@ pub trait Operation: Send + Sync + 'static {
         stats: &ArchiveStats,
         report_path: Option<&std::path::Path>,
     ) -> Result<(), Error>;
-
-    /// Fetch the history buffer for a checkpoint.
-    ///
-    /// Returns `Ok(HistoryFetch::Available(buf))` to process the buffer,
-    /// `Ok(HistoryFetch::NeedsRepair)` to record the history as needing repair
-    /// and skip its bucket discovery (repair dry-run), or `Err(_)` on a genuine
-    /// fetch error. Default implementation downloads from `src_store`
-    /// (scan/mirror behavior). Repair overrides this to read from destination
-    /// first, falling back to source.
-    async fn fetch_history_buffer(
-        &self,
-        history_path: &str,
-        src_store: &StorageRef,
-        _dst_store: Option<&StorageRef>,
-    ) -> Result<HistoryFetch, crate::storage::Error> {
-        Ok(HistoryFetch::Available(
-            download_buffer(src_store, history_path).await?,
-        ))
-    }
-
-    /// Write a fetched buffer (currently the history file) to the operation's
-    /// destination.
-    ///
-    /// Implementations diverge by mode: scan returns `Processed` without
-    /// writing; mirror writes via `storage::write_buffer_with_cleanup`;
-    /// repair skips the write in dry-run mode and otherwise writes like mirror.
-    async fn process_buffer(
-        &self,
-        path: &str,
-        buffer: Buffer,
-    ) -> Result<ProcessOutcome, crate::storage::Error>;
 }
 
 // ============================================================================
@@ -223,6 +182,10 @@ pub struct Pipeline<Op: Operation> {
     operation: Op,
     config: PipelineConfig,
     src_store: StorageRef,
+    /// Destination store. Currently unread: the history file now reaches its
+    /// destination via the operation's own `dst_store`. Retained pending a
+    /// follow-up that removes it from `Pipeline::new`.
+    #[allow(dead_code)]
     dst_store: Option<StorageRef>,
     stats: ArchiveStats,
     /// Hash → () presence cache used by `process_buckets` to skip buckets
@@ -401,68 +364,34 @@ impl<Op: Operation> Pipeline<Op> {
         }
     }
 
-    /// Fetch + parse + write a checkpoint's history file, then process all the
-    /// bucket references it discovers.
+    /// Process a checkpoint's history (HAS) file via the operation, then process
+    /// every bucket it references.
     ///
-    /// On history fetch/parse failure, `fetch_history_file_state` this method
-    /// returns early and buckets are not processed. On success, the history
-    /// buffer write and the bucket processing run concurrently.
+    /// The operation owns the probe/fetch/write/skip decision and returns the
+    /// parsed state. Buckets are walked only when a good HAS was obtained
+    /// (`state.is_some()`); a `NeedsRepair` outcome (repair dry-run) or an error
+    /// records the HISTORY failure and skips bucket discovery.
     pub(crate) async fn process_history_and_buckets(&self, checkpoint: u32) {
-        let Some((state, buffer)) = self.fetch_history_file_state(checkpoint).await else {
-            return;
-        };
         let history_path = checkpoint_path("history", checkpoint);
-        let write_history_buffer = self.process_history_file(checkpoint, &history_path, buffer);
-        let buckets = self.process_buckets(checkpoint, state);
-        let _ = join(write_history_buffer, buckets).await;
-    }
-
-    /// Fetch and parse a checkpoint's history file. On download or parse
-    /// failure, logs the error and records a failure into `stats`, returning
-    /// `None`. On success, returns the parsed state alongside the raw buffer
-    /// (the caller needs the buffer to write it to dst).
-    async fn fetch_history_file_state(
-        &self,
-        checkpoint: u32,
-    ) -> Option<(HistoryFileState, Buffer)> {
-        let history_path = checkpoint_path("history", checkpoint);
-
-        let fetched = utils::with_retries(
+        let result = utils::with_retries(
             self.config.storage_config.max_retries as u32,
             self.config.storage_config.retry_min_delay.as_millis() as u64,
-            "download history",
+            "process history",
             &history_path,
-            || {
-                self.operation.fetch_history_buffer(
-                    &history_path,
-                    &self.src_store,
-                    self.dst_store.as_ref(),
-                )
-            },
+            || self.operation.process_history(&history_path, &self.src_store),
         )
         .await;
 
-        // `buffer_or_skip` classifies + logs; both skip cases (needs-repair and
-        // fetch error) record the HISTORY failure here and stop bucket discovery.
-        let Some(buffer) = HistoryFetch::buffer_or_skip(fetched, checkpoint, &history_path) else {
-            self.stats.record_failure(checkpoint, &history_path).await;
-            return None;
-        };
-
-        match history_format::parse_history(&buffer, &history_path) {
-            Ok(state) => Some((state, buffer)),
+        match result {
+            Ok(HistoryOutcome { outcome, state }) => {
+                self.record_outcome(checkpoint, &history_path, Ok(outcome))
+                    .await;
+                if let Some(state) = state {
+                    self.process_buckets(checkpoint, state).await;
+                }
+            }
             Err(e) => {
-                error!(
-                    "Failed to parse history JSON for checkpoint {} (0x{:08x}): {}",
-                    checkpoint, checkpoint, e
-                );
-                warn!(
-                    "Bucket references for checkpoint {} (0x{:08x}) were not checked \
-                     because {} could not be parsed",
-                    checkpoint, checkpoint, history_path
-                );
-                self.stats.record_failure(checkpoint, &history_path).await;
-                None
+                self.record_outcome(checkpoint, &history_path, Err(e)).await;
             }
         }
     }
@@ -491,40 +420,6 @@ impl<Op: Operation> Pipeline<Op> {
         };
 
         join_all(bucket_futures).await;
-    }
-
-    /// Dispatch a parsed history buffer to the operation and record the
-    /// outcome into stats. Mirrors `process_file`'s match pattern but for
-    /// `process_buffer`. Retries write failures on the destination side just
-    /// like `process_object` retries fetch failures on the source side;
-    /// `Buffer` is `Bytes`-backed so each attempt clones cheaply.
-    async fn process_history_file(&self, checkpoint: u32, path: &str, buffer: Buffer) {
-        let result = utils::with_retries(
-            self.config.storage_config.max_retries as u32,
-            self.config.storage_config.retry_min_delay.as_millis() as u64,
-            "process",
-            path,
-            || self.operation.process_buffer(path, buffer.clone()),
-        )
-        .await;
-
-        match result {
-            Ok(ProcessOutcome::Processed) => {
-                debug!("Processed: {}", path);
-                self.stats.record_success(path);
-            }
-            Ok(ProcessOutcome::Skipped) => {
-                debug!("Skipped: {}", path);
-                self.stats.record_skipped(path);
-            }
-            Ok(ProcessOutcome::NeedsRepair) => {
-                debug!("Needs repair: {}", path);
-                self.stats.record_failure(checkpoint, path).await;
-            }
-            Err(_) => {
-                self.stats.record_failure(checkpoint, path).await;
-            }
-        }
     }
 
     /// Record the result of processing a single object/buffer into `stats`,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -53,6 +53,22 @@ const PROGRESS_REPORTING_FREQUENCY: usize = 100;
 // Operation trait
 // ============================================================================
 
+/// Non-error outcome of `Operation::process_object` / `process_buffer`.
+///
+/// Returned inside `Ok(_)`; the pipeline maps it to the matching
+/// `ArchiveStats` recorder: `Processed` → `record_success`,
+/// `Skipped` → `record_skipped`. Errors are signaled via `Err(_)` in the
+/// surrounding `Result` and recorded by the pipeline as `record_failure`
+/// (after retries exhaust).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessOutcome {
+    /// The operation did its work successfully.
+    Processed,
+    /// The operation deliberately did no work (e.g. mirror found the file
+    /// already present at dst).
+    Skipped,
+}
+
 /// Operation trait for scan, mirror, and repair.
 ///
 /// Pipeline owns `src_store`, `dst_store` (optional), `stats`, and handles
@@ -64,29 +80,25 @@ pub trait Operation: Send + Sync + 'static {
     /// Returns (`lower_bound`, `upper_bound`) checkpoints to process.
     async fn get_checkpoint_bounds(&self, source: &StorageRef) -> Result<(u32, u32), Error>;
 
-    /// Process a file from the source archive.
-    /// Each operation decides how to handle it (existence check, verify, copy, etc.).
+    /// Process a single file. Returns:
+    /// - `Ok(Processed)` — work succeeded.
+    /// - `Ok(Skipped)` — operation chose not to do the work (e.g. mirror when
+    ///   dst already has the file).
+    /// - `Err(_)` — wrapped by `with_retries`; final failure after retries
+    ///   exhaust is recorded by the pipeline.
+    ///
+    /// `checkpoint` is the context cp; for buckets, the discovering cp.
     async fn process_object(
         &self,
+        checkpoint: u32,
         path: &str,
         _src_store: &StorageRef,
-    ) -> Result<(), crate::storage::Error>;
+    ) -> Result<ProcessOutcome, crate::storage::Error>;
 
     /// Called when all work is complete. Pipeline passes stats for operations
     /// that need to check failure counts or record additional failures
     /// (e.g., cross-validation).
     async fn finalize(&self, highest_checkpoint: u32, stats: &ArchiveStats) -> Result<(), Error>;
-
-    /// Pre-check before hitting the source. Allows operations to skip files
-    /// without making a source request (e.g., if destination already exists).
-    ///
-    /// Returns:
-    /// - `Some(Ok(()))` to skip (file already handled)
-    /// - `Some(Err(e))` if pre-check failed
-    /// - `None` to proceed with fetching from source
-    async fn pre_check(&self, _path: &str) -> Option<Result<(), crate::storage::Error>> {
-        None
-    }
 
     /// Called when all files for a checkpoint have been processed.
     fn finalize_checkpoint(&self, _checkpoint: u32) {}
@@ -105,12 +117,17 @@ pub trait Operation: Send + Sync + 'static {
     }
 
     /// Write a fetched buffer (currently the history file) to the operation's
-    /// destination and record the outcome into `stats`.
+    /// destination.
     ///
-    /// Implementations diverge by mode: scan records success without writing;
-    /// mirror writes via `storage::write_buffer_with_cleanup`; repair skips the
-    /// write entirely in dry-run mode and otherwise writes like mirror.
-    async fn process_buffer(&self, path: &str, buffer: Buffer, stats: &ArchiveStats);
+    /// Implementations diverge by mode: scan returns `Processed` without
+    /// writing; mirror writes via `storage::write_buffer_with_cleanup`;
+    /// repair skips the write in dry-run mode and otherwise writes like mirror.
+    async fn process_buffer(
+        &self,
+        checkpoint: u32,
+        path: &str,
+        buffer: Buffer,
+    ) -> Result<ProcessOutcome, crate::storage::Error>;
 }
 
 // ============================================================================
@@ -211,23 +228,21 @@ impl<Op: Operation> Pipeline<Op> {
                 return;
             };
             let history_path = checkpoint_path("history", checkpoint);
-            let write_history_buffer =
-                self.operation
-                    .process_buffer(&history_path, buffer, &self.stats);
-            let buckets = self.process_buckets(state);
+            let write_history_buffer = self.process_history_file(checkpoint, &history_path, buffer);
+            let buckets = self.process_buckets(checkpoint, state);
             let _ = join(write_history_buffer, buckets).await;
         };
 
         let cats = join_all(["ledger", "transactions", "results"].map(|cat| {
             let path = checkpoint_path(cat, checkpoint);
-            self.process_file(path)
+            self.process_file(checkpoint, path)
         }));
 
         if self.config.skip_optional {
             let _ = join(history_work, cats).await;
         } else {
             let scp_path = checkpoint_path("scp", checkpoint);
-            let scp = self.process_file(scp_path);
+            let scp = self.process_file(checkpoint, scp_path);
             let _ = join3(history_work, cats, scp).await;
         }
 
@@ -264,7 +279,7 @@ impl<Op: Operation> Pipeline<Op> {
                  because {} could not be downloaded",
                 checkpoint, checkpoint, history_path
             );
-            self.stats.record_failure(&history_path).await;
+            self.stats.record_failure(checkpoint, &history_path).await;
             return None;
         };
 
@@ -280,7 +295,7 @@ impl<Op: Operation> Pipeline<Op> {
                      because {} could not be parsed",
                     checkpoint, checkpoint, history_path
                 );
-                self.stats.record_failure(&history_path).await;
+                self.stats.record_failure(checkpoint, &history_path).await;
                 None
             }
         }
@@ -291,7 +306,7 @@ impl<Op: Operation> Pipeline<Op> {
     /// → collect (CPU-only — `LruCache::put` returns `None` iff the key is
     /// new); each surviving `process_file` future then runs concurrently
     /// outside the lock.
-    async fn process_buckets(&self, state: HistoryFileState) {
+    async fn process_buckets(&self, checkpoint: u32, state: HistoryFileState) {
         let bucket_futures: Vec<_> = {
             let mut cache = self.bucket_lru.lock().unwrap();
             state
@@ -299,7 +314,9 @@ impl<Op: Operation> Pipeline<Op> {
                 .iter()
                 .filter_map(|bucket| {
                     if cache.put(bucket.clone(), ()).is_none() {
-                        bucket_path(bucket).ok().map(|path| self.process_file(path))
+                        bucket_path(bucket)
+                            .ok()
+                            .map(|path| self.process_file(checkpoint, path))
                     } else {
                         None
                     }
@@ -310,39 +327,65 @@ impl<Op: Operation> Pipeline<Op> {
         join_all(bucket_futures).await;
     }
 
-    /// Process a single file (bucket, ledger, transactions, results, scp).
-    async fn process_file(&self, path: String) {
-        // Pre-check: allow operation to skip without querying source
-        if let Some(result) = self.operation.pre_check(&path).await {
-            match result {
-                Ok(()) => {
-                    debug!("Skipping: {}", path);
-                    self.stats.record_skipped(&path);
-                }
-                Err(e) => {
-                    error!("Pre-check failed for {}: {}", path, e);
-                    self.stats.record_failure(&path).await;
-                }
-            }
-            return;
-        }
+    /// Dispatch a parsed history buffer to the operation and record the
+    /// outcome into stats. Mirrors `process_file`'s match pattern but for
+    /// `process_buffer`. Retries write failures on the destination side just
+    /// like `process_object` retries fetch failures on the source side;
+    /// `Buffer` is `Bytes`-backed so each attempt clones cheaply.
+    async fn process_history_file(&self, checkpoint: u32, path: &str, buffer: Buffer) {
+        let result = utils::with_retries(
+            self.config.storage_config.max_retries as u32,
+            self.config.storage_config.retry_min_delay.as_millis() as u64,
+            "process",
+            path,
+            || {
+                self.operation
+                    .process_buffer(checkpoint, path, buffer.clone())
+            },
+        )
+        .await;
 
+        match result {
+            Ok(ProcessOutcome::Processed) => {
+                debug!("Processed: {}", path);
+                self.stats.record_success(path);
+            }
+            Ok(ProcessOutcome::Skipped) => {
+                debug!("Skipped: {}", path);
+                self.stats.record_skipped(path);
+            }
+            Err(_) => {
+                self.stats.record_failure(checkpoint, path).await;
+            }
+        }
+    }
+
+    /// Process a single file (bucket, ledger, transactions, results, scp).
+    /// `checkpoint` is the cp context (for buckets, the discovering cp).
+    async fn process_file(&self, checkpoint: u32, path: String) {
         let result = utils::with_retries(
             self.config.storage_config.max_retries as u32,
             self.config.storage_config.retry_min_delay.as_millis() as u64,
             "process",
             &path,
-            || self.operation.process_object(&path, &self.src_store),
+            || {
+                self.operation
+                    .process_object(checkpoint, &path, &self.src_store)
+            },
         )
         .await;
 
         match result {
-            Ok(()) => {
+            Ok(ProcessOutcome::Processed) => {
                 debug!("Processed: {}", path);
                 self.stats.record_success(&path);
             }
+            Ok(ProcessOutcome::Skipped) => {
+                debug!("Skipped: {}", path);
+                self.stats.record_skipped(&path);
+            }
             Err(_) => {
-                self.stats.record_failure(&path).await;
+                self.stats.record_failure(checkpoint, &path).await;
             }
         }
     }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -17,7 +17,7 @@ use futures_util::{
 use lru::LruCache;
 use std::sync::Mutex;
 use thiserror::Error;
-use tracing::{debug, info};
+use tracing::{debug, error, info};
 
 /// Pipeline errors
 #[derive(Error, Debug)]
@@ -382,28 +382,51 @@ impl<Op: Operation> Pipeline<Op> {
         }
     }
 
-    /// Process every bucket referenced by `state`, deduped against the
-    /// pipeline-wide `bucket_lru`. The lock is held only across the filter-map
-    /// → collect (CPU-only — `LruCache::put` returns `None` iff the key is
-    /// new); each surviving `process_file` future then runs concurrently
-    /// outside the lock.
-    async fn process_buckets(&self, checkpoint: u32, state: HistoryFileState) {
-        let bucket_futures: Vec<_> = {
-            let mut cache = self.bucket_lru.lock().unwrap();
-            state
-                .buckets()
-                .iter()
-                .filter_map(|bucket| {
-                    if cache.put(bucket.clone(), ()).is_none() {
-                        bucket_path(bucket)
-                            .ok()
-                            .map(|path| self.process_file(checkpoint, path))
-                    } else {
-                        None
-                    }
-                })
-                .collect()
+    /// Schedule one bucket file through the shared dedupe gate. Both bucket
+    /// routes funnel here: HISTORY-discovered buckets (via `process_buckets`)
+    /// and buckets listed directly in `failures.buckets` (repair file-retry).
+    /// The pipeline-wide `bucket_lru` makes the first sighting of a
+    /// content-addressed bucket responsible for processing it; later sightings
+    /// in the same run are skipped (without recording a `Skipped` stat, matching
+    /// the prior `process_buckets` dedupe accounting).
+    ///
+    /// `bucket_hash_from_path` canonicalizes to lowercase 64-hex, so a bucket
+    /// reached as a HISTORY ref (hash → path → here) and one listed directly
+    /// (`hex::encode` → path → here) produce the SAME LRU key and dedupe — do
+    /// not drop this normalization in favor of keying on the raw path.
+    pub(crate) async fn process_bucket_file(&self, checkpoint: u32, path: String) {
+        // Invariant: callers only pass real bucket paths — `process_buckets`
+        // builds them via `bucket_path`, and repair's dispatch guards with
+        // `is_bucket_file` (which requires `bucket_hash_from_path` to be `Some`).
+        // A missing hash here is a routing bug, not a runtime condition.
+        let Some(bucket_hash) = history_format::bucket_hash_from_path(&path) else {
+            debug_assert!(false, "process_bucket_file requires a bucket path, got {path}");
+            error!("process_bucket_file got a non-bucket path, skipping: {path}");
+            return;
         };
+
+        // First sighting of this content-addressed bucket in the run? Scope the
+        // LRU guard so it is released before the await below.
+        let first_sighting = {
+            let mut cache = self.bucket_lru.lock().unwrap();
+            cache.put(bucket_hash, ()).is_none()
+        };
+        if first_sighting {
+            self.process_file(checkpoint, path).await;
+        } else {
+            debug!("Skipped duplicate bucket sighting: {}", path);
+        }
+    }
+
+    /// Expand a parsed HAS into bucket work, scheduling each referenced bucket
+    /// through [`Self::process_bucket_file`] (which owns the dedupe LRU gate).
+    async fn process_buckets(&self, checkpoint: u32, state: HistoryFileState) {
+        let bucket_futures: Vec<_> = state
+            .buckets()
+            .iter()
+            .filter_map(|bucket| bucket_path(bucket).ok())
+            .map(|path| self.process_bucket_file(checkpoint, path))
+            .collect();
 
         join_all(bucket_futures).await;
     }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -307,9 +307,12 @@ impl<Op: Operation> Pipeline<Op> {
     where
         I: IntoIterator<Item = u32>,
     {
-        let cps: Vec<u32> = cps.into_iter().collect();
-        let total = cps.len();
-        if total == 0 {
+        let cps = cps.into_iter();
+        // size_hint's upper bound is the exact count for every caller's
+        // iterator (StepBy<RangeInclusive<u32>> on the main path, Vec/set
+        // elsewhere), and we only use it for status reporting.
+        let total = cps.size_hint().1;
+        if total == Some(0) {
             return Ok(());
         }
 
@@ -320,8 +323,12 @@ impl<Op: Operation> Pipeline<Op> {
             .for_each_concurrent(self.config.concurrency, |ck| async move {
                 self.process_checkpoint(ck).await;
                 let done = completed_ref.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
-                if done.is_multiple_of(PROGRESS_REPORTING_FREQUENCY) || done == total {
-                    info!("Progress: {}/{} checkpoints processed", done, total);
+                if done.is_multiple_of(PROGRESS_REPORTING_FREQUENCY) || total == Some(done) {
+                    if let Some(total) = total {
+                        info!("Progress: {done}/{total} checkpoints processed");
+                    } else {
+                        info!("Progress: {done} checkpoints processed");
+                    }
                 }
             })
             .await;
@@ -330,7 +337,7 @@ impl<Op: Operation> Pipeline<Op> {
         // manager errors into `stats.failures`.
         if let Some(manager) = &self.verification_manager {
             manager.verify_checkpoint_chain();
-            manager.record_all_errors(&mut *self.stats.failures.lock().await);
+            manager.drain_all_errors(&mut *self.stats.failures.lock().await);
         }
 
         Ok(())

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -11,7 +11,7 @@ use crate::{
     xdr_verify::XdrVerificationManager,
 };
 use futures_util::{
-    future::{join, join3, join_all},
+    future::{join, join3, join_all, OptionFuture},
     stream, StreamExt,
 };
 use lru::LruCache;
@@ -142,6 +142,14 @@ pub struct PipelineConfig {
     pub concurrency: usize,
     /// Whether to skip optional SCP files
     pub skip_optional: bool,
+    /// When true, `process_checkpoint` skips `process_history_and_buckets`
+    /// entirely — no HAS fetch, no bucket discovery, no bucket fetches.
+    /// Used by repair's `retry_failed_checkpoints` inner pipeline, where
+    /// chain repair only needs the per-cp xdr files (ledger/tx/results/scp)
+    /// and bucket / HAS work is either redundant (`retry_failed_files`
+    /// covers bucket repair via `failures.buckets` and HISTORY-flagged
+    /// entries) or unnecessary (chain checks don't read bucket content).
+    pub skip_history_and_buckets: bool,
     /// Whether to construct the pipeline's XDR verification manager. When
     /// true, `process_object` receives `Some(&XdrVerificationManager)` and
     /// the pipeline drives `verify_and_release` per cp + chain check + drain
@@ -286,25 +294,26 @@ impl<Op: Operation> Pipeline<Op> {
     /// the pipeline machinery directly without `Pipeline::run`'s full bounds +
     /// iteration loop.
     pub async fn process_checkpoint(&self, checkpoint: u32) {
-        // History work fetches + parses + writes the history buffer and
-        // processes the bucket references it discovers. Fetch/parse failures
-        // are logged and recorded inside `fetch_history_file_state`; on
-        // failure the work returns early so the rest of the checkpoint's files
-        // still get processed.
-        let history_work = self.process_history_and_buckets(checkpoint);
+        // Always: the three required per-cp xdr files.
+        let cats = join_all(
+            ["ledger", "transactions", "results"]
+                .map(|cat| self.process_file(checkpoint, checkpoint_path(cat, checkpoint))),
+        );
 
-        let cats = join_all(["ledger", "transactions", "results"].map(|cat| {
-            let path = checkpoint_path(cat, checkpoint);
-            self.process_file(checkpoint, path)
-        }));
+        // Optional: SCP file. Skipped when `skip_optional` is set.
+        let scp: OptionFuture<_> = (!self.config.skip_optional)
+            .then(|| self.process_file(checkpoint, checkpoint_path("scp", checkpoint)))
+            .into();
 
-        if self.config.skip_optional {
-            let _ = join(history_work, cats).await;
-        } else {
-            let scp_path = checkpoint_path("scp", checkpoint);
-            let scp = self.process_file(checkpoint, scp_path);
-            let _ = join3(history_work, cats, scp).await;
-        }
+        // Optional: HAS fetch + bucket discovery + bucket fetches. Skipped
+        // by repair's `retry_failed_checkpoints` inner pipeline (chain
+        // repair only needs the per-cp xdr files; bucket / HAS work is
+        // handled by `retry_failed_files`).
+        let history: OptionFuture<_> = (!self.config.skip_history_and_buckets)
+            .then(|| self.process_history_and_buckets(checkpoint))
+            .into();
+
+        let _ = join3(cats, scp, history).await;
 
         // Per-cp manager release: drive `verify_and_release` for this cp's
         // accumulated per-file data. Triggers intra-cp completeness, tx/result

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -8,6 +8,7 @@ use crate::{
     history_format::{self, bucket_path, checkpoint_path, HistoryFileState},
     storage::{download_buffer, StorageConfig, StorageRef},
     utils::{self, ArchiveStats},
+    xdr_verify::XdrVerificationManager,
 };
 use futures_util::{
     future::{join, join3, join_all},
@@ -88,20 +89,22 @@ pub trait Operation: Send + Sync + 'static {
     ///   exhaust is recorded by the pipeline.
     ///
     /// `checkpoint` is the context cp; for buckets, the discovering cp.
+    /// `manager` is `Some` iff the pipeline was constructed with
+    /// `PipelineConfig::verify = true` — operations should branch on it
+    /// to decide between verify-and-record vs existence-only / plain-copy
+    /// paths, and call `manager.record_*` to feed per-file XDR data into
+    /// the pipeline's manager.
     async fn process_object(
         &self,
-        checkpoint: u32,
         path: &str,
         _src_store: &StorageRef,
+        manager: Option<&XdrVerificationManager>,
     ) -> Result<ProcessOutcome, crate::storage::Error>;
 
-    /// Called when all work is complete. Pipeline passes stats for operations
-    /// that need to check failure counts or record additional failures
-    /// (e.g., cross-validation).
+    /// Called by `Pipeline::finish` after the manager (if any) has been
+    /// drained into `stats.failures`. The operation is responsible for
+    /// reporting and deciding `has_failures`-gated success.
     async fn finalize(&self, highest_checkpoint: u32, stats: &ArchiveStats) -> Result<(), Error>;
-
-    /// Called when all files for a checkpoint have been processed.
-    fn finalize_checkpoint(&self, _checkpoint: u32) {}
 
     /// Fetch the history buffer for a checkpoint.
     ///
@@ -124,7 +127,6 @@ pub trait Operation: Send + Sync + 'static {
     /// repair skips the write in dry-run mode and otherwise writes like mirror.
     async fn process_buffer(
         &self,
-        checkpoint: u32,
         path: &str,
         buffer: Buffer,
     ) -> Result<ProcessOutcome, crate::storage::Error>;
@@ -140,6 +142,11 @@ pub struct PipelineConfig {
     pub concurrency: usize,
     /// Whether to skip optional SCP files
     pub skip_optional: bool,
+    /// Whether to construct the pipeline's XDR verification manager. When
+    /// true, `process_object` receives `Some(&XdrVerificationManager)` and
+    /// the pipeline drives `verify_and_release` per cp + chain check + drain
+    /// at the end of `run_checkpoints`.
+    pub verify: bool,
     /// Storage layer configuration (retry, timeout, bandwidth, etc.)
     pub storage_config: StorageConfig,
 }
@@ -153,6 +160,12 @@ pub struct Pipeline<Op: Operation> {
     /// Hash → () presence cache used by `process_buckets` to skip buckets
     /// already seen elsewhere in this pipeline run.
     bucket_lru: Mutex<LruCache<String, ()>>,
+    /// XDR verification manager — `Some` iff `config.verify` is true.
+    /// Pipeline drives the full manager lifecycle (record-per-file via the
+    /// `process_object` parameter, `verify_and_release` per cp in
+    /// `process_checkpoint`, `verify_checkpoint_chain` + `record_all_errors`
+    /// drain at the end of `run_checkpoints`).
+    verification_manager: Option<XdrVerificationManager>,
 }
 
 impl<Op: Operation> Pipeline<Op> {
@@ -164,6 +177,7 @@ impl<Op: Operation> Pipeline<Op> {
         src_store: StorageRef,
         dst_store: Option<StorageRef>,
     ) -> Self {
+        let verification_manager = config.verify.then(XdrVerificationManager::new);
         let bucket_lru = Mutex::new(LruCache::new(
             std::num::NonZeroUsize::new(BUCKET_LRU_CACHE_SIZE).unwrap(),
         ));
@@ -175,39 +189,93 @@ impl<Op: Operation> Pipeline<Op> {
             dst_store,
             stats: ArchiveStats::new(),
             bucket_lru,
+            verification_manager,
         }
     }
 
-    pub async fn run(&self) -> Result<(), Error> {
+    /// Read-only handle to the pipeline's owned `ArchiveStats`. Use this when
+    /// a caller (e.g. repair's retry phase) needs to report or inspect the
+    /// pipeline's stats after `run_checkpoints` returns.
+    pub fn stats(&self) -> &ArchiveStats {
+        &self.stats
+    }
+
+    /// Full pipeline run — consumes the pipeline.
+    ///
+    /// Computes checkpoint bounds via the operation, drives the per-cp
+    /// loop, then hands off to [`Self::finish`].
+    pub async fn run(self) -> Result<(), Error> {
         let (lower_bound, upper_bound) = self
             .operation
             .get_checkpoint_bounds(&self.src_store)
             .await?;
 
         let total_count = history_format::count_checkpoints_in_range(lower_bound, upper_bound);
-        if total_count == 0 {
+        if total_count != 0 {
+            let checkpoints =
+                (lower_bound..=upper_bound).step_by(history_format::CHECKPOINT_FREQUENCY as usize);
+            self.run_checkpoints(checkpoints).await?;
+        } else {
             info!("No checkpoints to process");
+        }
+        self.finish(upper_bound).await
+    }
+
+    /// Run the pipeline over an explicit set of checkpoints (possibly
+    /// disjoint or non-consecutive). Each checkpoint is dispatched through
+    /// `process_checkpoint` and bounded by `config.concurrency`.
+    ///
+    /// Does **not** call `operation.finalize` — that's [`Self::finish`]'s job.
+    /// Callers that want the full lifecycle should use [`Self::run`] (or
+    /// pair `run_checkpoints` with an explicit `finish`).
+    /// An empty input is a no-op.
+    pub async fn run_checkpoints<I>(&self, cps: I) -> Result<(), Error>
+    where
+        I: IntoIterator<Item = u32>,
+    {
+        let cps: Vec<u32> = cps.into_iter().collect();
+        let total = cps.len();
+        if total == 0 {
             return Ok(());
         }
 
         let num_completed = std::sync::atomic::AtomicUsize::new(0);
         let completed_ref = &num_completed;
-        let checkpoints =
-            (lower_bound..=upper_bound).step_by(history_format::CHECKPOINT_FREQUENCY as usize);
 
-        stream::iter(checkpoints)
+        stream::iter(cps)
             .for_each_concurrent(self.config.concurrency, |ck| async move {
                 self.process_checkpoint(ck).await;
                 let done = completed_ref.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
-                if done.is_multiple_of(PROGRESS_REPORTING_FREQUENCY) || done == total_count {
-                    info!("Progress: {}/{} checkpoints processed", done, total_count);
+                if done.is_multiple_of(PROGRESS_REPORTING_FREQUENCY) || done == total {
+                    info!("Progress: {}/{} checkpoints processed", done, total);
                 }
             })
             .await;
 
-        self.operation.finalize(upper_bound, &self.stats).await?;
+        // Batch-completion: run the cross-cp chain check and drain accumulated
+        // manager errors into `stats.failures`.
+        if let Some(manager) = &self.verification_manager {
+            manager.verify_checkpoint_chain();
+            manager.record_all_errors(&mut *self.stats.failures.lock().await);
+        }
 
         Ok(())
+    }
+
+    /// Consume the pipeline and run `operation.finalize` with `&stats` for
+    /// operation-specific wrap-up (report, has_failures gate, op-specific
+    /// side effects like well-known update.
+    pub async fn finish(self, highest_checkpoint: u32) -> Result<(), Error> {
+        let Self {
+            operation, stats, ..
+        } = self;
+        operation.finalize(highest_checkpoint, &stats).await
+    }
+
+    /// Consume the pipeline and return its `ArchiveStats`
+    pub fn into_stats(self) -> ArchiveStats {
+        let Self { stats, .. } = self;
+        stats
     }
 
     /// Process a single checkpoint: history+buckets concurrently with the
@@ -218,20 +286,12 @@ impl<Op: Operation> Pipeline<Op> {
     /// the pipeline machinery directly without `Pipeline::run`'s full bounds +
     /// iteration loop.
     pub async fn process_checkpoint(&self, checkpoint: u32) {
-        // History work: fetch + parse, then concurrently write the buffer to
-        // dst and process the buckets it references. Fetch/parse failures are
-        // logged and recorded inside `fetch_history_file_state`; on failure
-        // this future just returns early so the rest of the checkpoint's files
+        // History work fetches + parses + writes the history buffer and
+        // processes the bucket references it discovers. Fetch/parse failures
+        // are logged and recorded inside `fetch_history_file_state`; on
+        // failure the work returns early so the rest of the checkpoint's files
         // still get processed.
-        let history_work = async {
-            let Some((state, buffer)) = self.fetch_history_file_state(checkpoint).await else {
-                return;
-            };
-            let history_path = checkpoint_path("history", checkpoint);
-            let write_history_buffer = self.process_history_file(checkpoint, &history_path, buffer);
-            let buckets = self.process_buckets(checkpoint, state);
-            let _ = join(write_history_buffer, buckets).await;
-        };
+        let history_work = self.process_history_and_buckets(checkpoint);
 
         let cats = join_all(["ledger", "transactions", "results"].map(|cat| {
             let path = checkpoint_path(cat, checkpoint);
@@ -246,7 +306,28 @@ impl<Op: Operation> Pipeline<Op> {
             let _ = join3(history_work, cats, scp).await;
         }
 
-        self.operation.finalize_checkpoint(checkpoint);
+        // Per-cp manager release: drive `verify_and_release` for this cp's
+        // accumulated per-file data. Triggers intra-cp completeness, tx/result
+        // hash cross-checks, and the internal hash chain check.
+        if let Some(manager) = &self.verification_manager {
+            manager.verify_and_release(checkpoint);
+        }
+    }
+
+    /// Fetch + parse + write a checkpoint's history file, then process all the
+    /// bucket references it discovers.
+    ///
+    /// On history fetch/parse failure, `fetch_history_file_state` this method
+    /// returns early and buckets are not processed. On success, the history
+    /// buffer write and the bucket processing run concurrently.
+    pub(crate) async fn process_history_and_buckets(&self, checkpoint: u32) {
+        let Some((state, buffer)) = self.fetch_history_file_state(checkpoint).await else {
+            return;
+        };
+        let history_path = checkpoint_path("history", checkpoint);
+        let write_history_buffer = self.process_history_file(checkpoint, &history_path, buffer);
+        let buckets = self.process_buckets(checkpoint, state);
+        let _ = join(write_history_buffer, buckets).await;
     }
 
     /// Fetch and parse a checkpoint's history file. On download or parse
@@ -338,10 +419,7 @@ impl<Op: Operation> Pipeline<Op> {
             self.config.storage_config.retry_min_delay.as_millis() as u64,
             "process",
             path,
-            || {
-                self.operation
-                    .process_buffer(checkpoint, path, buffer.clone())
-            },
+            || self.operation.process_buffer(path, buffer.clone()),
         )
         .await;
 
@@ -362,15 +440,18 @@ impl<Op: Operation> Pipeline<Op> {
 
     /// Process a single file (bucket, ledger, transactions, results, scp).
     /// `checkpoint` is the cp context (for buckets, the discovering cp).
-    async fn process_file(&self, checkpoint: u32, path: String) {
+    pub(crate) async fn process_file(&self, checkpoint: u32, path: String) {
         let result = utils::with_retries(
             self.config.storage_config.max_retries as u32,
             self.config.storage_config.retry_min_delay.as_millis() as u64,
             "process",
             &path,
             || {
-                self.operation
-                    .process_object(checkpoint, &path, &self.src_store)
+                self.operation.process_object(
+                    &path,
+                    &self.src_store,
+                    self.verification_manager.as_ref(),
+                )
             },
         )
         .await;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     history_format::{self, bucket_path, checkpoint_path, HistoryFileState},
-    storage::{StorageConfig, StorageRef},
+    storage::StorageConfig,
     utils::{self, ArchiveStats},
     xdr_verify::XdrVerificationManager,
 };
@@ -86,14 +86,15 @@ pub struct HistoryOutcome {
 
 /// Operation trait for scan, mirror, and repair.
 ///
-/// Pipeline owns `src_store`, `dst_store` (optional), `stats`, and handles
-/// buffer writing and stats recording. Operations implement domain-specific
-/// logic: checkpoint bounds, file processing, verification, and finalization.
+/// Pipeline owns `stats` and the orchestration machinery (concurrency, retries,
+/// bucket dedup, verification manager); each `Operation` owns the storage
+/// backends it reads/writes. Operations implement domain-specific logic:
+/// checkpoint bounds, file processing, verification, and finalization.
 #[async_trait::async_trait]
 pub trait Operation: Send + Sync + 'static {
     /// Get the checkpoint bounds for this operation.
     /// Returns (`lower_bound`, `upper_bound`) checkpoints to process.
-    async fn get_checkpoint_bounds(&self, source: &StorageRef) -> Result<(u32, u32), Error>;
+    async fn get_checkpoint_bounds(&self) -> Result<(u32, u32), Error>;
 
     /// Process a single file. Returns:
     /// - `Ok(Processed)` — work succeeded.
@@ -111,7 +112,6 @@ pub trait Operation: Send + Sync + 'static {
     async fn process_object(
         &self,
         path: &str,
-        _src_store: &StorageRef,
         manager: Option<&XdrVerificationManager>,
     ) -> Result<ProcessOutcome, crate::storage::Error>;
 
@@ -125,7 +125,7 @@ pub trait Operation: Send + Sync + 'static {
     /// `None` only for `ProcessOutcome::NeedsRepair` (repair dry-run on a
     /// missing/corrupt destination), where bucket discovery is skipped.
     ///
-    /// - scan: download from `src_store`, parse, never write → `Processed`.
+    /// - scan: download from the source, parse, never write → `Processed`.
     /// - mirror: keep a valid dst copy when not overwriting (`Skipped`), else
     ///   copy from source (`Processed`).
     /// - repair: keep a valid dst copy (`Processed`, no write); fetch + write
@@ -137,7 +137,6 @@ pub trait Operation: Send + Sync + 'static {
     async fn process_history(
         &self,
         path: &str,
-        src_store: &StorageRef,
     ) -> Result<HistoryOutcome, crate::storage::Error>;
 
     /// Called by `Pipeline::finish` after the manager (if any) has been
@@ -181,12 +180,6 @@ pub struct PipelineConfig {
 pub struct Pipeline<Op: Operation> {
     operation: Op,
     config: PipelineConfig,
-    src_store: StorageRef,
-    /// Destination store. Currently unread: the history file now reaches its
-    /// destination via the operation's own `dst_store`. Retained pending a
-    /// follow-up that removes it from `Pipeline::new`.
-    #[allow(dead_code)]
-    dst_store: Option<StorageRef>,
     stats: ArchiveStats,
     /// Hash → () presence cache used by `process_buckets` to skip buckets
     /// already seen elsewhere in this pipeline run.
@@ -204,13 +197,11 @@ pub struct Pipeline<Op: Operation> {
 }
 
 impl<Op: Operation> Pipeline<Op> {
-    /// Create a new pipeline.
-    /// Callers create storage backends and pass them in directly.
+    /// Create a new pipeline. The operation owns the storage backends it needs;
+    /// the pipeline holds none.
     pub fn new(
         operation: Op,
         config: PipelineConfig,
-        src_store: StorageRef,
-        dst_store: Option<StorageRef>,
         report_path: Option<std::path::PathBuf>,
     ) -> Self {
         let verification_manager = config.verify.then(XdrVerificationManager::new);
@@ -221,8 +212,6 @@ impl<Op: Operation> Pipeline<Op> {
         Self {
             operation,
             config,
-            src_store,
-            dst_store,
             stats: ArchiveStats::new(),
             bucket_lru,
             verification_manager,
@@ -242,10 +231,7 @@ impl<Op: Operation> Pipeline<Op> {
     /// Computes checkpoint bounds via the operation, drives the per-cp
     /// loop, then hands off to [`Self::finish`].
     pub async fn run(self) -> Result<(), Error> {
-        let (lower_bound, upper_bound) = self
-            .operation
-            .get_checkpoint_bounds(&self.src_store)
-            .await?;
+        let (lower_bound, upper_bound) = self.operation.get_checkpoint_bounds().await?;
 
         let total_count = history_format::count_checkpoints_in_range(lower_bound, upper_bound);
         if total_count != 0 {
@@ -378,7 +364,7 @@ impl<Op: Operation> Pipeline<Op> {
             self.config.storage_config.retry_min_delay.as_millis() as u64,
             "process history",
             &history_path,
-            || self.operation.process_history(&history_path, &self.src_store),
+            || self.operation.process_history(&history_path),
         )
         .await;
 
@@ -459,11 +445,8 @@ impl<Op: Operation> Pipeline<Op> {
             "process",
             &path,
             || {
-                self.operation.process_object(
-                    &path,
-                    &self.src_store,
-                    self.verification_manager.as_ref(),
-                )
+                self.operation
+                    .process_object(&path, self.verification_manager.as_ref())
             },
         )
         .await;

--- a/src/repair_operation.rs
+++ b/src/repair_operation.rs
@@ -30,13 +30,13 @@
 use crate::history_format;
 use crate::mirror_operation::MirrorOperation;
 use crate::pipeline::{
-    self, async_trait, HistoryFetch, Operation, Pipeline, PipelineConfig, ProcessOutcome,
+    self, async_trait, HistoryOutcome, Operation, Pipeline, PipelineConfig, ProcessOutcome,
 };
 use crate::storage::{self, Error as StorageError, ErrorClass, StorageRef};
 use crate::utils::{self, ArchiveStats, FailureTracker};
 use crate::xdr_verify::{self, XdrParseResult, XdrVerificationManager};
 use futures_util::{stream, StreamExt};
-use opendal::{Buffer, Reader};
+use opendal::Reader;
 use std::sync::atomic::{AtomicBool, Ordering};
 use thiserror::Error;
 use tracing::{error, info, warn};
@@ -669,35 +669,54 @@ impl Operation for RepairOperation {
         Ok(ProcessOutcome::Processed)
     }
 
-    /// Override history buffer sourcing: read from destination first, fall back to source.
-    async fn fetch_history_buffer(
+    /// Process the history file: probe the destination first (a valid copy is
+    /// kept as-is, with NO write — symmetric with `verify_and_record_dst`), and
+    /// fetch from source only when the dst copy is missing/corrupt or the file
+    /// is on the known-broken list. Returns the parsed state so the pipeline can
+    /// walk bucket references.
+    async fn process_history(
         &self,
-        history_path: &str,
+        path: &str,
         src_store: &StorageRef,
-        dst_store: Option<&StorageRef>,
-    ) -> Result<HistoryFetch, StorageError> {
-        // Try reading from destination (local, cheap)
-        if let Some(dst) = dst_store {
-            if let Ok(buffer) = storage::download_buffer(dst, history_path).await {
-                if history_format::parse_history(&buffer, history_path).is_ok() {
-                    return Ok(HistoryFetch::Available(buffer));
+    ) -> Result<HistoryOutcome, StorageError> {
+        // Failed-list mode: a listed file is fetched from source directly (no dst
+        // probe), honoring `known_broken` exactly as verify_and_record_dst does.
+        let listed = self
+            .known_broken
+            .as_ref()
+            .is_some_and(|kb| kb.contains_path(path));
+
+        if !listed {
+            if let Ok(buffer) = storage::download_buffer(&self.dst_store, path).await {
+                if let Ok(state) = history_format::parse_history(&buffer, path) {
+                    // Healthy dst copy: keep it, do not write.
+                    return Ok(HistoryOutcome {
+                        outcome: ProcessOutcome::Processed,
+                        state: Some(state),
+                    });
                 }
-                // Exists but corrupt — fall through to source
+                // present but corrupt -> fall through and repair
             }
         }
 
-        // Destination missing or corrupt.
+        // Destination missing/corrupt, or this file is on the known-broken list.
         if self.dry_run {
-            // Signal "needs repair": the pipeline records the HISTORY failure and
-            // skips bucket discovery. No src fetch — the actual repair re-fetches
-            // history and its buckets together via process_history_and_buckets.
-            return Ok(HistoryFetch::NeedsRepair);
+            // Report needs-repair; never fetch or write under dry-run.
+            return Ok(HistoryOutcome {
+                outcome: ProcessOutcome::NeedsRepair,
+                state: None,
+            });
         }
 
-        // Download from source (pipeline will write to dst via process_buffer)
-        Ok(HistoryFetch::Available(
-            storage::download_buffer(src_store, history_path).await?,
-        ))
+        // Fetch from source, parse (before writing), then write to destination.
+        let buffer = storage::download_buffer(src_store, path).await?;
+        let state = history_format::parse_history(&buffer, path)
+            .map_err(|e| StorageError::fatal(format!("failed to parse history {path}: {e}")))?;
+        storage::write_buffer_with_cleanup(&self.dst_store, path, buffer).await?;
+        Ok(HistoryOutcome {
+            outcome: ProcessOutcome::Processed,
+            state: Some(state),
+        })
     }
 
     async fn finalize(
@@ -791,19 +810,4 @@ impl Operation for RepairOperation {
         Ok(())
     }
 
-    /// Repair writes the history buffer to its own dst. In dry-run mode the
-    /// write is skipped but the file is still reported as `Processed` (the
-    /// pipeline records it as a success — matching how repair's `process_object`
-    /// reports its dry-run no-op branches).
-    async fn process_buffer(
-        &self,
-        path: &str,
-        buffer: Buffer,
-    ) -> Result<ProcessOutcome, StorageError> {
-        if self.dry_run {
-            return Ok(ProcessOutcome::Processed);
-        }
-        storage::write_buffer_with_cleanup(&self.dst_store, path, buffer).await?;
-        Ok(ProcessOutcome::Processed)
-    }
 }

--- a/src/repair_operation.rs
+++ b/src/repair_operation.rs
@@ -25,7 +25,9 @@
 
 use crate::history_format;
 use crate::mirror_operation::MirrorOperation;
-use crate::pipeline::{self, async_trait, Operation, Pipeline, PipelineConfig, ProcessOutcome};
+use crate::pipeline::{
+    self, async_trait, HistoryFetch, Operation, Pipeline, PipelineConfig, ProcessOutcome,
+};
 use crate::storage::{self, Error as StorageError, ErrorClass, StorageRef};
 use crate::utils::{self, ArchiveStats};
 use crate::xdr_verify::{self, XdrParseResult, XdrVerificationManager};
@@ -619,12 +621,12 @@ impl Operation for RepairOperation {
         history_path: &str,
         src_store: &StorageRef,
         dst_store: Option<&StorageRef>,
-    ) -> Result<Buffer, StorageError> {
+    ) -> Result<HistoryFetch, StorageError> {
         // Try reading from destination (local, cheap)
         if let Some(dst) = dst_store {
             if let Ok(buffer) = storage::download_buffer(dst, history_path).await {
                 if history_format::parse_history(&buffer, history_path).is_ok() {
-                    return Ok(buffer);
+                    return Ok(HistoryFetch::Available(buffer));
                 }
                 // Exists but corrupt — fall through to source
             }
@@ -637,7 +639,9 @@ impl Operation for RepairOperation {
         }
 
         // Download from source (pipeline will write to dst via process_buffer)
-        storage::download_buffer(src_store, history_path).await
+        Ok(HistoryFetch::Available(
+            storage::download_buffer(src_store, history_path).await?,
+        ))
     }
 
     async fn finalize(

--- a/src/repair_operation.rs
+++ b/src/repair_operation.rs
@@ -437,36 +437,53 @@ impl RepairOperation {
         checkpoint_retry_pipeline.into_stats()
     }
 
-    /// Repair .well-known by copying from highest checkpoint's history file.
-    async fn repair_well_known(&self, highest_checkpoint: u32) {
+    /// Restore `.well-known/stellar-history.json` by copying the highest
+    /// checkpoint's history file on the destination — a local dst-to-dst copy,
+    /// not a fetch from the source.
+    ///
+    /// Returns `true` if `.well-known` is in its intended state (restored, or a
+    /// no-op on a non-filesystem backend) and `false` if a needed restoration
+    /// failed, so the caller can fail the run rather than report success with
+    /// `.well-known` still broken.
+    async fn repair_well_known(&self, highest_checkpoint: u32) -> bool {
         let history_path = history_format::checkpoint_path("history", highest_checkpoint);
         let well_known_path = history_format::ROOT_WELL_KNOWN_PATH;
 
-        if let Some(base_path) = self.dst_store.get_base_path() {
-            let src_file = base_path.join(&history_path);
-            let dst_file = base_path.join(well_known_path);
+        let Some(base_path) = self.dst_store.get_base_path() else {
+            // Non-filesystem backend: nothing to copy locally. R-3.11 permits
+            // a silent no-op (no writable non-filesystem backend exists today).
+            return true;
+        };
 
-            if !tokio::fs::try_exists(&src_file).await.unwrap_or(false) {
-                error!(
-                    "Cannot repair .well-known: history file at checkpoint {} not found",
-                    highest_checkpoint
-                );
-                return;
+        let src_file = base_path.join(&history_path);
+        let dst_file = base_path.join(well_known_path);
+
+        if !tokio::fs::try_exists(&src_file).await.unwrap_or(false) {
+            error!(
+                "Cannot repair .well-known: history file at checkpoint {} not found",
+                highest_checkpoint
+            );
+            return false;
+        }
+
+        if let Some(parent) = dst_file.parent() {
+            if let Err(e) = tokio::fs::create_dir_all(parent).await {
+                error!("Failed to create .well-known directory: {}", e);
+                return false;
             }
+        }
 
-            if let Some(parent) = dst_file.parent() {
-                if let Err(e) = tokio::fs::create_dir_all(parent).await {
-                    error!("Failed to create .well-known directory: {}", e);
-                    return;
-                }
-            }
-
-            match tokio::fs::copy(&src_file, &dst_file).await {
-                Ok(_) => info!(
+        match tokio::fs::copy(&src_file, &dst_file).await {
+            Ok(_) => {
+                info!(
                     "Restored .well-known from checkpoint {} (0x{:08x})",
                     highest_checkpoint, highest_checkpoint
-                ),
-                Err(e) => error!("Failed to restore .well-known: {}", e),
+                );
+                true
+            }
+            Err(e) => {
+                error!("Failed to restore .well-known: {}", e);
+                false
             }
         }
     }
@@ -638,13 +655,6 @@ impl Operation for RepairOperation {
             return Ok(());
         }
 
-        // .well-known restoration. Separate path from the two retry stages
-        // (a follow-up may fold it into `retry_failed_files`'s per-path
-        // repair flow).
-        if self.well_known_needs_repair.load(Ordering::Relaxed) {
-            self.repair_well_known(highest_checkpoint).await;
-        }
-
         stats.report("repair main").await;
 
         // Per-file retry: re-fetch every entry in failures.files /
@@ -660,13 +670,22 @@ impl Operation for RepairOperation {
             .report("repair checkpoint retry")
             .await;
 
-        // Overall success = both retries recovered everything they attempted.
-        // The parent's failures are expected — those are what we just tried
-        // to fix; the retries' own failure trackers are the ground truth for
-        // "what's still broken."
+        // .well-known restoration runs *after* the retry stages. It copies the
+        // highest checkpoint's history file on dst, and that history file may
+        // itself be what the file-retry stage just restored (when its main-pass
+        // fetch failed).
+        //
+        // `repair_well_known` returns whether .well-known ended up in its
+        // intended state; a restoration failure (missing history file,
+        // directory creation, or copy) feeds the success gate below directly.
+        let well_known_failed = self.well_known_needs_repair.load(Ordering::Relaxed)
+            && !self.repair_well_known(highest_checkpoint).await;
+
+        // Overall success = both retries recovered everything they attempted and
+        // .well-known restoration (if needed) succeeded.
         let file_retry_failed = file_retry_stats.has_failures().await;
         let checkpoint_retry_failed = checkpoint_retry_stats.has_failures().await;
-        if file_retry_failed || checkpoint_retry_failed {
+        if file_retry_failed || checkpoint_retry_failed || well_known_failed {
             return Err(Error::RepairFailed.into());
         }
 

--- a/src/repair_operation.rs
+++ b/src/repair_operation.rs
@@ -358,11 +358,7 @@ impl RepairOperation {
             retry_config.clone(),
             /*update_well_known=*/ false,
         );
-        Pipeline::new(
-            mirror_op,
-            retry_config,
-            /*report_path=*/ None,
-        )
+        Pipeline::new(mirror_op, retry_config, /*report_path=*/ None)
     }
 
     /// Build a fresh `Pipeline<RepairOperation>` for the per-file retry stage.
@@ -807,5 +803,4 @@ impl Operation for RepairOperation {
 
         Ok(())
     }
-
 }

--- a/src/repair_operation.rs
+++ b/src/repair_operation.rs
@@ -25,7 +25,7 @@
 
 use crate::history_format;
 use crate::mirror_operation::MirrorOperation;
-use crate::pipeline::{self, async_trait, Operation, Pipeline, PipelineConfig};
+use crate::pipeline::{self, async_trait, Operation, Pipeline, PipelineConfig, ProcessOutcome};
 use crate::storage::{
     self, cleanup_partial_file, Error as StorageError, ErrorClass, StorageConfig, StorageRef,
 };
@@ -172,7 +172,8 @@ impl RepairOperation {
                         }
                         Err(e) => {
                             error!("Failed to repair {}: {}", path, e);
-                            stats.record_failure(path).await;
+                            let cp = history_format::checkpoint_from_path(path).unwrap_or(0);
+                            stats.record_failure(cp, path).await;
                         }
                     }
                     let done = completed.fetch_add(1, Ordering::Relaxed) + 1;
@@ -184,7 +185,7 @@ impl RepairOperation {
             .await;
 
         stats.report("repair").await;
-        if stats.has_failures() {
+        if stats.has_failures().await {
             return Err(Error::RepairFailed);
         }
         Ok(())
@@ -210,7 +211,10 @@ impl RepairOperation {
                 {
                     Ok(()) => Ok(None),
                     Err(e) => {
-                        cleanup_partial_file(&self.dst_store, path).await?;
+                        if let Err(cleanup_err) = cleanup_partial_file(&self.dst_store, path).await
+                        {
+                            error!("Failed to cleanup partial file {}: {}", path, cleanup_err);
+                        }
                         Err(e)
                     }
                 };
@@ -223,7 +227,10 @@ impl RepairOperation {
                 return match xdr_verify::verify_and_write_xdr(path, reader, &self.dst_store).await {
                     Ok(result) => Ok(Some(result)),
                     Err(e) => {
-                        cleanup_partial_file(&self.dst_store, path).await?;
+                        if let Err(cleanup_err) = cleanup_partial_file(&self.dst_store, path).await
+                        {
+                            error!("Failed to cleanup partial file {}: {}", path, cleanup_err);
+                        }
                         Err(e)
                     }
                 };
@@ -232,7 +239,9 @@ impl RepairOperation {
         match self.dst_store.copy_from_reader(path, reader).await {
             Ok(()) => Ok(None),
             Err(e) => {
-                cleanup_partial_file(&self.dst_store, path).await?;
+                if let Err(cleanup_err) = cleanup_partial_file(&self.dst_store, path).await {
+                    error!("Failed to cleanup partial file {}: {}", path, cleanup_err);
+                }
                 Err(e)
             }
         }
@@ -469,21 +478,22 @@ impl Operation for RepairOperation {
     /// verification logic lives here, matching scan/mirror's pattern.
     async fn process_object(
         &self,
+        _checkpoint: u32,
         path: &str,
         _src_store: &StorageRef,
-    ) -> Result<(), StorageError> {
+    ) -> Result<ProcessOutcome, StorageError> {
         if self.verify_and_record_dst(path).await? {
-            return Ok(());
+            return Ok(ProcessOutcome::Processed);
         }
         if self.dry_run {
             self.note_dry_run(path);
-            return Ok(());
+            return Ok(ProcessOutcome::Processed);
         }
         let result = self.fetch_from_src(path).await?;
         if let Some(parsed) = result {
             self.record_result(path, parsed);
         }
-        Ok(())
+        Ok(ProcessOutcome::Processed)
     }
 
     /// Override history buffer sourcing: read from destination first, fall back to source.
@@ -515,10 +525,11 @@ impl Operation for RepairOperation {
 
     fn finalize_checkpoint(&self, checkpoint: u32) {
         if let Some(ref manager) = self.verification_manager {
-            let errors = manager.verify_and_release(checkpoint);
-            if !errors.is_empty() {
-                self.retry_checkpoints.lock().unwrap().insert(checkpoint);
-            }
+            manager.verify_and_release(checkpoint);
+            // TODO(repair-retry-redesign): `verify_and_release` no longer
+            // returns errors; they're now accumulated in the manager and the
+            // pipeline's `stats.failures.checkpoints` set. Drive the retry
+            // decision from `stats.failures.checkpoints` in a follow-up.
         }
     }
 
@@ -529,14 +540,13 @@ impl Operation for RepairOperation {
     ) -> Result<(), pipeline::Error> {
         // Step 1: cross-checkpoint chain check; both ends of any break go to retry.
         if let Some(ref manager) = self.verification_manager {
-            let chain_errors = manager.verify_checkpoint_chain();
-            let mut retry = self.retry_checkpoints.lock().unwrap();
-            for err in chain_errors {
-                retry.insert(err.checkpoint);
-                if err.checkpoint >= history_format::CHECKPOINT_FREQUENCY {
-                    retry.insert(err.checkpoint - history_format::CHECKPOINT_FREQUENCY);
-                }
-            }
+            manager.verify_checkpoint_chain();
+            // TODO(repair-retry-redesign): `verify_checkpoint_chain` no longer
+            // returns errors; they're now accumulated in the manager. With
+            // boundary failures already recording both flanking cps into
+            // `stats.failures.checkpoints`, drive retry directly from there in
+            // a follow-up. Until then, `retry_checkpoints` stays empty and the
+            // retry phase below is effectively a no-op.
         }
 
         let retry: Vec<u32> = std::mem::take(&mut *self.retry_checkpoints.lock().unwrap())
@@ -563,7 +573,7 @@ impl Operation for RepairOperation {
             );
         } else {
             stats.report("repair").await;
-            if stats.has_failures() {
+            if stats.has_failures().await {
                 return Err(Error::RepairFailed.into());
             }
         }
@@ -571,21 +581,21 @@ impl Operation for RepairOperation {
         Ok(())
     }
 
-    /// Repair writes the history buffer to its own dst, except in dry-run mode
-    /// where the write is skipped entirely (and stats are left untouched —
-    /// dry-run reports via `needs_repair_count`, populated in
-    /// `fetch_history_buffer`).
-    async fn process_buffer(&self, path: &str, buffer: Buffer, stats: &ArchiveStats) {
+    /// Repair writes the history buffer to its own dst. In dry-run mode the
+    /// write is skipped but the file is still reported as `Processed` (the
+    /// pipeline records it as a success — matching how repair's `process_object`
+    /// reports its dry-run no-op branches).
+    async fn process_buffer(
+        &self,
+        _checkpoint: u32,
+        path: &str,
+        buffer: Buffer,
+    ) -> Result<ProcessOutcome, StorageError> {
         if self.dry_run {
-            return;
+            return Ok(ProcessOutcome::Processed);
         }
-        match storage::write_buffer_with_cleanup(&self.dst_store, path, buffer).await {
-            Ok(()) => stats.record_success(path),
-            Err(e) => {
-                error!("Failed to write history file {}: {}", path, e);
-                stats.record_failure(path).await;
-            }
-        }
+        storage::write_buffer_with_cleanup(&self.dst_store, path, buffer).await?;
+        Ok(ProcessOutcome::Processed)
     }
 }
 

--- a/src/repair_operation.rs
+++ b/src/repair_operation.rs
@@ -349,6 +349,7 @@ impl RepairOperation {
         let mut retry_config = self.pipeline_config.clone();
         retry_config.skip_history_and_buckets = true;
         let mirror_op = MirrorOperation::new(
+            self.src_store.clone(),
             self.dst_store.clone(),
             /*overwrite=*/ true,
             None,
@@ -360,8 +361,6 @@ impl RepairOperation {
         Pipeline::new(
             mirror_op,
             retry_config,
-            self.src_store.clone(),
-            Some(self.dst_store.clone()),
             /*report_path=*/ None,
         )
     }
@@ -385,8 +384,6 @@ impl RepairOperation {
         Pipeline::new(
             repair_op,
             self.pipeline_config.clone(),
-            self.src_store.clone(),
-            Some(self.dst_store.clone()),
             /*report_path=*/ None,
         )
     }
@@ -605,10 +602,7 @@ fn build_failed_files_work_list(failures: &FailureTracker) -> Vec<(u32, String)>
 
 #[async_trait]
 impl Operation for RepairOperation {
-    async fn get_checkpoint_bounds(
-        &self,
-        source: &StorageRef,
-    ) -> Result<(u32, u32), pipeline::Error> {
+    async fn get_checkpoint_bounds(&self) -> Result<(u32, u32), pipeline::Error> {
         // Try destination .well-known first (determines what range to repair)
         let dst_result = utils::fetch_well_known_history_file(
             &self.dst_store,
@@ -631,7 +625,7 @@ impl Operation for RepairOperation {
 
                 // Fall back to source .well-known
                 let src_state = utils::fetch_well_known_history_file(
-                    source,
+                    &self.src_store,
                     self.pipeline_config.storage_config.max_retries as u32,
                     self.pipeline_config
                         .storage_config
@@ -654,7 +648,6 @@ impl Operation for RepairOperation {
     async fn process_object(
         &self,
         path: &str,
-        _src_store: &StorageRef,
         manager: Option<&XdrVerificationManager>,
     ) -> Result<ProcessOutcome, StorageError> {
         if self.verify_and_record_dst(path, manager).await? {
@@ -674,11 +667,7 @@ impl Operation for RepairOperation {
     /// fetch from source only when the dst copy is missing/corrupt or the file
     /// is on the known-broken list. Returns the parsed state so the pipeline can
     /// walk bucket references.
-    async fn process_history(
-        &self,
-        path: &str,
-        src_store: &StorageRef,
-    ) -> Result<HistoryOutcome, StorageError> {
+    async fn process_history(&self, path: &str) -> Result<HistoryOutcome, StorageError> {
         // Failed-list mode: a listed file is fetched from source directly (no dst
         // probe), honoring `known_broken` exactly as verify_and_record_dst does.
         let listed = self
@@ -709,7 +698,7 @@ impl Operation for RepairOperation {
         }
 
         // Fetch from source, parse (before writing), then write to destination.
-        let buffer = storage::download_buffer(src_store, path).await?;
+        let buffer = storage::download_buffer(&self.src_store, path).await?;
         let state = history_format::parse_history(&buffer, path)
             .map_err(|e| StorageError::fatal(format!("failed to parse history {path}: {e}")))?;
         storage::write_buffer_with_cleanup(&self.dst_store, path, buffer).await?;

--- a/src/repair_operation.rs
+++ b/src/repair_operation.rs
@@ -9,7 +9,9 @@
 //! XDR (or verify bucket hash), and on success record the parsed data into the
 //! verification manager and stop. On parse failure or missing dst file, fetch
 //! from src via `verify_and_write_xdr` (or `verify_and_write_bucket`) and record
-//! the result.
+//! the result. In **failed-list mode** (`known_broken` is `Some` — the retry
+//! stage and plan mode) a listed file skips the dst probe entirely and is
+//! fetched from src directly; only unlisted (discovered) files get the probe.
 //!
 //! **Retry phase** (in `finalize`): after the main pass completes, the manager
 //! has data for every file in the range. Run `verify_checkpoint_chain` (cross-
@@ -31,7 +33,7 @@ use crate::pipeline::{
     self, async_trait, HistoryFetch, Operation, Pipeline, PipelineConfig, ProcessOutcome,
 };
 use crate::storage::{self, Error as StorageError, ErrorClass, StorageRef};
-use crate::utils::{self, ArchiveStats};
+use crate::utils::{self, ArchiveStats, FailureTracker};
 use crate::xdr_verify::{self, XdrParseResult, XdrVerificationManager};
 use futures_util::{stream, StreamExt};
 use opendal::{Buffer, Reader};
@@ -85,6 +87,12 @@ pub struct RepairOperation {
     pipeline_config: PipelineConfig,
     /// Set during get_checkpoint_bounds if dest .well-known needs repair
     well_known_needs_repair: AtomicBool,
+    /// Failures already known broken — `Some` only in the failed-list pipelines
+    /// (the stage-2 file retry, which plan mode also drives), seeded from the
+    /// main pass's stats or the plan. A file in this set is fetched from src
+    /// directly, skipping the dst probe entirely. `None` (regular repair: main
+    /// pass, dry-run) probes dst-first for every file.
+    known_broken: Option<FailureTracker>,
 }
 
 impl RepairOperation {
@@ -108,24 +116,38 @@ impl RepairOperation {
             dry_run,
             pipeline_config,
             well_known_needs_repair: AtomicBool::new(false),
+            known_broken: None,
         }
+    }
+
+    /// Switch this operation into failed-list mode: every file in
+    /// `known_broken` is fetched from src directly (no dst probe); files not
+    /// in the set keep the regular dst-first probe.
+    #[must_use]
+    pub(crate) fn with_known_broken(mut self, known_broken: FailureTracker) -> Self {
+        debug_assert!(self.known_broken.is_none());
+        self.known_broken = Some(known_broken);
+        self
     }
 
     /// Manual repair driven by a plan: apply an `ArchiveReport` (typically
     /// produced by an earlier `--dry-run`) by seeding the failure set and
     /// running the same two-stage retry the main flow uses — phase 1 over
-    /// files/buckets, phase 2 over checkpoints. The plan is a directive: every
-    /// listed item is re-fetched from source unconditionally (the retry stages
-    /// overwrite).
+    /// files/buckets, phase 2 over checkpoints. The plan is trusted: every
+    /// listed item is re-fetched from source unconditionally (the destination
+    /// is not re-audited). Only buckets *discovered* by re-walking a listed
+    /// HISTORY are validated on dst and fetched just when missing or invalid.
+    /// `--verify` works exactly as in regular repair: it governs validation
+    /// of the downloaded source content and the probing of discovered files.
     ///
     /// `.well-known` is restored from the checkpoint carried in the plan, so no
     /// archive-bound recomputation is needed.
     pub async fn run_manual(
         &self,
-        report: crate::report::ArchiveReport,
+        plan: crate::report::ArchiveReport,
         report_path: Option<&std::path::Path>,
     ) -> Result<(), Error> {
-        let tracker = report
+        let tracker = plan
             .into_failures()
             .map_err(|e| Error::InvalidPlan(e.to_string()))?;
         if tracker.is_empty() {
@@ -185,7 +207,9 @@ impl RepairOperation {
     ///
     /// Returns:
     /// - `Ok(true)` — dst is acceptable; caller skips src fetch.
-    /// - `Ok(false)` — dst is missing or corrupt; caller should fetch from src.
+    /// - `Ok(false)` — dst is missing or corrupt, OR the file is in
+    ///   `known_broken` (failed-list mode: no dst probe at all); caller
+    ///   should fetch from src.
     ///   NotFound on `open_reader`/`exists()` is treated as "missing" so the
     ///   repair can fetch from src immediately. Same for parse failures on a
     ///   present-but-corrupt file.
@@ -206,6 +230,17 @@ impl RepairOperation {
         path: &str,
         manager: Option<&XdrVerificationManager>,
     ) -> Result<bool, StorageError> {
+        // Failed-list mode: a file already recorded broken is fetched from src
+        // directly to avoid the expensive verification (bucket decompress+hash,
+        // transactions parse). Files NOT in the list — e.g. buckets discovered
+        // by re-walking a listed HISTORY — are probed normally so a still-valid
+        // copy isn't re-downloaded.
+        if let Some(known_broken) = &self.known_broken {
+            if known_broken.contains_path(path) {
+                return Ok(false);
+            }
+        }
+
         let Some(manager) = manager else {
             return match self.dst_store.exists(path).await {
                 Ok(present) => Ok(present),
@@ -303,29 +338,25 @@ impl RepairOperation {
         }
     }
 
-    /// Build a fresh `Pipeline<MirrorOperation>` configured for retry use:
-    /// overwrite=true, allow_mirror_gaps=true (the retry set is intentionally
-    /// disjoint), update_well_known=false (a partial-set retry can't claim
-    /// contiguous coverage), wired to repair's `src_store` and `dst_store`,
-    /// with the outer `pipeline_config` cloned. The caller chooses whether
-    /// the inner pipeline's `process_checkpoint` should skip
-    /// history-and-bucket work: `retry_failed_checkpoints` sets it true
-    /// (chain repair needs only per-cp xdr files); `retry_failed_files`
-    /// leaves it false (it drives `process_file` /
-    /// `process_history_and_buckets` directly, but the flag is wired
-    /// through explicitly for clarity).
-    fn build_retry_pipeline(&self, skip_history_and_buckets: bool) -> Pipeline<MirrorOperation> {
+    /// Build a fresh `Pipeline<MirrorOperation>` for the per-checkpoint retry
+    /// stage: overwrite=true (re-mirror whole cps whose files are individually
+    /// valid but cross-file/chain inconsistent — a dst-first probe would wrongly
+    /// skip them), allow_mirror_gaps=true (the retry set is disjoint),
+    /// update_well_known=false (a partial-set retry can't claim contiguous
+    /// coverage). `skip_history_and_buckets=true` because chain repair needs only
+    /// the per-cp xdr files; bucket / HAS work is handled by the file-retry stage.
+    fn build_checkpoint_retry_pipeline(&self) -> Pipeline<MirrorOperation> {
+        let mut retry_config = self.pipeline_config.clone();
+        retry_config.skip_history_and_buckets = true;
         let mirror_op = MirrorOperation::new(
             self.dst_store.clone(),
             /*overwrite=*/ true,
             None,
             None,
             /*allow_mirror_gaps=*/ true,
-            &self.pipeline_config.storage_config,
+            retry_config.clone(),
             /*update_well_known=*/ false,
         );
-        let mut retry_config = self.pipeline_config.clone();
-        retry_config.skip_history_and_buckets = skip_history_and_buckets;
         Pipeline::new(
             mirror_op,
             retry_config,
@@ -335,9 +366,34 @@ impl RepairOperation {
         )
     }
 
+    /// Build a fresh `Pipeline<RepairOperation>` for the per-file retry stage.
+    /// Reuses repair's per-file logic (`process_object`) in failed-list mode:
+    /// seeded with `known_broken`, so every listed file (any type) skips the
+    /// dst probe and is re-fetched directly, while transitively-discovered
+    /// buckets are validated first. `dry_run` is always false here (the retry
+    /// stages early-return under dry_run).
+    fn build_file_retry_pipeline(&self, known_broken: FailureTracker) -> Pipeline<RepairOperation> {
+        let repair_op = RepairOperation::new(
+            self.src_store.clone(),
+            self.dst_store.clone(),
+            self.low,
+            self.high,
+            /*dry_run=*/ false,
+            self.pipeline_config.clone(),
+        )
+        .with_known_broken(known_broken);
+        Pipeline::new(
+            repair_op,
+            self.pipeline_config.clone(),
+            self.src_store.clone(),
+            Some(self.dst_store.clone()),
+            /*report_path=*/ None,
+        )
+    }
+
     /// Per-file retry — re-fetch individual files that the main pass failed
-    /// to repair, on a **fresh `Pipeline<MirrorOperation>`** built by
-    /// [`Self::build_retry_pipeline`].
+    /// to repair, on a **fresh `Pipeline<RepairOperation>`** built by
+    /// [`Self::build_file_retry_pipeline`].
     ///
     /// For each broken file recorded in `parent_stats.failures` (per-cp file
     /// flags + bucket hashes), dispatch through the inner pipeline:
@@ -352,24 +408,35 @@ impl RepairOperation {
     /// verification), only the per-item primitives. Stats are extracted via
     /// `into_stats` (bypassing mirror's `finalize` and its `has_failures`
     /// gate). Returns the inner's stats directly — no merging into the parent.
+    ///
+    /// Per-file validation still runs when `--verify` is on (the manager is
+    /// carried via `pipeline_config.verify`), so each re-fetched file is checked
+    /// before commit. Cross-file / chain checks don't run here and don't need
+    /// to: single-file retry has no siblings loaded to cross-check, and any cp
+    /// with a real cross-file/chain inconsistency is in `failures.checkpoints`,
+    /// handled by [`Self::retry_failed_checkpoints`].
     pub(crate) async fn retry_failed_files(&self, parent_stats: &ArchiveStats) -> ArchiveStats {
         if self.dry_run {
             return ArchiveStats::new();
         }
 
-        let work = build_failed_files_work_list(parent_stats).await;
+        // One snapshot of the main pass's failures drives both the work list
+        // (what to retry) and `known_broken` (which files to fetch directly vs.
+        // probe). `parent_stats` is not mutated during file-retry, so the
+        // snapshot stays consistent. The snapshot is stays read-only (built
+        // once).
+        let known_broken = parent_stats.failures.lock().await.clone();
+        let work = build_failed_files_work_list(&known_broken);
         if work.is_empty() {
             return ArchiveStats::new();
         }
 
         info!("Retrying {} failed file(s)", work.len());
 
-        // `retry_failed_files` drives `process_file` /
-        // `process_history_and_buckets` directly — these bypass
-        // `process_checkpoint`, so `skip_history_and_buckets` has no
-        // effect here. Passed `false` for clarity.
-        let file_retry_pipeline =
-            self.build_retry_pipeline(/*skip_history_and_buckets=*/ false);
+        // File-retry runs in failed-list mode: every listed file is fetched
+        // from src directly (no dst probe); transitively discovered buckets are
+        // validated on dst and re-fetched only if missing/invalid.
+        let file_retry_pipeline = self.build_file_retry_pipeline(known_broken);
         stream::iter(work.into_iter())
             .for_each_concurrent(self.pipeline_config.concurrency, |(cp, path)| {
                 let pipeline = &file_retry_pipeline;
@@ -387,7 +454,7 @@ impl RepairOperation {
 
     /// Per-checkpoint retry — re-mirror whole checkpoints flagged by cross-
     /// file or cross-cp chain checks, on a **fresh `Pipeline<MirrorOperation>`**
-    /// built by [`Self::build_retry_pipeline`].
+    /// built by [`Self::build_checkpoint_retry_pipeline`].
     ///
     /// For each cp in `parent_stats.failures.checkpoints`, drive the inner
     /// pipeline's `run_checkpoints` to re-fetch every file in that cp from src
@@ -422,9 +489,8 @@ impl RepairOperation {
         // covered by `retry_failed_files` (either via `failures.buckets`
         // direct fetches or via its HISTORY entries, which trigger
         // `process_history_and_buckets`). So skip HAS + bucket work in
-        // the inner `process_checkpoint`.
-        let checkpoint_retry_pipeline =
-            self.build_retry_pipeline(/*skip_history_and_buckets=*/ true);
+        // the inner `process_checkpoint` (the builder sets that).
+        let checkpoint_retry_pipeline = self.build_checkpoint_retry_pipeline();
         let _ = checkpoint_retry_pipeline.run_checkpoints(retry_cps).await;
         checkpoint_retry_pipeline.into_stats()
     }
@@ -485,12 +551,10 @@ impl RepairOperation {
 // Repair helpers (free functions)
 // ============================================================================
 
-/// Build a `(cp, path)` work list from the current state of the failure
-/// tracker. Read-only on `parent_stats` — no `mem::take`, no mutation. The
-/// work list captures every uniquely-identifiable failed file at the moment
-/// of the snapshot; concurrent writers (there shouldn't be any at this point,
-/// but the lock is taken regardless) are blocked only for the duration of
-/// the read.
+/// Build a `(cp, path)` work list from a snapshot of the failure tracker.
+/// Read-only — captures every uniquely-identifiable failed file in `failures`.
+/// The caller snapshots `parent_stats.failures` once and reuses it for both
+/// this work list and the inner pipeline's `known_broken`.
 ///
 /// Non-HISTORY per-cp file entries whose cp is also in `failures.checkpoints`
 /// are skipped — `retry_failed_checkpoints` will re-mirror the whole cp
@@ -502,12 +566,11 @@ impl RepairOperation {
 /// bucket refs were walked). Bucket entries are also kept unconditionally —
 /// they're content-addressed, not cp-keyed, and `retry_failed_files` is the
 /// only place that repairs `failures.buckets`.
-async fn build_failed_files_work_list(parent_stats: &ArchiveStats) -> Vec<(u32, String)> {
-    let f = parent_stats.failures.lock().await;
+fn build_failed_files_work_list(failures: &FailureTracker) -> Vec<(u32, String)> {
     let mut work = Vec::new();
 
-    for (&cp, flags) in &f.files {
-        let cp_in_chain_retry = f.checkpoints.contains(&cp);
+    for (&cp, flags) in &failures.files {
+        let cp_in_chain_retry = failures.checkpoints.contains(&cp);
         for (bit, prefix) in [
             (utils::FileFlags::HISTORY, "history"),
             (utils::FileFlags::LEDGER, "ledger"),
@@ -529,7 +592,7 @@ async fn build_failed_files_work_list(parent_stats: &ArchiveStats) -> Vec<(u32, 
         }
     }
 
-    for hash in &f.buckets {
+    for hash in &failures.buckets {
         if let Ok(path) = history_format::bucket_path(&hex::encode(hash.0)) {
             // cp context is 0 — buckets are content-addressed and
             // `record_failure`'s bucket-path dispatch ignores cp.
@@ -662,9 +725,9 @@ impl Operation for RepairOperation {
                     .map_err(|e| pipeline::Error::RepairOperation(Error::Report(e)))?;
             }
             return Ok(());
-        } else {
-            stats.report("repair main").await;
         }
+
+        stats.report("repair main").await;
 
         // Per-file retry: re-fetch every entry in failures.files /
         // failures.buckets. Returns its own stats — no merging.

--- a/src/repair_operation.rs
+++ b/src/repair_operation.rs
@@ -34,7 +34,7 @@ use crate::xdr_verify::{self, XdrParseResult, XdrVerificationManager};
 use futures_util::{stream, StreamExt};
 use opendal::{Buffer, Reader};
 use std::collections::HashSet;
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use thiserror::Error;
 use tracing::{debug, error, info, warn};
 
@@ -60,6 +60,9 @@ pub enum Error {
 
     #[error("Scan operation error: {0}")]
     ScanOperation(#[from] crate::scan_operation::Error),
+
+    #[error("Report error: {0}")]
+    Report(#[from] crate::report::ReportError),
 }
 
 /// How often to report progress (every N files) in manual mode
@@ -84,8 +87,6 @@ pub struct RepairOperation {
     pipeline_config: PipelineConfig,
     /// Set during get_checkpoint_bounds if dest .well-known needs repair
     well_known_needs_repair: AtomicBool,
-    /// Dry-run counter: files that would be repaired
-    needs_repair_count: AtomicU64,
 }
 
 impl RepairOperation {
@@ -109,7 +110,6 @@ impl RepairOperation {
             dry_run,
             pipeline_config,
             well_known_needs_repair: AtomicBool::new(false),
-            needs_repair_count: AtomicU64::new(0),
         }
     }
 
@@ -182,13 +182,6 @@ impl RepairOperation {
             return Err(Error::RepairFailed);
         }
         Ok(())
-    }
-
-    /// Increment the dry-run counter (signalling "we'd repair this file but
-    /// did nothing"). Used when dst checks fail and we'd otherwise fetch from src.
-    fn note_dry_run(&self, path: &str) {
-        self.needs_repair_count.fetch_add(1, Ordering::Relaxed);
-        debug!("Dry run: would repair {}", path);
     }
 
     /// Check whether dst already has a good copy of `path` and (when verify
@@ -342,6 +335,7 @@ impl RepairOperation {
             retry_config,
             self.src_store.clone(),
             Some(self.dst_store.clone()),
+            /*report_path=*/ None,
         )
     }
 
@@ -608,8 +602,9 @@ impl Operation for RepairOperation {
             return Ok(ProcessOutcome::Processed);
         }
         if self.dry_run {
-            self.note_dry_run(path);
-            return Ok(ProcessOutcome::Processed);
+            // Record the broken file/bucket into the pipeline's stats (via the
+            // NeedsRepair recorder) without fetching or writing.
+            return Ok(ProcessOutcome::NeedsRepair);
         }
         xdr_verify::fetch_verify_and_write(&self.src_store, &self.dst_store, path, manager).await?;
         Ok(ProcessOutcome::Processed)
@@ -632,10 +627,12 @@ impl Operation for RepairOperation {
             }
         }
 
-        // Destination missing or corrupt — need from source
+        // Destination missing or corrupt.
         if self.dry_run {
-            self.needs_repair_count.fetch_add(1, Ordering::Relaxed);
-            debug!("Dry run: would repair {}", history_path);
+            // Signal "needs repair": the pipeline records the HISTORY failure and
+            // skips bucket discovery. No src fetch — the actual repair re-fetches
+            // history and its buckets together via process_history_and_buckets.
+            return Ok(HistoryFetch::NeedsRepair);
         }
 
         // Download from source (pipeline will write to dst via process_buffer)
@@ -648,25 +645,32 @@ impl Operation for RepairOperation {
         &self,
         highest_checkpoint: u32,
         stats: &ArchiveStats,
+        report_path: Option<&std::path::Path>,
     ) -> Result<(), pipeline::Error> {
         // Manager drain (verify_checkpoint_chain + record_all_errors) already
         // happened in `Pipeline::run_checkpoints`, so `stats.failures.checkpoints`
         // is already populated for `retry_failed_checkpoints` to consume.
 
         if self.dry_run {
-            let count = self.needs_repair_count.load(Ordering::Relaxed);
-            info!("Dry run: {} file(s) would be repaired", count);
-            // Cross-file and chain failures are found by the verification
-            // manager (drained into stats.failures before finalize) and are
-            // invisible to the per-file dst probe, so they aren't in the count
-            // above. Report them separately: a real run would re-fetch these
-            // whole checkpoints in the checkpoint-retry stage.
-            let checkpoint_failures = stats.failures.lock().await.checkpoints.len();
-            if checkpoint_failures > 0 {
-                info!(
-                    "Dry run: {} checkpoint(s) with cross-file/chain failures would be re-fetched",
-                    checkpoint_failures
-                );
+            // Reflect the well-known flag into stats so the plan includes it,
+            // then report: dry-run records the broken inventory into
+            // `stats.failures` (per-file/bucket via NeedsRepair, checkpoints via
+            // the manager), so logging + the JSON plan both read from it.
+            if self.well_known_needs_repair.load(Ordering::Relaxed) {
+                stats
+                    .failures
+                    .lock()
+                    .await
+                    .record_well_known(highest_checkpoint);
+            }
+            stats.report("repair").await;
+            if let Some(path) = report_path {
+                let report = crate::report::ArchiveReport {
+                    version: crate::report::REPORT_VERSION,
+                    section: stats.report_section().await,
+                };
+                crate::report::write_to_path(path, &report)
+                    .map_err(|e| pipeline::Error::RepairOperation(Error::Report(e)))?;
             }
             return Ok(());
         }
@@ -696,6 +700,29 @@ impl Operation for RepairOperation {
         // directory creation, or copy) feeds the success gate below directly.
         let well_known_failed = self.well_known_needs_repair.load(Ordering::Relaxed)
             && !self.repair_well_known(highest_checkpoint).await;
+
+        // Full-context report: one section per stage (main pass + both retries).
+        // Built and written once — all three stats are in hand here.
+        if let Some(path) = report_path {
+            let report = crate::report::MultiSectionReport {
+                version: crate::report::REPORT_VERSION,
+                sections: [
+                    ("main_pass".to_string(), stats.report_section().await),
+                    (
+                        "file_retry".to_string(),
+                        file_retry_stats.report_section().await,
+                    ),
+                    (
+                        "checkpoint_retry".to_string(),
+                        checkpoint_retry_stats.report_section().await,
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+            };
+            crate::report::write_to_path(path, &report)
+                .map_err(|e| pipeline::Error::RepairOperation(Error::Report(e)))?;
+        }
 
         // Overall success = both retries recovered everything they attempted and
         // .well-known restoration (if needed) succeeded.

--- a/src/repair_operation.rs
+++ b/src/repair_operation.rs
@@ -433,6 +433,11 @@ impl RepairOperation {
         // File-retry runs in failed-list mode: every listed file is fetched
         // from src directly (no dst probe); transitively discovered buckets are
         // validated on dst and re-fetched only if missing/invalid.
+        //
+        // HISTORY work re-walks its referenced buckets through the pipeline's
+        // bucket scheduler; direct bucket work enters that same scheduler via
+        // `process_bucket_file`. So a bucket listed directly AND referenced by a
+        // failed HISTORY is processed once per file-retry run (shared LRU gate).
         let file_retry_pipeline = self.build_file_retry_pipeline(known_broken);
         stream::iter(work.into_iter())
             .for_each_concurrent(self.pipeline_config.concurrency, |(cp, path)| {
@@ -440,6 +445,8 @@ impl RepairOperation {
                 async move {
                     if history_format::is_history_file(&path) {
                         pipeline.process_history_and_buckets(cp).await;
+                    } else if history_format::is_bucket_file(&path) {
+                        pipeline.process_bucket_file(cp, path).await;
                     } else {
                         pipeline.process_file(cp, path).await;
                     }
@@ -562,7 +569,9 @@ impl RepairOperation {
 /// never probed (the case where the history download itself failed before
 /// bucket refs were walked). Bucket entries are also kept unconditionally —
 /// they're content-addressed, not cp-keyed, and `retry_failed_files` is the
-/// only place that repairs `failures.buckets`.
+/// only place that repairs `failures.buckets`. Keeping a bucket here that a
+/// failed HISTORY also references no longer means double processing: both routes
+/// go through `Pipeline::process_bucket_file`, which dedupes on the bucket hash.
 fn build_failed_files_work_list(failures: &FailureTracker) -> Vec<(u32, String)> {
     let mut work = Vec::new();
 

--- a/src/repair_operation.rs
+++ b/src/repair_operation.rs
@@ -26,13 +26,11 @@
 use crate::history_format;
 use crate::mirror_operation::MirrorOperation;
 use crate::pipeline::{self, async_trait, Operation, Pipeline, PipelineConfig, ProcessOutcome};
-use crate::storage::{
-    self, cleanup_partial_file, Error as StorageError, ErrorClass, StorageConfig, StorageRef,
-};
+use crate::storage::{self, Error as StorageError, ErrorClass, StorageRef};
 use crate::utils::{self, ArchiveStats};
 use crate::xdr_verify::{self, XdrParseResult, XdrVerificationManager};
 use futures_util::{stream, StreamExt};
-use opendal::Buffer;
+use opendal::{Buffer, Reader};
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use thiserror::Error;
@@ -74,17 +72,14 @@ pub struct RepairOperation {
     dst_store: StorageRef,
     low: Option<u32>,
     high: Option<u32>,
-    /// Kept (despite the verification manager moving to Pipeline) because
-    /// `retry_failed_files` / `retry_failed_checkpoints` build inner
-    /// `Pipeline<MirrorOperation>` instances and need to set
-    /// `PipelineConfig::verify` on them. Repair's own `process_object`
-    /// doesn't read this field — it branches on whether the `manager`
-    /// parameter (from the outer pipeline) is `Some`.
-    verify: bool,
     dry_run: bool,
-    concurrency: usize,
-    skip_optional: bool,
-    storage_config: StorageConfig,
+    /// Outer pipeline's config — held so the retry-phase inner pipelines
+    /// (`retry_failed_files`, `retry_failed_checkpoints`) can be constructed
+    /// with the same concurrency / skip_optional / verify / storage_config.
+    /// Note: repair's own `process_object` does not read `pipeline_config.verify`;
+    /// it branches on whether the `manager` parameter (from the outer pipeline)
+    /// is `Some`.
+    pipeline_config: PipelineConfig,
     /// Set during get_checkpoint_bounds if dest .well-known needs repair
     well_known_needs_repair: AtomicBool,
     /// Dry-run counter: files that would be repaired
@@ -92,17 +87,13 @@ pub struct RepairOperation {
 }
 
 impl RepairOperation {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         src_store: StorageRef,
         dst_store: StorageRef,
         low: Option<u32>,
         high: Option<u32>,
-        verify: bool,
         dry_run: bool,
-        concurrency: usize,
-        skip_optional: bool,
-        storage_config: &StorageConfig,
+        pipeline_config: PipelineConfig,
     ) -> Self {
         debug_assert!(
             dst_store.supports_writes(),
@@ -113,11 +104,8 @@ impl RepairOperation {
             dst_store,
             low,
             high,
-            verify,
             dry_run,
-            concurrency,
-            skip_optional,
-            storage_config: storage_config.clone(),
+            pipeline_config,
             well_known_needs_repair: AtomicBool::new(false),
             needs_repair_count: AtomicU64::new(0),
         }
@@ -144,18 +132,28 @@ impl RepairOperation {
         let total = files.len();
 
         stream::iter(files.iter())
-            .for_each_concurrent(self.concurrency, |path| {
+            .for_each_concurrent(self.pipeline_config.concurrency, |path| {
                 let stats = &stats;
                 let completed = &completed;
                 async move {
                     let result = utils::with_retries(
-                        self.storage_config.max_retries as u32,
-                        self.storage_config.retry_min_delay.as_millis() as u64,
+                        self.pipeline_config.storage_config.max_retries as u32,
+                        self.pipeline_config
+                            .storage_config
+                            .retry_min_delay
+                            .as_millis() as u64,
                         "repair",
                         path,
                         // Manual mode: no verification manager. Use plain
                         // src-fetch / dst-copy semantics.
-                        || async { self.fetch_from_src(path, None).await.map(|_| ()) },
+                        || {
+                            xdr_verify::fetch_verify_and_write(
+                                &self.src_store,
+                                &self.dst_store,
+                                path,
+                                None,
+                            )
+                        },
                     )
                     .await;
                     match result {
@@ -189,59 +187,6 @@ impl RepairOperation {
     fn note_dry_run(&self, path: &str) {
         self.needs_repair_count.fetch_add(1, Ordering::Relaxed);
         debug!("Dry run: would repair {}", path);
-    }
-
-    /// Fetch a file from src and write to dst with optional verification.
-    /// Returns the parsed XDR data (for XDR files when `verify` is on) so the
-    /// caller can record it into the manager. Returns `None` for buckets,
-    /// non-verified copies, and unrecognized file types.
-    async fn fetch_from_src(
-        &self,
-        path: &str,
-        manager: Option<&XdrVerificationManager>,
-    ) -> Result<Option<XdrParseResult>, StorageError> {
-        let reader = self.src_store.open_reader(path).await?;
-        if manager.is_some() {
-            if history_format::is_bucket_file(path) {
-                return match crate::verify::verify_and_write_bucket(path, reader, &self.dst_store)
-                    .await
-                {
-                    Ok(()) => Ok(None),
-                    Err(e) => {
-                        if let Err(cleanup_err) = cleanup_partial_file(&self.dst_store, path).await
-                        {
-                            error!("Failed to cleanup partial file {}: {}", path, cleanup_err);
-                        }
-                        Err(e)
-                    }
-                };
-            }
-            if history_format::is_ledger_header_file(path)
-                || history_format::is_transactions_file(path)
-                || history_format::is_results_file(path)
-                || history_format::is_scp_file(path)
-            {
-                return match xdr_verify::verify_and_write_xdr(path, reader, &self.dst_store).await {
-                    Ok(result) => Ok(Some(result)),
-                    Err(e) => {
-                        if let Err(cleanup_err) = cleanup_partial_file(&self.dst_store, path).await
-                        {
-                            error!("Failed to cleanup partial file {}: {}", path, cleanup_err);
-                        }
-                        Err(e)
-                    }
-                };
-            }
-        }
-        match self.dst_store.copy_from_reader(path, reader).await {
-            Ok(()) => Ok(None),
-            Err(e) => {
-                if let Err(cleanup_err) = cleanup_partial_file(&self.dst_store, path).await {
-                    error!("Failed to cleanup partial file {}: {}", path, cleanup_err);
-                }
-                Err(e)
-            }
-        }
     }
 
     /// Check whether dst already has a good copy of `path` and (when verify
@@ -281,62 +226,61 @@ impl RepairOperation {
         // Buckets and SCP files have no per-checkpoint manager state — verify
         // structurally on dst, no recording.
         if history_format::is_bucket_file(path) {
-            return match self.dst_store.open_reader(path).await {
-                Ok(reader) => Ok(crate::verify::verify_bucket_stream(path, reader)
-                    .await
-                    .is_ok()),
-                Err(e) if e.class == ErrorClass::NotFound => Ok(false),
-                Err(e) => Err(e),
-            };
+            return self
+                .check_dst_or_missing(path, |reader| async move {
+                    crate::verify::verify_bucket_stream(path, reader)
+                        .await
+                        .is_ok()
+                })
+                .await;
         }
         if history_format::is_scp_file(path) {
-            return match self.dst_store.open_reader(path).await {
-                Ok(reader) => Ok(xdr_verify::parse_scp_stream(path, reader).await.is_ok()),
-                Err(e) if e.class == ErrorClass::NotFound => Ok(false),
-                Err(e) => Err(e),
-            };
+            return self
+                .check_dst_or_missing(path, |reader| async move {
+                    xdr_verify::parse_scp_stream(path, reader).await.is_ok()
+                })
+                .await;
         }
 
-        // XDR file types: open, parse, and route recording through the shared
-        // `record_result` helper inside the success arm.
+        // XDR file types: open, parse, and on success record into the manager.
         if history_format::is_ledger_header_file(path) {
-            return match self.dst_store.open_reader(path).await {
-                Ok(reader) => match xdr_verify::parse_ledger_header_stream(path, reader).await {
-                    Ok(data) => {
-                        record_result(manager, path, XdrParseResult::Ledger(data));
-                        Ok(true)
+            return self
+                .check_dst_or_missing(path, |reader| async move {
+                    match xdr_verify::parse_ledger_header_stream(path, reader).await {
+                        Ok(data) => {
+                            manager.record(path, XdrParseResult::Ledger(data));
+                            true
+                        }
+                        Err(_) => false,
                     }
-                    Err(_) => Ok(false),
-                },
-                Err(e) if e.class == ErrorClass::NotFound => Ok(false),
-                Err(e) => Err(e),
-            };
+                })
+                .await;
         }
         if history_format::is_transactions_file(path) {
-            return match self.dst_store.open_reader(path).await {
-                Ok(reader) => match xdr_verify::parse_transactions_stream(path, reader).await {
-                    Ok(hashes) => {
-                        record_result(manager, path, XdrParseResult::Transactions(hashes));
-                        Ok(true)
+            return self
+                .check_dst_or_missing(path, |reader| async move {
+                    match xdr_verify::parse_transactions_stream(path, reader).await {
+                        Ok(hashes) => {
+                            manager.record(path, XdrParseResult::Transactions(hashes));
+                            true
+                        }
+                        Err(_) => false,
                     }
-                    Err(_) => Ok(false),
-                },
-                Err(e) if e.class == ErrorClass::NotFound => Ok(false),
-                Err(e) => Err(e),
-            };
+                })
+                .await;
         }
         if history_format::is_results_file(path) {
-            return match self.dst_store.open_reader(path).await {
-                Ok(reader) => match xdr_verify::parse_results_stream(path, reader).await {
-                    Ok(hashes) => {
-                        record_result(manager, path, XdrParseResult::Results(hashes));
-                        Ok(true)
+            return self
+                .check_dst_or_missing(path, |reader| async move {
+                    match xdr_verify::parse_results_stream(path, reader).await {
+                        Ok(hashes) => {
+                            manager.record(path, XdrParseResult::Results(hashes));
+                            true
+                        }
+                        Err(_) => false,
                     }
-                    Err(_) => Ok(false),
-                },
-                Err(e) if e.class == ErrorClass::NotFound => Ok(false),
-                Err(e) => Err(e),
-            };
+                })
+                .await;
         }
 
         Err(StorageError::fatal(format!(
@@ -345,8 +289,55 @@ impl RepairOperation {
         )))
     }
 
+    /// Run a content check on the dst copy of `path`, treating a missing
+    /// dst file as the check failing.
+    ///
+    /// Returns:
+    /// - `Ok(true)` — dst file opened AND `f(reader)` returned `true`.
+    /// - `Ok(false)` — dst file is missing (`open_reader` returned `NotFound`),
+    ///   OR `f(reader)` returned `false`.
+    /// - `Err(_)` — any non-`NotFound` storage error from `open_reader`.
+    ///
+    /// `f` is typically a parse or hash verification that returns `true`
+    /// when the dst content is good.
+    async fn check_dst_or_missing<F, Fut>(&self, path: &str, f: F) -> Result<bool, StorageError>
+    where
+        F: FnOnce(Reader) -> Fut,
+        Fut: std::future::Future<Output = bool> + Send,
+    {
+        match self.dst_store.open_reader(path).await {
+            Ok(reader) => Ok(f(reader).await),
+            Err(e) if e.class == ErrorClass::NotFound => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Build a fresh `Pipeline<MirrorOperation>` configured for retry use:
+    /// overwrite=true, allow_mirror_gaps=true (the retry set is intentionally
+    /// disjoint), update_well_known=false (a partial-set retry can't claim
+    /// contiguous coverage), wired to repair's `src_store` and `dst_store`,
+    /// with the outer `pipeline_config` cloned verbatim.
+    fn build_retry_pipeline(&self) -> Pipeline<MirrorOperation> {
+        let mirror_op = MirrorOperation::new(
+            self.dst_store.clone(),
+            /*overwrite=*/ true,
+            None,
+            None,
+            /*allow_mirror_gaps=*/ true,
+            &self.pipeline_config.storage_config,
+            /*update_well_known=*/ false,
+        );
+        Pipeline::new(
+            mirror_op,
+            self.pipeline_config.clone(),
+            self.src_store.clone(),
+            Some(self.dst_store.clone()),
+        )
+    }
+
     /// Per-file retry — re-fetch individual files that the main pass failed
-    /// to repair, on a **fresh `Pipeline<MirrorOperation>`**.
+    /// to repair, on a **fresh `Pipeline<MirrorOperation>`** built by
+    /// [`Self::build_retry_pipeline`].
     ///
     /// For each broken file recorded in `parent_stats.failures` (per-cp file
     /// flags + bucket hashes), dispatch through the inner pipeline:
@@ -357,12 +348,10 @@ impl RepairOperation {
     ///   refs, covering buckets the main pass never probed when history
     ///   failed before bucket discovery).
     ///
-    /// The inner mirror is constructed with `overwrite=true` and
-    /// `update_well_known=false`. We don't run the full pipeline (no
-    /// `process_checkpoint`, no chain verification), only the per-item
-    /// primitives. Stats are extracted via `into_stats` (bypassing mirror's
-    /// `finalize` and its `has_failures` gate). Returns the inner's stats
-    /// directly — no merging into the parent.
+    /// We don't run the full pipeline (no `process_checkpoint`, no chain
+    /// verification), only the per-item primitives. Stats are extracted via
+    /// `into_stats` (bypassing mirror's `finalize` and its `has_failures`
+    /// gate). Returns the inner's stats directly — no merging into the parent.
     pub(crate) async fn retry_failed_files(&self, parent_stats: &ArchiveStats) -> ArchiveStats {
         if self.dry_run {
             return ArchiveStats::new();
@@ -375,46 +364,25 @@ impl RepairOperation {
 
         info!("Retrying {} failed file(s)", work.len());
 
-        let mirror_op = MirrorOperation::new(
-            self.dst_store.clone(),
-            /*overwrite=*/ true,
-            None,
-            None,
-            /*allow_mirror_gaps=*/ true,
-            &self.storage_config,
-            /*update_well_known=*/ false,
-        );
-        let file_retry_pipeline = Pipeline::new(
-            mirror_op,
-            PipelineConfig {
-                concurrency: self.concurrency,
-                skip_optional: self.skip_optional,
-                verify: self.verify,
-                storage_config: self.storage_config.clone(),
-            },
-            self.src_store.clone(),
-            Some(self.dst_store.clone()),
-        );
-
-        {
-            let pref = &file_retry_pipeline;
-            let cs = self.concurrency;
-            stream::iter(work.into_iter())
-                .for_each_concurrent(cs, |(cp, path)| async move {
+        let file_retry_pipeline = self.build_retry_pipeline();
+        stream::iter(work.into_iter())
+            .for_each_concurrent(self.pipeline_config.concurrency, |(cp, path)| {
+                let pipeline = &file_retry_pipeline;
+                async move {
                     if history_format::is_history_file(&path) {
-                        pref.process_history_and_buckets(cp).await;
+                        pipeline.process_history_and_buckets(cp).await;
                     } else {
-                        pref.process_file(cp, path).await;
+                        pipeline.process_file(cp, path).await;
                     }
-                })
-                .await;
-        }
-
+                }
+            })
+            .await;
         file_retry_pipeline.into_stats()
     }
 
     /// Per-checkpoint retry — re-mirror whole checkpoints flagged by cross-
-    /// file or cross-cp chain checks.
+    /// file or cross-cp chain checks, on a **fresh `Pipeline<MirrorOperation>`**
+    /// built by [`Self::build_retry_pipeline`].
     ///
     /// For each cp in `parent_stats.failures.checkpoints`, drive the inner
     /// pipeline's `run_checkpoints` to re-fetch every file in that cp from src
@@ -444,29 +412,8 @@ impl RepairOperation {
             retry_cps.len()
         );
 
-        let mirror_op = MirrorOperation::new(
-            self.dst_store.clone(),
-            /*overwrite=*/ true,
-            None,
-            None,
-            /*allow_mirror_gaps=*/ true,
-            &self.storage_config,
-            /*update_well_known=*/ false,
-        );
-        let checkpoint_retry_pipeline = Pipeline::new(
-            mirror_op,
-            PipelineConfig {
-                concurrency: self.concurrency,
-                skip_optional: self.skip_optional,
-                verify: self.verify,
-                storage_config: self.storage_config.clone(),
-            },
-            self.src_store.clone(),
-            Some(self.dst_store.clone()),
-        );
-
+        let checkpoint_retry_pipeline = self.build_retry_pipeline();
         let _ = checkpoint_retry_pipeline.run_checkpoints(retry_cps).await;
-
         checkpoint_retry_pipeline.into_stats()
     }
 
@@ -508,22 +455,6 @@ impl RepairOperation {
 // ============================================================================
 // Repair helpers (free functions)
 // ============================================================================
-
-/// Record a parsed XDR result into the verification manager. Used for both
-/// dst-side parses (via `verify_and_record_dst`) and src-side fetches (via
-/// `process_object` after `fetch_from_src`). No-op when the path doesn't
-/// carry a checkpoint number.
-fn record_result(manager: &XdrVerificationManager, path: &str, result: XdrParseResult) {
-    let Some(cp) = history_format::checkpoint_from_path(path) else {
-        return;
-    };
-    match result {
-        XdrParseResult::Ledger(data) => manager.record_header_data(cp, data),
-        XdrParseResult::Transactions(hashes) => manager.record_tx_set_hashes(cp, hashes),
-        XdrParseResult::Results(hashes) => manager.record_result_hashes(cp, hashes),
-        XdrParseResult::None => {}
-    }
-}
 
 /// Build a `(cp, path)` work list from the current state of the failure
 /// tracker. Read-only on `parent_stats` — no `mem::take`, no mutation. The
@@ -570,7 +501,10 @@ impl Operation for RepairOperation {
         let dst_result = utils::fetch_well_known_history_file(
             &self.dst_store,
             0, // no retries for local filesystem
-            self.storage_config.retry_min_delay.as_millis() as u64,
+            self.pipeline_config
+                .storage_config
+                .retry_min_delay
+                .as_millis() as u64,
         )
         .await;
 
@@ -586,8 +520,11 @@ impl Operation for RepairOperation {
                 // Fall back to source .well-known
                 let src_state = utils::fetch_well_known_history_file(
                     source,
-                    self.storage_config.max_retries as u32,
-                    self.storage_config.retry_min_delay.as_millis() as u64,
+                    self.pipeline_config.storage_config.max_retries as u32,
+                    self.pipeline_config
+                        .storage_config
+                        .retry_min_delay
+                        .as_millis() as u64,
                 )
                 .await
                 .map_err(|e| pipeline::Error::RepairOperation(Error::Utils(e)))?;
@@ -600,8 +537,8 @@ impl Operation for RepairOperation {
     }
 
     /// Process a file: try dst first (verify + record into manager), and on
-    /// missing/corrupt fetch from src (verify-and-write + record). All
-    /// verification logic lives here, matching scan/mirror's pattern.
+    /// missing/corrupt fetch from src and record the parsed XDR result into the
+    /// manager.
     async fn process_object(
         &self,
         path: &str,
@@ -615,10 +552,7 @@ impl Operation for RepairOperation {
             self.note_dry_run(path);
             return Ok(ProcessOutcome::Processed);
         }
-        let result = self.fetch_from_src(path, manager).await?;
-        if let (Some(parsed), Some(manager)) = (result, manager) {
-            record_result(manager, path, parsed);
-        }
+        xdr_verify::fetch_verify_and_write(&self.src_store, &self.dst_store, path, manager).await?;
         Ok(ProcessOutcome::Processed)
     }
 

--- a/src/repair_operation.rs
+++ b/src/repair_operation.rs
@@ -652,6 +652,18 @@ impl Operation for RepairOperation {
         if self.dry_run {
             let count = self.needs_repair_count.load(Ordering::Relaxed);
             info!("Dry run: {} file(s) would be repaired", count);
+            // Cross-file and chain failures are found by the verification
+            // manager (drained into stats.failures before finalize) and are
+            // invisible to the per-file dst probe, so they aren't in the count
+            // above. Report them separately: a real run would re-fetch these
+            // whole checkpoints in the checkpoint-retry stage.
+            let checkpoint_failures = stats.failures.lock().await.checkpoints.len();
+            if checkpoint_failures > 0 {
+                info!(
+                    "Dry run: {} checkpoint(s) with cross-file/chain failures would be re-fetched",
+                    checkpoint_failures
+                );
+            }
             return Ok(());
         }
 

--- a/src/repair_operation.rs
+++ b/src/repair_operation.rs
@@ -316,8 +316,14 @@ impl RepairOperation {
     /// overwrite=true, allow_mirror_gaps=true (the retry set is intentionally
     /// disjoint), update_well_known=false (a partial-set retry can't claim
     /// contiguous coverage), wired to repair's `src_store` and `dst_store`,
-    /// with the outer `pipeline_config` cloned verbatim.
-    fn build_retry_pipeline(&self) -> Pipeline<MirrorOperation> {
+    /// with the outer `pipeline_config` cloned. The caller chooses whether
+    /// the inner pipeline's `process_checkpoint` should skip
+    /// history-and-bucket work: `retry_failed_checkpoints` sets it true
+    /// (chain repair needs only per-cp xdr files); `retry_failed_files`
+    /// leaves it false (it drives `process_file` /
+    /// `process_history_and_buckets` directly, but the flag is wired
+    /// through explicitly for clarity).
+    fn build_retry_pipeline(&self, skip_history_and_buckets: bool) -> Pipeline<MirrorOperation> {
         let mirror_op = MirrorOperation::new(
             self.dst_store.clone(),
             /*overwrite=*/ true,
@@ -327,9 +333,11 @@ impl RepairOperation {
             &self.pipeline_config.storage_config,
             /*update_well_known=*/ false,
         );
+        let mut retry_config = self.pipeline_config.clone();
+        retry_config.skip_history_and_buckets = skip_history_and_buckets;
         Pipeline::new(
             mirror_op,
-            self.pipeline_config.clone(),
+            retry_config,
             self.src_store.clone(),
             Some(self.dst_store.clone()),
         )
@@ -364,7 +372,12 @@ impl RepairOperation {
 
         info!("Retrying {} failed file(s)", work.len());
 
-        let file_retry_pipeline = self.build_retry_pipeline();
+        // `retry_failed_files` drives `process_file` /
+        // `process_history_and_buckets` directly — these bypass
+        // `process_checkpoint`, so `skip_history_and_buckets` has no
+        // effect here. Passed `false` for clarity.
+        let file_retry_pipeline =
+            self.build_retry_pipeline(/*skip_history_and_buckets=*/ false);
         stream::iter(work.into_iter())
             .for_each_concurrent(self.pipeline_config.concurrency, |(cp, path)| {
                 let pipeline = &file_retry_pipeline;
@@ -412,7 +425,14 @@ impl RepairOperation {
             retry_cps.len()
         );
 
-        let checkpoint_retry_pipeline = self.build_retry_pipeline();
+        // `retry_failed_checkpoints` only needs per-cp xdr files. Chain
+        // checks don't read bucket content, and bucket failures are
+        // covered by `retry_failed_files` (either via `failures.buckets`
+        // direct fetches or via its HISTORY entries, which trigger
+        // `process_history_and_buckets`). So skip HAS + bucket work in
+        // the inner `process_checkpoint`.
+        let checkpoint_retry_pipeline =
+            self.build_retry_pipeline(/*skip_history_and_buckets=*/ true);
         let _ = checkpoint_retry_pipeline.run_checkpoints(retry_cps).await;
         checkpoint_retry_pipeline.into_stats()
     }
@@ -462,11 +482,23 @@ impl RepairOperation {
 /// of the snapshot; concurrent writers (there shouldn't be any at this point,
 /// but the lock is taken regardless) are blocked only for the duration of
 /// the read.
+///
+/// Non-HISTORY per-cp file entries whose cp is also in `failures.checkpoints`
+/// are skipped — `retry_failed_checkpoints` will re-mirror the whole cp
+/// anyway, so re-fetching individual files in `retry_failed_files` is
+/// redundant. HISTORY entries are kept unconditionally because the HISTORY
+/// repair path dispatches through `Pipeline::process_history_and_buckets(cp)`,
+/// which is the only bucket-discovery path for buckets that the main pass
+/// never probed (the case where the history download itself failed before
+/// bucket refs were walked). Bucket entries are also kept unconditionally —
+/// they're content-addressed, not cp-keyed, and `retry_failed_files` is the
+/// only place that repairs `failures.buckets`.
 async fn build_failed_files_work_list(parent_stats: &ArchiveStats) -> Vec<(u32, String)> {
     let f = parent_stats.failures.lock().await;
     let mut work = Vec::new();
 
     for (&cp, flags) in &f.files {
+        let cp_in_chain_retry = f.checkpoints.contains(&cp);
         for (bit, prefix) in [
             (utils::FileFlags::HISTORY, "history"),
             (utils::FileFlags::LEDGER, "ledger"),
@@ -474,9 +506,17 @@ async fn build_failed_files_work_list(parent_stats: &ArchiveStats) -> Vec<(u32, 
             (utils::FileFlags::RESULTS, "results"),
             (utils::FileFlags::SCP, "scp"),
         ] {
-            if flags.has(bit) {
-                work.push((cp, history_format::checkpoint_path(prefix, cp)));
+            if !flags.has(bit) {
+                continue;
             }
+            // Skip non-HISTORY per-cp files when `retry_failed_checkpoints`
+            // will re-mirror this whole cp anyway. HISTORY is kept because
+            // its repair path in `retry_failed_files` also re-walks bucket
+            // refs.
+            if bit != utils::FileFlags::HISTORY && cp_in_chain_retry {
+                continue;
+            }
+            work.push((cp, history_format::checkpoint_path(prefix, cp)));
         }
     }
 
@@ -590,7 +630,7 @@ impl Operation for RepairOperation {
     ) -> Result<(), pipeline::Error> {
         // Manager drain (verify_checkpoint_chain + record_all_errors) already
         // happened in `Pipeline::run_checkpoints`, so `stats.failures.checkpoints`
-        // is already populated for phase 2 to consume.
+        // is already populated for `retry_failed_checkpoints` to consume.
 
         if self.dry_run {
             let count = self.needs_repair_count.load(Ordering::Relaxed);
@@ -598,8 +638,9 @@ impl Operation for RepairOperation {
             return Ok(());
         }
 
-        // .well-known restoration. Separate path from phases (a follow-up
-        // may fold it into phase 1's per-path repair flow).
+        // .well-known restoration. Separate path from the two retry stages
+        // (a follow-up may fold it into `retry_failed_files`'s per-path
+        // repair flow).
         if self.well_known_needs_repair.load(Ordering::Relaxed) {
             self.repair_well_known(highest_checkpoint).await;
         }

--- a/src/repair_operation.rs
+++ b/src/repair_operation.rs
@@ -33,9 +33,8 @@ use crate::utils::{self, ArchiveStats};
 use crate::xdr_verify::{self, XdrParseResult, XdrVerificationManager};
 use futures_util::{stream, StreamExt};
 use opendal::Buffer;
-use std::collections::{BTreeSet, HashSet};
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
 use thiserror::Error;
 use tracing::{debug, error, info, warn};
 
@@ -75,23 +74,21 @@ pub struct RepairOperation {
     dst_store: StorageRef,
     low: Option<u32>,
     high: Option<u32>,
+    /// Kept (despite the verification manager moving to Pipeline) because
+    /// `retry_failed_files` / `retry_failed_checkpoints` build inner
+    /// `Pipeline<MirrorOperation>` instances and need to set
+    /// `PipelineConfig::verify` on them. Repair's own `process_object`
+    /// doesn't read this field — it branches on whether the `manager`
+    /// parameter (from the outer pipeline) is `Some`.
     verify: bool,
     dry_run: bool,
     concurrency: usize,
     skip_optional: bool,
     storage_config: StorageConfig,
-    /// Verification manager — populated only when `verify` is on. Records
-    /// per-file XDR data (from dst-first parse or src-fetched verify) so that
-    /// `finalize_checkpoint` can run cross-file checks and `finalize` can run
-    /// the cross-checkpoint chain check.
-    verification_manager: Option<Arc<XdrVerificationManager>>,
     /// Set during get_checkpoint_bounds if dest .well-known needs repair
     well_known_needs_repair: AtomicBool,
     /// Dry-run counter: files that would be repaired
     needs_repair_count: AtomicU64,
-    /// Checkpoints whose cross-file or chain checks failed; re-mirrored from
-    /// src in `finalize`.
-    retry_checkpoints: Mutex<BTreeSet<u32>>,
 }
 
 impl RepairOperation {
@@ -121,14 +118,8 @@ impl RepairOperation {
             concurrency,
             skip_optional,
             storage_config: storage_config.clone(),
-            verification_manager: if verify {
-                Some(Arc::new(XdrVerificationManager::new()))
-            } else {
-                None
-            },
             well_known_needs_repair: AtomicBool::new(false),
             needs_repair_count: AtomicU64::new(0),
-            retry_checkpoints: Mutex::new(BTreeSet::new()),
         }
     }
 
@@ -162,7 +153,9 @@ impl RepairOperation {
                         self.storage_config.retry_min_delay.as_millis() as u64,
                         "repair",
                         path,
-                        || async { self.fetch_from_src(path).await.map(|_| ()) },
+                        // Manual mode: no verification manager. Use plain
+                        // src-fetch / dst-copy semantics.
+                        || async { self.fetch_from_src(path, None).await.map(|_| ()) },
                     )
                     .await;
                     match result {
@@ -202,9 +195,13 @@ impl RepairOperation {
     /// Returns the parsed XDR data (for XDR files when `verify` is on) so the
     /// caller can record it into the manager. Returns `None` for buckets,
     /// non-verified copies, and unrecognized file types.
-    async fn fetch_from_src(&self, path: &str) -> Result<Option<XdrParseResult>, StorageError> {
+    async fn fetch_from_src(
+        &self,
+        path: &str,
+        manager: Option<&XdrVerificationManager>,
+    ) -> Result<Option<XdrParseResult>, StorageError> {
         let reader = self.src_store.open_reader(path).await?;
-        if self.verify {
+        if manager.is_some() {
             if history_format::is_bucket_file(path) {
                 return match crate::verify::verify_and_write_bucket(path, reader, &self.dst_store)
                     .await
@@ -247,7 +244,7 @@ impl RepairOperation {
         }
     }
 
-    /// Check whether dst already has a good copy of `path` and (when `--verify`
+    /// Check whether dst already has a good copy of `path` and (when verify
     /// is on) record the parsed data into the manager.
     ///
     /// Returns:
@@ -266,16 +263,20 @@ impl RepairOperation {
     ///   failure and move on instead of attempting a src fetch under broken
     ///   conditions.
     ///
-    /// When `--verify` is off, only existence is checked — content is not
-    /// validated and nothing is recorded into the manager.
-    async fn verify_and_record_dst(&self, path: &str) -> Result<bool, StorageError> {
-        if !self.verify {
+    /// When `manager` is `None` (verify off), only existence is checked —
+    /// content is not validated and nothing is recorded.
+    async fn verify_and_record_dst(
+        &self,
+        path: &str,
+        manager: Option<&XdrVerificationManager>,
+    ) -> Result<bool, StorageError> {
+        let Some(manager) = manager else {
             return match self.dst_store.exists(path).await {
                 Ok(present) => Ok(present),
                 Err(e) if e.class == ErrorClass::NotFound => Ok(false),
                 Err(e) => Err(e),
             };
-        }
+        };
 
         // Buckets and SCP files have no per-checkpoint manager state — verify
         // structurally on dst, no recording.
@@ -302,7 +303,7 @@ impl RepairOperation {
             return match self.dst_store.open_reader(path).await {
                 Ok(reader) => match xdr_verify::parse_ledger_header_stream(path, reader).await {
                     Ok(data) => {
-                        self.record_result(path, XdrParseResult::Ledger(data));
+                        record_result(manager, path, XdrParseResult::Ledger(data));
                         Ok(true)
                     }
                     Err(_) => Ok(false),
@@ -315,7 +316,7 @@ impl RepairOperation {
             return match self.dst_store.open_reader(path).await {
                 Ok(reader) => match xdr_verify::parse_transactions_stream(path, reader).await {
                     Ok(hashes) => {
-                        self.record_result(path, XdrParseResult::Transactions(hashes));
+                        record_result(manager, path, XdrParseResult::Transactions(hashes));
                         Ok(true)
                     }
                     Err(_) => Ok(false),
@@ -328,7 +329,7 @@ impl RepairOperation {
             return match self.dst_store.open_reader(path).await {
                 Ok(reader) => match xdr_verify::parse_results_stream(path, reader).await {
                     Ok(hashes) => {
-                        self.record_result(path, XdrParseResult::Results(hashes));
+                        record_result(manager, path, XdrParseResult::Results(hashes));
                         Ok(true)
                     }
                     Err(_) => Ok(false),
@@ -344,34 +345,36 @@ impl RepairOperation {
         )))
     }
 
-    /// Record a parsed XDR result into the verification manager. Used for both
-    /// dst-side parses (via `verify_and_record_dst`) and src-side fetches (via
-    /// `process_object` after `fetch_from_src`). No-op when `--verify` is off
-    /// (manager is `None`) or the path doesn't carry a checkpoint number.
-    fn record_result(&self, path: &str, result: XdrParseResult) {
-        let Some(ref manager) = self.verification_manager else {
-            return;
-        };
-        let Some(cp) = history_format::checkpoint_from_path(path) else {
-            return;
-        };
-        match result {
-            XdrParseResult::Ledger(data) => manager.record_header_data(cp, data),
-            XdrParseResult::Transactions(hashes) => manager.record_tx_set_hashes(cp, hashes),
-            XdrParseResult::Results(hashes) => manager.record_result_hashes(cp, hashes),
-            XdrParseResult::None => {}
+    /// Per-file retry — re-fetch individual files that the main pass failed
+    /// to repair, on a **fresh `Pipeline<MirrorOperation>`**.
+    ///
+    /// For each broken file recorded in `parent_stats.failures` (per-cp file
+    /// flags + bucket hashes), dispatch through the inner pipeline:
+    ///
+    /// - per-cp standard files (LEDGER/TRANSACTIONS/RESULTS/SCP) and buckets
+    ///   → `Pipeline::process_file`.
+    /// - HISTORY → `Pipeline::process_history_and_buckets` (re-walks bucket
+    ///   refs, covering buckets the main pass never probed when history
+    ///   failed before bucket discovery).
+    ///
+    /// The inner mirror is constructed with `overwrite=true` and
+    /// `update_well_known=false`. We don't run the full pipeline (no
+    /// `process_checkpoint`, no chain verification), only the per-item
+    /// primitives. Stats are extracted via `into_stats` (bypassing mirror's
+    /// `finalize` and its `has_failures` gate). Returns the inner's stats
+    /// directly — no merging into the parent.
+    pub(crate) async fn retry_failed_files(&self, parent_stats: &ArchiveStats) -> ArchiveStats {
+        if self.dry_run {
+            return ArchiveStats::new();
         }
-    }
 
-    /// Re-mirror a list of checkpoints from src using `Pipeline<MirrorOperation>`
-    /// with overwrite semantics (`overwrite=true`, `verify=false`). Trust src
-    /// is canonical — no residual verification. Retry checkpoints are
-    /// processed concurrently up to `self.concurrency`.
-    async fn run_retry(&self, retry: &[u32]) {
-        info!(
-            "Retrying {} checkpoint(s) from src (cross-file or chain inconsistency)",
-            retry.len()
-        );
+        let work = build_failed_files_work_list(parent_stats).await;
+        if work.is_empty() {
+            return ArchiveStats::new();
+        }
+
+        info!("Retrying {} failed file(s)", work.len());
+
         let mirror_op = MirrorOperation::new(
             self.dst_store.clone(),
             /*overwrite=*/ true,
@@ -379,24 +382,92 @@ impl RepairOperation {
             None,
             /*allow_mirror_gaps=*/ true,
             &self.storage_config,
-            /*verify=*/ false,
+            /*update_well_known=*/ false,
         );
-        let retry_pipeline = Pipeline::new(
+        let file_retry_pipeline = Pipeline::new(
             mirror_op,
             PipelineConfig {
                 concurrency: self.concurrency,
                 skip_optional: self.skip_optional,
+                verify: self.verify,
                 storage_config: self.storage_config.clone(),
             },
             self.src_store.clone(),
             Some(self.dst_store.clone()),
         );
-        let pipeline_ref = &retry_pipeline;
-        stream::iter(retry.iter().copied())
-            .for_each_concurrent(self.concurrency, |cp| async move {
-                pipeline_ref.process_checkpoint(cp).await;
-            })
-            .await;
+
+        {
+            let pref = &file_retry_pipeline;
+            let cs = self.concurrency;
+            stream::iter(work.into_iter())
+                .for_each_concurrent(cs, |(cp, path)| async move {
+                    if history_format::is_history_file(&path) {
+                        pref.process_history_and_buckets(cp).await;
+                    } else {
+                        pref.process_file(cp, path).await;
+                    }
+                })
+                .await;
+        }
+
+        file_retry_pipeline.into_stats()
+    }
+
+    /// Per-checkpoint retry — re-mirror whole checkpoints flagged by cross-
+    /// file or cross-cp chain checks.
+    ///
+    /// For each cp in `parent_stats.failures.checkpoints`, drive the inner
+    /// pipeline's `run_checkpoints` to re-fetch every file in that cp from src
+    /// (overwrite=true). `run_checkpoints` exercises the full per-cp loop
+    /// (`verify_and_release` per cp) AND runs the cross-cp chain check + drain
+    /// at its end, so `checkpoint_retry_pipeline.stats().failures.checkpoints`
+    /// is fully populated by the time it returns. We just call `into_stats`
+    /// to extract — no manual drain step.
+    pub(crate) async fn retry_failed_checkpoints(
+        &self,
+        parent_stats: &ArchiveStats,
+    ) -> ArchiveStats {
+        if self.dry_run {
+            return ArchiveStats::new();
+        }
+
+        let retry_cps: Vec<u32> = {
+            let f = parent_stats.failures.lock().await;
+            f.checkpoints.iter().copied().collect()
+        };
+        if retry_cps.is_empty() {
+            return ArchiveStats::new();
+        }
+
+        info!(
+            "Retrying {} failed checkpoint(s) (cross-file / chain failures)",
+            retry_cps.len()
+        );
+
+        let mirror_op = MirrorOperation::new(
+            self.dst_store.clone(),
+            /*overwrite=*/ true,
+            None,
+            None,
+            /*allow_mirror_gaps=*/ true,
+            &self.storage_config,
+            /*update_well_known=*/ false,
+        );
+        let checkpoint_retry_pipeline = Pipeline::new(
+            mirror_op,
+            PipelineConfig {
+                concurrency: self.concurrency,
+                skip_optional: self.skip_optional,
+                verify: self.verify,
+                storage_config: self.storage_config.clone(),
+            },
+            self.src_store.clone(),
+            Some(self.dst_store.clone()),
+        );
+
+        let _ = checkpoint_retry_pipeline.run_checkpoints(retry_cps).await;
+
+        checkpoint_retry_pipeline.into_stats()
     }
 
     /// Repair .well-known by copying from highest checkpoint's history file.
@@ -432,6 +503,61 @@ impl RepairOperation {
             }
         }
     }
+}
+
+// ============================================================================
+// Repair helpers (free functions)
+// ============================================================================
+
+/// Record a parsed XDR result into the verification manager. Used for both
+/// dst-side parses (via `verify_and_record_dst`) and src-side fetches (via
+/// `process_object` after `fetch_from_src`). No-op when the path doesn't
+/// carry a checkpoint number.
+fn record_result(manager: &XdrVerificationManager, path: &str, result: XdrParseResult) {
+    let Some(cp) = history_format::checkpoint_from_path(path) else {
+        return;
+    };
+    match result {
+        XdrParseResult::Ledger(data) => manager.record_header_data(cp, data),
+        XdrParseResult::Transactions(hashes) => manager.record_tx_set_hashes(cp, hashes),
+        XdrParseResult::Results(hashes) => manager.record_result_hashes(cp, hashes),
+        XdrParseResult::None => {}
+    }
+}
+
+/// Build a `(cp, path)` work list from the current state of the failure
+/// tracker. Read-only on `parent_stats` — no `mem::take`, no mutation. The
+/// work list captures every uniquely-identifiable failed file at the moment
+/// of the snapshot; concurrent writers (there shouldn't be any at this point,
+/// but the lock is taken regardless) are blocked only for the duration of
+/// the read.
+async fn build_failed_files_work_list(parent_stats: &ArchiveStats) -> Vec<(u32, String)> {
+    let f = parent_stats.failures.lock().await;
+    let mut work = Vec::new();
+
+    for (&cp, flags) in &f.files {
+        for (bit, prefix) in [
+            (utils::FileFlags::HISTORY, "history"),
+            (utils::FileFlags::LEDGER, "ledger"),
+            (utils::FileFlags::TRANSACTIONS, "transactions"),
+            (utils::FileFlags::RESULTS, "results"),
+            (utils::FileFlags::SCP, "scp"),
+        ] {
+            if flags.has(bit) {
+                work.push((cp, history_format::checkpoint_path(prefix, cp)));
+            }
+        }
+    }
+
+    for hash in &f.buckets {
+        if let Ok(path) = history_format::bucket_path(&hex::encode(hash.0)) {
+            // cp context is 0 — buckets are content-addressed and
+            // `record_failure`'s bucket-path dispatch ignores cp.
+            work.push((0, path));
+        }
+    }
+
+    work
 }
 
 #[async_trait]
@@ -478,20 +604,20 @@ impl Operation for RepairOperation {
     /// verification logic lives here, matching scan/mirror's pattern.
     async fn process_object(
         &self,
-        _checkpoint: u32,
         path: &str,
         _src_store: &StorageRef,
+        manager: Option<&XdrVerificationManager>,
     ) -> Result<ProcessOutcome, StorageError> {
-        if self.verify_and_record_dst(path).await? {
+        if self.verify_and_record_dst(path, manager).await? {
             return Ok(ProcessOutcome::Processed);
         }
         if self.dry_run {
             self.note_dry_run(path);
             return Ok(ProcessOutcome::Processed);
         }
-        let result = self.fetch_from_src(path).await?;
-        if let Some(parsed) = result {
-            self.record_result(path, parsed);
+        let result = self.fetch_from_src(path, manager).await?;
+        if let (Some(parsed), Some(manager)) = (result, manager) {
+            record_result(manager, path, parsed);
         }
         Ok(ProcessOutcome::Processed)
     }
@@ -523,59 +649,50 @@ impl Operation for RepairOperation {
         storage::download_buffer(src_store, history_path).await
     }
 
-    fn finalize_checkpoint(&self, checkpoint: u32) {
-        if let Some(ref manager) = self.verification_manager {
-            manager.verify_and_release(checkpoint);
-            // TODO(repair-retry-redesign): `verify_and_release` no longer
-            // returns errors; they're now accumulated in the manager and the
-            // pipeline's `stats.failures.checkpoints` set. Drive the retry
-            // decision from `stats.failures.checkpoints` in a follow-up.
-        }
-    }
-
     async fn finalize(
         &self,
         highest_checkpoint: u32,
         stats: &ArchiveStats,
     ) -> Result<(), pipeline::Error> {
-        // Step 1: cross-checkpoint chain check; both ends of any break go to retry.
-        if let Some(ref manager) = self.verification_manager {
-            manager.verify_checkpoint_chain();
-            // TODO(repair-retry-redesign): `verify_checkpoint_chain` no longer
-            // returns errors; they're now accumulated in the manager. With
-            // boundary failures already recording both flanking cps into
-            // `stats.failures.checkpoints`, drive retry directly from there in
-            // a follow-up. Until then, `retry_checkpoints` stays empty and the
-            // retry phase below is effectively a no-op.
+        // Manager drain (verify_checkpoint_chain + record_all_errors) already
+        // happened in `Pipeline::run_checkpoints`, so `stats.failures.checkpoints`
+        // is already populated for phase 2 to consume.
+
+        if self.dry_run {
+            let count = self.needs_repair_count.load(Ordering::Relaxed);
+            info!("Dry run: {} file(s) would be repaired", count);
+            return Ok(());
         }
 
-        let retry: Vec<u32> = std::mem::take(&mut *self.retry_checkpoints.lock().unwrap())
-            .into_iter()
-            .collect();
-
-        // Step 2: re-mirror retry checkpoints from src using Pipeline<MirrorOperation>.
-        if !retry.is_empty() && !self.dry_run {
-            self.run_retry(&retry).await;
-        }
-
-        // Step 3: .well-known repair (after retry, so it reflects fixed data).
-        if self.well_known_needs_repair.load(Ordering::Relaxed) && !self.dry_run {
+        // .well-known restoration. Separate path from phases (a follow-up
+        // may fold it into phase 1's per-path repair flow).
+        if self.well_known_needs_repair.load(Ordering::Relaxed) {
             self.repair_well_known(highest_checkpoint).await;
         }
 
-        // Step 4: report results.
-        if self.dry_run {
-            let count = self.needs_repair_count.load(Ordering::Relaxed);
-            info!(
-                "Dry run: {} file(s) would be repaired ({} checkpoint(s) would retry)",
-                count,
-                retry.len()
-            );
-        } else {
-            stats.report("repair").await;
-            if stats.has_failures().await {
-                return Err(Error::RepairFailed.into());
-            }
+        stats.report("repair main").await;
+
+        // Per-file retry: re-fetch every entry in failures.files /
+        // failures.buckets. Returns its own stats — no merging.
+        let file_retry_stats = self.retry_failed_files(stats).await;
+        file_retry_stats.report("repair file retry").await;
+
+        // Per-checkpoint retry: re-mirror every cp in failures.checkpoints.
+        // Returns its own stats (including any chain errors surfaced
+        // post-retry).
+        let checkpoint_retry_stats = self.retry_failed_checkpoints(stats).await;
+        checkpoint_retry_stats
+            .report("repair checkpoint retry")
+            .await;
+
+        // Overall success = both retries recovered everything they attempted.
+        // The parent's failures are expected — those are what we just tried
+        // to fix; the retries' own failure trackers are the ground truth for
+        // "what's still broken."
+        let file_retry_failed = file_retry_stats.has_failures().await;
+        let checkpoint_retry_failed = checkpoint_retry_stats.has_failures().await;
+        if file_retry_failed || checkpoint_retry_failed {
+            return Err(Error::RepairFailed.into());
         }
 
         Ok(())
@@ -587,7 +704,6 @@ impl Operation for RepairOperation {
     /// reports its dry-run no-op branches).
     async fn process_buffer(
         &self,
-        _checkpoint: u32,
         path: &str,
         buffer: Buffer,
     ) -> Result<ProcessOutcome, StorageError> {

--- a/src/repair_operation.rs
+++ b/src/repair_operation.rs
@@ -20,8 +20,10 @@
 //! `MirrorOperation` (overwrite=true, verify=false) — pure copy from src,
 //! trusting src is canonical.
 //!
-//! **Manual mode** (`run_manual`): downloads a fixed list of paths directly,
-//! bypassing the pipeline and the retry machinery.
+//! **Manual mode** (`run_manual`): applies a plan (an `ArchiveReport`, typically
+//! from a prior `--dry-run`) by seeding the failure set and running the same
+//! two-stage retry, bypassing the main-pass pipeline. `.well-known` is restored
+//! from the checkpoint carried in the plan.
 
 use crate::history_format;
 use crate::mirror_operation::MirrorOperation;
@@ -33,18 +35,17 @@ use crate::utils::{self, ArchiveStats};
 use crate::xdr_verify::{self, XdrParseResult, XdrVerificationManager};
 use futures_util::{stream, StreamExt};
 use opendal::{Buffer, Reader};
-use std::collections::HashSet;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use thiserror::Error;
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Archive repair failed")]
     RepairFailed,
 
-    #[error("Invalid file list: {0}")]
-    InvalidFileList(String),
+    #[error("Invalid plan: {0}")]
+    InvalidPlan(String),
 
     #[error(transparent)]
     Utils(#[from] utils::Error),
@@ -64,9 +65,6 @@ pub enum Error {
     #[error("Report error: {0}")]
     Report(#[from] crate::report::ReportError),
 }
-
-/// How often to report progress (every N files) in manual mode
-const MANUAL_PROGRESS_FREQUENCY: usize = 100;
 
 // ============================================================================
 // RepairOperation
@@ -113,72 +111,72 @@ impl RepairOperation {
         }
     }
 
-    /// Manual mode: download a fixed list of paths directly (no checkpoint
-    /// iteration, no bucket discovery, no verification manager, no retry).
-    pub async fn run_manual(&self, files: &[String]) -> Result<(), Error> {
-        info!("Manual repair mode: {} files specified", files.len());
-        let files = validate_file_list(files)?;
-        if files.is_empty() {
-            info!("No files need repair");
+    /// Manual repair driven by a plan: apply an `ArchiveReport` (typically
+    /// produced by an earlier `--dry-run`) by seeding the failure set and
+    /// running the same two-stage retry the main flow uses — phase 1 over
+    /// files/buckets, phase 2 over checkpoints. The plan is a directive: every
+    /// listed item is re-fetched from source unconditionally (the retry stages
+    /// overwrite).
+    ///
+    /// `.well-known` is restored from the checkpoint carried in the plan, so no
+    /// archive-bound recomputation is needed.
+    pub async fn run_manual(
+        &self,
+        report: crate::report::ArchiveReport,
+        report_path: Option<&std::path::Path>,
+    ) -> Result<(), Error> {
+        let tracker = report
+            .into_failures()
+            .map_err(|e| Error::InvalidPlan(e.to_string()))?;
+        if tracker.is_empty() {
+            info!("Plan is empty; nothing to repair");
             return Ok(());
         }
-        info!("{} file(s) to repair", files.len());
-
-        if self.dry_run {
-            report_dry_run(&files);
-            return Ok(());
-        }
+        let well_known_cp = tracker.well_known;
 
         let stats = ArchiveStats::new();
-        let completed = AtomicUsize::new(0);
-        let total = files.len();
+        *stats.failures.lock().await = tracker;
 
-        stream::iter(files.iter())
-            .for_each_concurrent(self.pipeline_config.concurrency, |path| {
-                let stats = &stats;
-                let completed = &completed;
-                async move {
-                    let result = utils::with_retries(
-                        self.pipeline_config.storage_config.max_retries as u32,
-                        self.pipeline_config
-                            .storage_config
-                            .retry_min_delay
-                            .as_millis() as u64,
-                        "repair",
-                        path,
-                        // Manual mode: no verification manager. Use plain
-                        // src-fetch / dst-copy semantics.
-                        || {
-                            xdr_verify::fetch_verify_and_write(
-                                &self.src_store,
-                                &self.dst_store,
-                                path,
-                                None,
-                            )
-                        },
-                    )
-                    .await;
-                    match result {
-                        Ok(()) => {
-                            debug!("Repaired: {}", path);
-                            stats.record_success(path);
-                        }
-                        Err(e) => {
-                            error!("Failed to repair {}: {}", path, e);
-                            let cp = history_format::checkpoint_from_path(path).unwrap_or(0);
-                            stats.record_failure(cp, path).await;
-                        }
-                    }
-                    let done = completed.fetch_add(1, Ordering::Relaxed) + 1;
-                    if done.is_multiple_of(MANUAL_PROGRESS_FREQUENCY) || done == total {
-                        info!("Repair progress: {}/{} files", done, total);
-                    }
-                }
-            })
+        let file_retry_stats = self.retry_failed_files(&stats).await;
+        file_retry_stats.report("repair file retry").await;
+
+        let checkpoint_retry_stats = self.retry_failed_checkpoints(&stats).await;
+        checkpoint_retry_stats
+            .report("repair checkpoint retry")
             .await;
 
-        stats.report("repair").await;
-        if stats.has_failures().await {
+        // `.well_known` restoration runs after the retry stages because the
+        // history file it copies may itself be one the file retry just
+        // restored.
+        let well_known_failed = match well_known_cp {
+            Some(cp) => !self.repair_well_known(cp).await,
+            None => false,
+        };
+
+        // Two sections — plan-driven repair has no main pass.
+        if let Some(path) = report_path {
+            let out = crate::report::MultiSectionReport {
+                version: crate::report::REPORT_VERSION,
+                sections: [
+                    (
+                        "file_retry".to_string(),
+                        file_retry_stats.report_section().await,
+                    ),
+                    (
+                        "checkpoint_retry".to_string(),
+                        checkpoint_retry_stats.report_section().await,
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+            };
+            crate::report::write_to_path(path, &out)?;
+        }
+
+        if file_retry_stats.has_failures().await
+            || checkpoint_retry_stats.has_failures().await
+            || well_known_failed
+        {
             return Err(Error::RepairFailed);
         }
         Ok(())
@@ -749,276 +747,5 @@ impl Operation for RepairOperation {
         }
         storage::write_buffer_with_cleanup(&self.dst_store, path, buffer).await?;
         Ok(ProcessOutcome::Processed)
-    }
-}
-
-// ============================================================================
-// Manual-mode helpers
-// ============================================================================
-
-/// Log what would be repaired (for manual mode dry-run).
-fn report_dry_run(files: &[String]) {
-    info!("Dry run: {} file(s) would be repaired:", files.len());
-
-    let mut counts = [0u64; 7];
-    for path in files {
-        let idx = if path.starts_with("history/") || path.contains("stellar-history.json") {
-            0
-        } else if path.starts_with("ledger/") {
-            1
-        } else if path.starts_with("transactions/") {
-            2
-        } else if path.starts_with("results/") {
-            3
-        } else if path.starts_with("bucket/") {
-            4
-        } else if path.starts_with("scp/") {
-            5
-        } else {
-            6
-        };
-        counts[idx] += 1;
-    }
-
-    let labels = [
-        "history",
-        "ledger",
-        "transactions",
-        "results",
-        "bucket",
-        "scp",
-        "other",
-    ];
-    for (count, label) in counts.iter().zip(labels.iter()) {
-        if *count > 0 {
-            info!("  {} {} file(s)", count, label);
-        }
-    }
-}
-
-/// Validate a JSON file list for manual repair mode.
-///
-/// Each entry must be a recognized archive path — `.well-known/stellar-history.json`
-/// or one of the per-category checkpoint/bucket paths under `history/`,
-/// `ledger/`, `transactions/`, `results/`, `scp/`, or `bucket/`. This prevents
-/// path traversal: manual-mode paths flow into `dst_store.copy_from_reader`,
-/// which on filesystem-backed destinations joins onto the archive root, so
-/// arbitrary input like `../../etc/foo` or `/absolute/path` would otherwise
-/// allow writes outside the archive.
-///
-/// Defense-in-depth: also reject any path containing `..` segments, a leading
-/// `/`, or a backslash, even if the per-category predicate were to drift in
-/// the future. Empty strings are skipped (legacy behavior). Duplicates are
-/// deduped.
-pub fn validate_file_list(file_list: &[String]) -> Result<Vec<String>, Error> {
-    let mut seen = HashSet::new();
-    let mut result = Vec::new();
-    for path in file_list {
-        if path.is_empty() {
-            continue;
-        }
-
-        // Path-traversal guards. Reject anything that looks like an absolute
-        // path, a Windows path separator, or contains a `..` segment.
-        if path.starts_with('/') || path.contains('\\') {
-            return Err(Error::InvalidFileList(format!(
-                "path '{path}' must be a relative archive path \
-                 (no leading '/', no '\\\\' separators)"
-            )));
-        }
-        if path.split('/').any(|seg| seg == "..") {
-            return Err(Error::InvalidFileList(format!(
-                "path '{path}' contains '..' segment; archive paths must not traverse"
-            )));
-        }
-
-        // Must be a recognized archive path shape.
-        let recognized = path == history_format::ROOT_WELL_KNOWN_PATH
-            || history_format::is_history_file(path)
-            || history_format::is_ledger_header_file(path)
-            || history_format::is_transactions_file(path)
-            || history_format::is_results_file(path)
-            || history_format::is_scp_file(path)
-            || history_format::is_bucket_file(path);
-        if !recognized {
-            return Err(Error::InvalidFileList(format!(
-                "path '{path}' is not a recognized archive path \
-                 (expected .well-known/stellar-history.json or a file under \
-                 history/ ledger/ transactions/ results/ scp/ bucket/)"
-            )));
-        }
-
-        if seen.insert(path.clone()) {
-            result.push(path.clone());
-        }
-    }
-    Ok(result)
-}
-
-/// Parse a JSON file containing an array of file paths for manual repair.
-pub fn parse_file_list_json(content: &str) -> Result<Vec<String>, Error> {
-    let parsed: serde_json::Value = serde_json::from_str(content)
-        .map_err(|e| Error::InvalidFileList(format!("Invalid JSON: {e}")))?;
-
-    let array = parsed
-        .as_array()
-        .ok_or_else(|| Error::InvalidFileList("Expected a JSON array of file paths".to_string()))?;
-
-    let mut paths = Vec::with_capacity(array.len());
-    for (i, item) in array.iter().enumerate() {
-        let path = item.as_str().ok_or_else(|| {
-            Error::InvalidFileList(format!("Element at index {i} is not a string"))
-        })?;
-        paths.push(path.to_string());
-    }
-
-    validate_file_list(&paths)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_validate_file_list_valid() {
-        let list = vec![
-            "ledger/00/00/3f/ledger-0000003f.xdr.gz".to_string(),
-            "bucket/ab/cd/ef/bucket-abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890.xdr.gz".to_string(),
-        ];
-        let result = validate_file_list(&list).unwrap();
-        assert_eq!(result.len(), 2);
-    }
-
-    #[test]
-    fn test_validate_file_list_empty() {
-        let list: Vec<String> = vec![];
-        let result = validate_file_list(&list).unwrap();
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn test_validate_file_list_deduplicates() {
-        let list = vec![
-            "ledger/00/00/3f/ledger-0000003f.xdr.gz".to_string(),
-            "ledger/00/00/3f/ledger-0000003f.xdr.gz".to_string(),
-        ];
-        let result = validate_file_list(&list).unwrap();
-        assert_eq!(result.len(), 1);
-    }
-
-    #[test]
-    fn test_validate_file_list_skips_empty_strings() {
-        let list = vec![
-            String::new(),
-            "ledger/00/00/3f/ledger-0000003f.xdr.gz".to_string(),
-        ];
-        let result = validate_file_list(&list).unwrap();
-        assert_eq!(result.len(), 1);
-    }
-
-    #[test]
-    fn test_validate_file_list_accepts_all_recognized_kinds() {
-        let list = vec![
-            ".well-known/stellar-history.json".to_string(),
-            "history/00/00/3f/history-0000003f.json".to_string(),
-            "ledger/00/00/3f/ledger-0000003f.xdr.gz".to_string(),
-            "transactions/00/00/3f/transactions-0000003f.xdr.gz".to_string(),
-            "results/00/00/3f/results-0000003f.xdr.gz".to_string(),
-            "scp/00/00/3f/scp-0000003f.xdr.gz".to_string(),
-            "bucket/ab/cd/ef/bucket-abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890.xdr.gz".to_string(),
-        ];
-        let result = validate_file_list(&list).unwrap();
-        assert_eq!(result.len(), 7);
-    }
-
-    #[test]
-    fn test_validate_file_list_rejects_path_traversal() {
-        let list = vec!["ledger/../etc/passwd".to_string()];
-        let err = validate_file_list(&list).unwrap_err().to_string();
-        assert!(err.contains(".."), "got: {err}");
-    }
-
-    #[test]
-    fn test_validate_file_list_rejects_path_traversal_at_start() {
-        let list = vec!["../escape.txt".to_string()];
-        let err = validate_file_list(&list).unwrap_err().to_string();
-        assert!(err.contains(".."), "got: {err}");
-    }
-
-    #[test]
-    fn test_validate_file_list_rejects_absolute_path() {
-        let list = vec!["/etc/passwd".to_string()];
-        let err = validate_file_list(&list).unwrap_err().to_string();
-        assert!(err.contains("relative"), "got: {err}");
-    }
-
-    #[test]
-    fn test_validate_file_list_rejects_backslash() {
-        let list = vec!["ledger\\foo.xdr.gz".to_string()];
-        let err = validate_file_list(&list).unwrap_err().to_string();
-        assert!(err.contains("relative"), "got: {err}");
-    }
-
-    #[test]
-    fn test_validate_file_list_rejects_unknown_prefix() {
-        let list = vec!["garbage/foo.xdr.gz".to_string()];
-        let err = validate_file_list(&list).unwrap_err().to_string();
-        assert!(err.contains("not a recognized"), "got: {err}");
-    }
-
-    #[test]
-    fn test_validate_file_list_rejects_bucket_with_bad_hash() {
-        // Right prefix, but the hash isn't 64 hex chars → is_bucket_file returns false.
-        let list = vec!["bucket/ab/cd/ef/bucket-shorthash.xdr.gz".to_string()];
-        let err = validate_file_list(&list).unwrap_err().to_string();
-        assert!(err.contains("not a recognized"), "got: {err}");
-    }
-
-    #[test]
-    fn test_parse_file_list_json_valid() {
-        let json = r#"["ledger/00/00/3f/ledger-0000003f.xdr.gz", "bucket/ab/cd/ef/bucket-abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890.xdr.gz"]"#;
-        let result = parse_file_list_json(json).unwrap();
-        assert_eq!(result.len(), 2);
-    }
-
-    #[test]
-    fn test_parse_file_list_json_empty_array() {
-        let json = "[]";
-        let result = parse_file_list_json(json).unwrap();
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn test_parse_file_list_json_invalid_json() {
-        let json = "not json {{";
-        let result = parse_file_list_json(json);
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        assert!(err.contains("Invalid JSON"), "got: {err}");
-    }
-
-    #[test]
-    fn test_parse_file_list_json_non_array() {
-        let json = r#"{"key": "value"}"#;
-        let result = parse_file_list_json(json);
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        assert!(err.contains("JSON array"), "got: {err}");
-    }
-
-    #[test]
-    fn test_parse_file_list_json_non_string_elements() {
-        let json = "[1, 2, 3]";
-        let result = parse_file_list_json(json);
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        assert!(err.contains("not a string"), "got: {err}");
-    }
-
-    #[test]
-    fn test_parse_file_list_json_deduplicates() {
-        let json = r#"["ledger/00/00/3f/ledger-0000003f.xdr.gz", "ledger/00/00/3f/ledger-0000003f.xdr.gz"]"#;
-        let result = parse_file_list_json(json).unwrap();
-        assert_eq!(result.len(), 1);
     }
 }

--- a/src/repair_operation.rs
+++ b/src/repair_operation.rs
@@ -148,10 +148,11 @@ impl RepairOperation {
         // `.well_known` restoration runs after the retry stages because the
         // history file it copies may itself be one the file retry just
         // restored.
-        let well_known_failed = match well_known_cp {
-            Some(cp) => !self.repair_well_known(cp).await,
-            None => false,
-        };
+        if let Some(cp) = well_known_cp {
+            if !self.repair_well_known(cp).await {
+                file_retry_stats.failures.lock().await.record_well_known(cp);
+            }
+        }
 
         // Two sections — plan-driven repair has no main pass.
         if let Some(path) = report_path {
@@ -173,10 +174,7 @@ impl RepairOperation {
             crate::report::write_to_path(path, &out)?;
         }
 
-        if file_retry_stats.has_failures().await
-            || checkpoint_retry_stats.has_failures().await
-            || well_known_failed
-        {
+        if file_retry_stats.has_failures().await || checkpoint_retry_stats.has_failures().await {
             return Err(Error::RepairFailed);
         }
         Ok(())
@@ -645,22 +643,15 @@ impl Operation for RepairOperation {
         stats: &ArchiveStats,
         report_path: Option<&std::path::Path>,
     ) -> Result<(), pipeline::Error> {
-        // Manager drain (verify_checkpoint_chain + record_all_errors) already
-        // happened in `Pipeline::run_checkpoints`, so `stats.failures.checkpoints`
-        // is already populated for `retry_failed_checkpoints` to consume.
+        if self.well_known_needs_repair.load(Ordering::Relaxed) {
+            stats
+                .failures
+                .lock()
+                .await
+                .record_well_known(highest_checkpoint);
+        }
 
         if self.dry_run {
-            // Reflect the well-known flag into stats so the plan includes it,
-            // then report: dry-run records the broken inventory into
-            // `stats.failures` (per-file/bucket via NeedsRepair, checkpoints via
-            // the manager), so logging + the JSON plan both read from it.
-            if self.well_known_needs_repair.load(Ordering::Relaxed) {
-                stats
-                    .failures
-                    .lock()
-                    .await
-                    .record_well_known(highest_checkpoint);
-            }
             stats.report("repair").await;
             if let Some(path) = report_path {
                 let report = crate::report::ArchiveReport {
@@ -671,9 +662,9 @@ impl Operation for RepairOperation {
                     .map_err(|e| pipeline::Error::RepairOperation(Error::Report(e)))?;
             }
             return Ok(());
+        } else {
+            stats.report("repair main").await;
         }
-
-        stats.report("repair main").await;
 
         // Per-file retry: re-fetch every entry in failures.files /
         // failures.buckets. Returns its own stats — no merging.
@@ -692,12 +683,16 @@ impl Operation for RepairOperation {
         // highest checkpoint's history file on dst, and that history file may
         // itself be what the file-retry stage just restored (when its main-pass
         // fetch failed).
-        //
-        // `repair_well_known` returns whether .well-known ended up in its
-        // intended state; a restoration failure (missing history file,
-        // directory creation, or copy) feeds the success gate below directly.
-        let well_known_failed = self.well_known_needs_repair.load(Ordering::Relaxed)
-            && !self.repair_well_known(highest_checkpoint).await;
+        if self.well_known_needs_repair.load(Ordering::Relaxed) {
+            let repair_success = self.repair_well_known(highest_checkpoint).await;
+            if !repair_success {
+                file_retry_stats
+                    .failures
+                    .lock()
+                    .await
+                    .record_well_known(highest_checkpoint);
+            }
+        }
 
         // Full-context report: one section per stage (main pass + both retries).
         // Built and written once — all three stats are in hand here.
@@ -726,7 +721,7 @@ impl Operation for RepairOperation {
         // .well-known restoration (if needed) succeeded.
         let file_retry_failed = file_retry_stats.has_failures().await;
         let checkpoint_retry_failed = checkpoint_retry_stats.has_failures().await;
-        if file_retry_failed || checkpoint_retry_failed || well_known_failed {
+        if file_retry_failed || checkpoint_retry_failed {
             return Err(Error::RepairFailed.into());
         }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,9 +1,14 @@
 //! JSON plan/report schema for repair and status output.
 //!
-//! `ArchiveReport` is a versioned, deterministic serialization of an operation's
-//! `FailureTracker` plus an outcome `Summary`. It serves three roles: repair
-//! dry-run output (a "plan"), repair input (`--plan`), and status output for any
-//! operation (`--report`). It round-trips: `into_failures` is the inverse of the
+//! `ArchiveReport` is a versioned, deterministic serialization of an
+//! operation's `FailureTracker` plus an outcome `Summary`. It is the single
+//! shared schema for scan/mirror/repair-dry-run output and repair `--plan`
+//! input, so any `--report` can be replayed as a plan. On apply, every listed
+//! item is re-fetched from src; the CLI `--verify` works exactly as in regular
+//! repair (it governs validation of the src content and the dst probing of
+//! discovered bucket files). It serves three roles: repair dry-run output (a
+//! "plan"), repair input (`--plan`), and status output for any operation
+//! (`--report`). It round-trips: `into_failures` is the inverse of the
 //! `from_failures_and_summary` projection (modulo `summary`/`version`).
 //!
 //! Multi-stage runs (non-dry-run repair) use `MultiSectionReport` — one labeled

--- a/src/report.rs
+++ b/src/report.rs
@@ -58,7 +58,9 @@ pub struct Summary {
 /// one named section of a [`MultiSectionReport`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReportSection {
-    pub well_known: bool,
+    /// `Some(cp)` if the root `.well-known` is broken, carrying the checkpoint
+    /// to restore it from (the archive's highest checkpoint); `null` if healthy.
+    pub well_known: Option<u32>,
     /// checkpoint (decimal string) -> per-cp file type names
     pub files: BTreeMap<String, Vec<String>>,
     /// 64-hex bucket content hashes
@@ -164,6 +166,9 @@ impl ArchiveReport {
             )));
         }
 
+        if let Some(cp) = body.well_known {
+            validate_checkpoint(cp)?;
+        }
         let mut tracker = FailureTracker {
             well_known: body.well_known,
             ..FailureTracker::default()

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,0 +1,243 @@
+//! JSON plan/report schema for repair and status output.
+//!
+//! `ArchiveReport` is a versioned, deterministic serialization of an operation's
+//! `FailureTracker` plus an outcome `Summary`. It serves three roles: repair
+//! dry-run output (a "plan"), repair input (`--plan`), and status output for any
+//! operation (`--report`). It round-trips: `into_failures` is the inverse of the
+//! `from_failures_and_summary` projection (modulo `summary`/`version`).
+//!
+//! Multi-stage runs (non-dry-run repair) use `MultiSectionReport` — one labeled
+//! `ReportSection` per stage (`main_pass` / `file_retry` / `checkpoint_retry`).
+
+use crate::history_format::{is_checkpoint, is_valid_bucket_hash};
+use crate::utils::{hex_to_hash, FailureTracker, FileFlags};
+use crate::xdr_verify::HashExt;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::Path;
+use stellar_xdr::curr::Hash;
+use thiserror::Error;
+
+/// Current schema version.
+pub const REPORT_VERSION: u32 = 1;
+
+/// Upper bound on total plan entries (files + buckets + checkpoints) accepted
+/// from an external `--plan`. Guards against accidental/malicious oversized input.
+pub const MAX_PLAN_ENTRIES: usize = 10_000_000;
+
+/// Canonical (flag, name) table — also fixes the serialization order of a
+/// checkpoint's file-type list.
+const FLAG_NAMES: &[(u8, &str)] = &[
+    (FileFlags::HISTORY, "history"),
+    (FileFlags::LEDGER, "ledger"),
+    (FileFlags::TRANSACTIONS, "transactions"),
+    (FileFlags::RESULTS, "results"),
+    (FileFlags::SCP, "scp"),
+];
+
+#[derive(Debug, Error)]
+pub enum ReportError {
+    #[error("invalid plan: {0}")]
+    Invalid(String),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Summary {
+    pub succeeded: u64,
+    pub skipped: u64,
+    pub failed: u64,
+    pub retries: u64,
+}
+
+/// The body of a report: a `FailureTracker` projection plus outcome counters.
+/// Used both as the flattened body of a single-section [`ArchiveReport`] and as
+/// one named section of a [`MultiSectionReport`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReportSection {
+    pub well_known: bool,
+    /// checkpoint (decimal string) -> per-cp file type names
+    pub files: BTreeMap<String, Vec<String>>,
+    /// 64-hex bucket content hashes
+    pub buckets: Vec<String>,
+    /// checkpoints with cross-file / chain failures
+    pub checkpoints: Vec<u32>,
+    /// Outcome counters. Always serialized; `#[serde(default)]` lets a
+    /// hand-authored plan omit it (`into_failures` ignores it anyway).
+    #[serde(default)]
+    pub summary: Summary,
+}
+
+/// A single-section report (scan/mirror status, or a repair plan). The body is
+/// `#[serde(flatten)]`ed so the JSON stays flat: `{version, well_known, …}`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArchiveReport {
+    pub version: u32,
+    #[serde(flatten)]
+    pub section: ReportSection,
+}
+
+fn flags_to_names(flags: FileFlags) -> Vec<String> {
+    FLAG_NAMES
+        .iter()
+        .filter(|(bit, _)| flags.has(*bit))
+        .map(|(_, name)| (*name).to_string())
+        .collect()
+}
+
+fn name_to_flag(name: &str) -> Option<u8> {
+    FLAG_NAMES
+        .iter()
+        .find(|(_, n)| *n == name)
+        .map(|(bit, _)| *bit)
+}
+
+fn validate_checkpoint(cp: u32) -> Result<(), ReportError> {
+    if is_checkpoint(cp) {
+        Ok(())
+    } else {
+        Err(ReportError::Invalid(format!(
+            "{cp} is not a valid checkpoint boundary"
+        )))
+    }
+}
+
+fn parse_bucket_hash(s: &str) -> Result<Hash, ReportError> {
+    if !is_valid_bucket_hash(s) {
+        return Err(ReportError::Invalid(format!(
+            "bucket hash '{s}' must be 64 hex characters"
+        )));
+    }
+    hex_to_hash(s)
+        .ok_or_else(|| ReportError::Invalid(format!("bucket hash '{s}' is not valid hex")))
+}
+
+/// Project a `FailureTracker` plus an outcome `Summary` into a report body.
+/// Ordering is deterministic: BTree order for `files`/`checkpoints`/`buckets`,
+/// fixed flag order within each file list. The single home for the projection,
+/// shared by [`ArchiveReport::from_failures_and_summary`] and [`section`].
+fn project(failures: &FailureTracker, summary: Summary) -> ReportSection {
+    ReportSection {
+        well_known: failures.well_known,
+        files: failures
+            .files
+            .iter()
+            .map(|(cp, flags)| (cp.to_string(), flags_to_names(*flags)))
+            .collect(),
+        buckets: failures.buckets.iter().map(HashExt::to_hex).collect(),
+        checkpoints: failures.checkpoints.iter().copied().collect(),
+        summary,
+    }
+}
+
+impl ArchiveReport {
+    /// Build a single-section report from a `FailureTracker` plus a `Summary`.
+    #[must_use]
+    pub fn from_failures_and_summary(failures: &FailureTracker, summary: Summary) -> Self {
+        Self {
+            version: REPORT_VERSION,
+            section: project(failures, summary),
+        }
+    }
+
+    /// Validate and convert into a `FailureTracker`. Inverse of the `project`
+    /// projection (the summary is ignored). Rejects unsupported versions,
+    /// non-boundary checkpoints, unknown file types, malformed bucket hashes,
+    /// and oversized plans.
+    pub fn into_failures(self) -> Result<FailureTracker, ReportError> {
+        if self.version != REPORT_VERSION {
+            return Err(ReportError::Invalid(format!(
+                "unsupported report version {} (expected {REPORT_VERSION})",
+                self.version
+            )));
+        }
+        let body = self.section;
+        let total = body.files.values().map(Vec::len).sum::<usize>()
+            + body.buckets.len()
+            + body.checkpoints.len();
+        if total > MAX_PLAN_ENTRIES {
+            return Err(ReportError::Invalid(format!(
+                "plan has {total} entries, exceeds maximum {MAX_PLAN_ENTRIES}"
+            )));
+        }
+
+        let mut tracker = FailureTracker {
+            well_known: body.well_known,
+            ..FailureTracker::default()
+        };
+        for (cp_str, names) in &body.files {
+            let cp: u32 = cp_str
+                .parse()
+                .map_err(|_| ReportError::Invalid(format!("invalid checkpoint key '{cp_str}'")))?;
+            validate_checkpoint(cp)?;
+            for name in names {
+                let flag = name_to_flag(name)
+                    .ok_or_else(|| ReportError::Invalid(format!("unknown file type '{name}'")))?;
+                tracker.record_file(cp, flag);
+            }
+        }
+        for &cp in &body.checkpoints {
+            validate_checkpoint(cp)?;
+            tracker.record_checkpoint(cp);
+        }
+        for bucket in &body.buckets {
+            tracker.record_bucket(parse_bucket_hash(bucket)?);
+        }
+        Ok(tracker)
+    }
+}
+
+/// Outcome counters derived from a stats' failures + the given totals. `failed`
+/// = file failures + bucket failures (checkpoint failures are reported via the
+/// `checkpoints` body, not folded into `failed`).
+fn summary_of(failures: &FailureTracker, succeeded: u64, skipped: u64, retries: u64) -> Summary {
+    Summary {
+        succeeded,
+        skipped,
+        retries,
+        failed: u64::from(failures.total_file_failures()) + failures.buckets.len() as u64,
+    }
+}
+
+/// A multi-section report: named sections (e.g. repair's `main_pass` /
+/// `file_retry` / `checkpoint_retry`) in one file.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MultiSectionReport {
+    pub version: u32,
+    pub sections: BTreeMap<String, ReportSection>,
+}
+
+/// Build one section from a stats' failures + counters (same projection as a
+/// single-section report's body).
+#[must_use]
+pub fn section(
+    failures: &FailureTracker,
+    succeeded: u64,
+    skipped: u64,
+    retries: u64,
+) -> ReportSection {
+    project(failures, summary_of(failures, succeeded, skipped, retries))
+}
+
+/// Read and deserialize a single-section report from a local path.
+pub fn read_from_path(path: &Path) -> Result<ArchiveReport, ReportError> {
+    let content = std::fs::read_to_string(path)?;
+    Ok(serde_json::from_str(&content)?)
+}
+
+/// Write a report value to a local path as pretty JSON, creating parent
+/// directories as needed. Generic so it serves both the single-section
+/// [`ArchiveReport`] and the multi-section [`MultiSectionReport`].
+pub fn write_to_path<T: Serialize>(path: &Path, report: &T) -> Result<(), ReportError> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    let json = serde_json::to_string_pretty(report)?;
+    std::fs::write(path, json)?;
+    Ok(())
+}

--- a/src/scan_operation.rs
+++ b/src/scan_operation.rs
@@ -1,11 +1,12 @@
 use crate::history_format;
-use crate::pipeline::{async_trait, Operation, ProcessOutcome};
-use crate::storage::{from_opendal_error, Error as StorageError, StorageConfig, StorageRef};
+use crate::pipeline::{async_trait, Operation, PipelineConfig, ProcessOutcome};
+use crate::storage::{from_opendal_error, Error as StorageError, StorageRef};
 use crate::utils::{compute_checkpoint_bounds, fetch_well_known_history_file, ArchiveStats};
 use crate::xdr_verify::XdrVerificationManager;
 use opendal::Buffer;
 use opendal::Reader;
 use thiserror::Error;
+use tracing::error;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -30,16 +31,16 @@ pub struct ScanOperation {
     low: Option<u32>,
     high: Option<u32>,
 
-    // Storage configuration (retry params for source fetches live here)
-    storage_config: StorageConfig,
+    // Pipeline configuration (storage retry params + verify mode for the report)
+    pipeline_config: PipelineConfig,
 }
 
 impl ScanOperation {
-    pub fn new(low: Option<u32>, high: Option<u32>, storage_config: &StorageConfig) -> Self {
+    pub fn new(low: Option<u32>, high: Option<u32>, pipeline_config: PipelineConfig) -> Self {
         Self {
             low,
             high,
-            storage_config: storage_config.clone(),
+            pipeline_config,
         }
     }
 
@@ -69,8 +70,11 @@ impl Operation for ScanOperation {
     ) -> Result<(u32, u32), crate::pipeline::Error> {
         let source_state = fetch_well_known_history_file(
             source,
-            self.storage_config.max_retries as u32,
-            self.storage_config.retry_min_delay.as_millis() as u64,
+            self.pipeline_config.storage_config.max_retries as u32,
+            self.pipeline_config
+                .storage_config
+                .retry_min_delay
+                .as_millis() as u64,
         )
         .await
         .map_err(|e| crate::pipeline::Error::ScanOperation(Error::Utils(e)))?;
@@ -133,6 +137,17 @@ impl Operation for ScanOperation {
             };
             crate::report::write_to_path(path, &report)
                 .map_err(|e| crate::pipeline::Error::ScanOperation(Error::Report(e)))?;
+        }
+
+        // Cross-file/chain checks compare files that each passed their own
+        // verification; a flagged checkpoint means they don't agree. Scan is
+        // read-only, so this only reports the inconsistency.
+        let inconsistent = stats.checkpoint_failure_count().await;
+        if inconsistent > 0 {
+            error!(
+                "{inconsistent} checkpoint(s) failed cross-file/chain verification: the files are \
+                 individually valid but mutually inconsistent (scan does not modify the archive)."
+            );
         }
 
         if stats.has_failures().await {

--- a/src/scan_operation.rs
+++ b/src/scan_operation.rs
@@ -20,6 +20,9 @@ pub enum Error {
 
     #[error("History format error: {0}")]
     HistoryFormat(#[from] crate::history_format::Error),
+
+    #[error("Report error: {0}")]
+    Report(#[from] crate::report::ReportError),
 }
 
 pub struct ScanOperation {
@@ -119,8 +122,18 @@ impl Operation for ScanOperation {
         &self,
         _highest_checkpoint: u32,
         stats: &ArchiveStats,
+        report_path: Option<&std::path::Path>,
     ) -> Result<(), crate::pipeline::Error> {
         stats.report("scan").await;
+
+        if let Some(path) = report_path {
+            let report = crate::report::ArchiveReport {
+                version: crate::report::REPORT_VERSION,
+                section: stats.report_section().await,
+            };
+            crate::report::write_to_path(path, &report)
+                .map_err(|e| crate::pipeline::Error::ScanOperation(Error::Report(e)))?;
+        }
 
         if stats.has_failures().await {
             return Err(Error::ScanFailed.into());

--- a/src/scan_operation.rs
+++ b/src/scan_operation.rs
@@ -26,6 +26,9 @@ pub enum Error {
 }
 
 pub struct ScanOperation {
+    // The source archive being scanned.
+    src_store: StorageRef,
+
     // User-specified arguments from CLI
     low: Option<u32>,
     high: Option<u32>,
@@ -35,8 +38,14 @@ pub struct ScanOperation {
 }
 
 impl ScanOperation {
-    pub fn new(low: Option<u32>, high: Option<u32>, pipeline_config: PipelineConfig) -> Self {
+    pub fn new(
+        src_store: StorageRef,
+        low: Option<u32>,
+        high: Option<u32>,
+        pipeline_config: PipelineConfig,
+    ) -> Self {
         Self {
+            src_store,
             low,
             high,
             pipeline_config,
@@ -63,12 +72,9 @@ impl ScanOperation {
 
 #[async_trait]
 impl Operation for ScanOperation {
-    async fn get_checkpoint_bounds(
-        &self,
-        source: &StorageRef,
-    ) -> Result<(u32, u32), crate::pipeline::Error> {
+    async fn get_checkpoint_bounds(&self) -> Result<(u32, u32), crate::pipeline::Error> {
         let source_state = fetch_well_known_history_file(
-            source,
+            &self.src_store,
             self.pipeline_config.storage_config.max_retries as u32,
             self.pipeline_config
                 .storage_config
@@ -87,12 +93,11 @@ impl Operation for ScanOperation {
     async fn process_object(
         &self,
         path: &str,
-        src_store: &StorageRef,
         manager: Option<&XdrVerificationManager>,
     ) -> Result<ProcessOutcome, StorageError> {
         if let Some(manager) = manager {
             // Verify mode: stream content and validate
-            let reader = src_store.open_reader(path).await?;
+            let reader = self.src_store.open_reader(path).await?;
             if crate::history_format::is_bucket_file(path) {
                 crate::verify::verify_bucket_stream(path, reader).await?;
             } else if crate::history_format::is_ledger_header_file(path) {
@@ -114,7 +119,7 @@ impl Operation for ScanOperation {
             }
         } else {
             // Existence-only mode: just check if file exists (no streaming)
-            if !src_store.exists(path).await? {
+            if !self.src_store.exists(path).await? {
                 return Err(StorageError::not_found());
             }
         }
@@ -158,12 +163,8 @@ impl Operation for ScanOperation {
 
     /// Scan reads the history file from the source and parses it for bucket
     /// discovery; it never writes.
-    async fn process_history(
-        &self,
-        path: &str,
-        src_store: &StorageRef,
-    ) -> Result<HistoryOutcome, StorageError> {
-        let buffer = crate::storage::download_buffer(src_store, path).await?;
+    async fn process_history(&self, path: &str) -> Result<HistoryOutcome, StorageError> {
+        let buffer = crate::storage::download_buffer(&self.src_store, path).await?;
         let state = crate::history_format::parse_history(&buffer, path)
             .map_err(|e| StorageError::fatal(format!("failed to parse history {path}: {e}")))?;
         Ok(HistoryOutcome {

--- a/src/scan_operation.rs
+++ b/src/scan_operation.rs
@@ -1,9 +1,8 @@
 use crate::history_format;
-use crate::pipeline::{async_trait, Operation, PipelineConfig, ProcessOutcome};
+use crate::pipeline::{async_trait, HistoryOutcome, Operation, PipelineConfig, ProcessOutcome};
 use crate::storage::{from_opendal_error, Error as StorageError, StorageRef};
 use crate::utils::{compute_checkpoint_bounds, fetch_well_known_history_file, ArchiveStats};
 use crate::xdr_verify::XdrVerificationManager;
-use opendal::Buffer;
 use opendal::Reader;
 use thiserror::Error;
 use tracing::error;
@@ -157,12 +156,19 @@ impl Operation for ScanOperation {
         Ok(())
     }
 
-    /// Scan never writes — return `Processed` and let the pipeline record it.
-    async fn process_buffer(
+    /// Scan reads the history file from the source and parses it for bucket
+    /// discovery; it never writes.
+    async fn process_history(
         &self,
-        _path: &str,
-        _buffer: Buffer,
-    ) -> Result<ProcessOutcome, StorageError> {
-        Ok(ProcessOutcome::Processed)
+        path: &str,
+        src_store: &StorageRef,
+    ) -> Result<HistoryOutcome, StorageError> {
+        let buffer = crate::storage::download_buffer(src_store, path).await?;
+        let state = crate::history_format::parse_history(&buffer, path)
+            .map_err(|e| StorageError::fatal(format!("failed to parse history {path}: {e}")))?;
+        Ok(HistoryOutcome {
+            outcome: ProcessOutcome::Processed,
+            state: Some(state),
+        })
     }
 }

--- a/src/scan_operation.rs
+++ b/src/scan_operation.rs
@@ -5,9 +5,7 @@ use crate::utils::{compute_checkpoint_bounds, fetch_well_known_history_file, Arc
 use crate::xdr_verify::XdrVerificationManager;
 use opendal::Buffer;
 use opendal::Reader;
-use std::sync::Arc;
 use thiserror::Error;
-use tracing::error;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -31,27 +29,14 @@ pub struct ScanOperation {
 
     // Storage configuration (retry params for source fetches live here)
     storage_config: StorageConfig,
-
-    // Populated if we should verify files, otherwise None
-    verification_manager: Option<Arc<XdrVerificationManager>>,
 }
 
 impl ScanOperation {
-    pub fn new(
-        low: Option<u32>,
-        high: Option<u32>,
-        storage_config: &StorageConfig,
-        verify: bool,
-    ) -> Self {
+    pub fn new(low: Option<u32>, high: Option<u32>, storage_config: &StorageConfig) -> Self {
         Self {
             low,
             high,
             storage_config: storage_config.clone(),
-            verification_manager: if verify {
-                Some(Arc::new(XdrVerificationManager::new()))
-            } else {
-                None
-            },
         }
     }
 
@@ -95,11 +80,11 @@ impl Operation for ScanOperation {
 
     async fn process_object(
         &self,
-        _checkpoint: u32,
         path: &str,
         src_store: &StorageRef,
+        manager: Option<&XdrVerificationManager>,
     ) -> Result<ProcessOutcome, StorageError> {
-        if let Some(ref manager) = self.verification_manager {
+        if let Some(manager) = manager {
             // Verify mode: stream content and validate
             let reader = src_store.open_reader(path).await?;
             if crate::history_format::is_bucket_file(path) {
@@ -135,21 +120,6 @@ impl Operation for ScanOperation {
         _highest_checkpoint: u32,
         stats: &ArchiveStats,
     ) -> Result<(), crate::pipeline::Error> {
-        if let Some(ref manager) = self.verification_manager {
-            manager.verify_checkpoint_chain();
-            let all_errors = manager.get_errors();
-            for err in &all_errors {
-                stats.record_verification_failure(&err.kind).await;
-            }
-
-            if !all_errors.is_empty() {
-                error!(
-                    "XDR verification found {} cross-file hash mismatches",
-                    all_errors.len()
-                );
-            }
-        }
-
         stats.report("scan").await;
 
         if stats.has_failures().await {
@@ -159,16 +129,9 @@ impl Operation for ScanOperation {
         Ok(())
     }
 
-    fn finalize_checkpoint(&self, checkpoint: u32) {
-        if let Some(ref manager) = self.verification_manager {
-            manager.verify_and_release(checkpoint);
-        }
-    }
-
     /// Scan never writes — return `Processed` and let the pipeline record it.
     async fn process_buffer(
         &self,
-        _checkpoint: u32,
         _path: &str,
         _buffer: Buffer,
     ) -> Result<ProcessOutcome, StorageError> {

--- a/src/scan_operation.rs
+++ b/src/scan_operation.rs
@@ -1,5 +1,5 @@
 use crate::history_format;
-use crate::pipeline::{async_trait, Operation};
+use crate::pipeline::{async_trait, Operation, ProcessOutcome};
 use crate::storage::{from_opendal_error, Error as StorageError, StorageConfig, StorageRef};
 use crate::utils::{compute_checkpoint_bounds, fetch_well_known_history_file, ArchiveStats};
 use crate::xdr_verify::XdrVerificationManager;
@@ -93,40 +93,41 @@ impl Operation for ScanOperation {
             .map_err(|e| crate::pipeline::Error::ScanOperation(Error::Utils(e)))
     }
 
-    async fn process_object(&self, path: &str, src_store: &StorageRef) -> Result<(), StorageError> {
+    async fn process_object(
+        &self,
+        _checkpoint: u32,
+        path: &str,
+        src_store: &StorageRef,
+    ) -> Result<ProcessOutcome, StorageError> {
         if let Some(ref manager) = self.verification_manager {
             // Verify mode: stream content and validate
             let reader = src_store.open_reader(path).await?;
             if crate::history_format::is_bucket_file(path) {
-                crate::verify::verify_bucket_stream(path, reader).await
+                crate::verify::verify_bucket_stream(path, reader).await?;
             } else if crate::history_format::is_ledger_header_file(path) {
                 let checkpoint = Self::checkpoint_from_verified_path(path)?;
                 let data = crate::xdr_verify::parse_ledger_header_stream(path, reader).await?;
                 manager.record_header_data(checkpoint, data);
-                Ok(())
             } else if crate::history_format::is_transactions_file(path) {
                 let checkpoint = Self::checkpoint_from_verified_path(path)?;
                 let hashes = crate::xdr_verify::parse_transactions_stream(path, reader).await?;
                 manager.record_tx_set_hashes(checkpoint, hashes);
-                Ok(())
             } else if crate::history_format::is_results_file(path) {
                 let checkpoint = Self::checkpoint_from_verified_path(path)?;
                 let hashes = crate::xdr_verify::parse_results_stream(path, reader).await?;
                 manager.record_result_hashes(checkpoint, hashes);
-                Ok(())
             } else if crate::history_format::is_scp_file(path) {
-                crate::xdr_verify::parse_scp_stream(path, reader).await
+                crate::xdr_verify::parse_scp_stream(path, reader).await?;
             } else {
-                self.consume_stream(path, reader).await
+                self.consume_stream(path, reader).await?;
             }
         } else {
             // Existence-only mode: just check if file exists (no streaming)
-            if src_store.exists(path).await? {
-                Ok(())
-            } else {
-                Err(StorageError::not_found())
+            if !src_store.exists(path).await? {
+                return Err(StorageError::not_found());
             }
         }
+        Ok(ProcessOutcome::Processed)
     }
 
     async fn finalize(
@@ -135,29 +136,23 @@ impl Operation for ScanOperation {
         stats: &ArchiveStats,
     ) -> Result<(), crate::pipeline::Error> {
         if let Some(ref manager) = self.verification_manager {
-            let chain_errors = manager.verify_checkpoint_chain();
-            for err in &chain_errors {
-                error!("Checkpoint {}: {}", err.checkpoint, err.message);
-                stats.record_failure("xdr-chain-verification").await;
+            manager.verify_checkpoint_chain();
+            let all_errors = manager.get_errors();
+            for err in &all_errors {
+                stats.record_verification_failure(&err.kind).await;
             }
 
-            let accumulated_errors = manager.get_errors();
-            for _ in &accumulated_errors {
-                stats.record_failure("xdr-cross-verification").await;
-            }
-
-            let total_errors = chain_errors.len() + accumulated_errors.len();
-            if total_errors > 0 {
+            if !all_errors.is_empty() {
                 error!(
                     "XDR verification found {} cross-file hash mismatches",
-                    total_errors
+                    all_errors.len()
                 );
             }
         }
 
         stats.report("scan").await;
 
-        if stats.has_failures() {
+        if stats.has_failures().await {
             return Err(Error::ScanFailed.into());
         }
 
@@ -170,8 +165,13 @@ impl Operation for ScanOperation {
         }
     }
 
-    /// Scan never writes — record success and discard the buffer.
-    async fn process_buffer(&self, path: &str, _buffer: Buffer, stats: &ArchiveStats) {
-        stats.record_success(path);
+    /// Scan never writes — return `Processed` and let the pipeline record it.
+    async fn process_buffer(
+        &self,
+        _checkpoint: u32,
+        _path: &str,
+        _buffer: Buffer,
+    ) -> Result<ProcessOutcome, StorageError> {
+        Ok(ProcessOutcome::Processed)
     }
 }

--- a/src/tests/mirror_op_test.rs
+++ b/src/tests/mirror_op_test.rs
@@ -1070,6 +1070,7 @@ async fn test_mirror_with_update_well_known_false_does_not_touch_well_known() {
         PipelineConfig {
             concurrency: 4,
             skip_optional: true,
+            skip_history_and_buckets: false,
             verify: false,
             storage_config: storage_config.clone(),
         },

--- a/src/tests/mirror_op_test.rs
+++ b/src/tests/mirror_op_test.rs
@@ -192,6 +192,7 @@ async fn test_mirror_full_archive() {
     let src_url = file_url_from_path(&test_archive_path);
 
     let mirror_config = MirrorConfig {
+        report_path: None,
         src: src_url,
         dst: mirror_dest_url.clone(),
         concurrency: 20,
@@ -208,6 +209,7 @@ async fn test_mirror_full_archive() {
 
     // Verify with scan
     run_scan(ScanConfig {
+        report_path: None,
         archive: mirror_dest_url,
         concurrency: 4,
         skip_optional: false,
@@ -243,6 +245,7 @@ async fn test_mirror_bounded() {
     let src_url = file_url_from_path(&test_archive_path);
 
     let mirror_config = MirrorConfig {
+        report_path: None,
         src: src_url,
         dst: mirror_dest_url.clone(),
         concurrency: 20,
@@ -261,6 +264,7 @@ async fn test_mirror_bounded() {
 
     // Verify with scan
     run_scan(ScanConfig {
+        report_path: None,
         archive: mirror_dest_url,
         concurrency: 4,
         skip_optional: false,
@@ -295,6 +299,7 @@ async fn test_mirror_skip_optional() {
     let src_url = file_url_from_path(&test_archive_path);
 
     let mirror_config = MirrorConfig {
+        report_path: None,
         src: src_url,
         dst: mirror_dest_url.clone(),
         concurrency: 4,
@@ -316,6 +321,7 @@ async fn test_mirror_skip_optional() {
 
     // Verify with scan (must also skip optional)
     run_scan(ScanConfig {
+        report_path: None,
         archive: mirror_dest_url,
         concurrency: 4,
         skip_optional: true,
@@ -816,6 +822,7 @@ async fn test_mirror_http_to_filesystem() {
 
     // Mirror from HTTP to filesystem
     let mirror_config = MirrorConfig {
+        report_path: None,
         src: server_url.clone(),
         dst: mirror_dest_url.clone(),
         concurrency: 4,
@@ -835,6 +842,7 @@ async fn test_mirror_http_to_filesystem() {
 
     // Verify the mirrored archive
     let scan_config = ScanConfig {
+        report_path: None,
         archive: mirror_dest_url,
         concurrency: 4,
         skip_optional: false,
@@ -912,6 +920,7 @@ async fn test_mirror_race_condition_with_advancing_archive() {
     let mirror_dest_url = file_url_from_path(temp_dest.path());
 
     let mirror_config = MirrorConfig {
+        report_path: None,
         src: server_url.clone(),
         dst: mirror_dest_url,
         concurrency: 4,
@@ -1076,6 +1085,7 @@ async fn test_mirror_with_update_well_known_false_does_not_touch_well_known() {
         },
         src_store,
         Some(dst_store),
+        None,
     );
 
     pipeline.run().await.expect("Mirror should succeed");
@@ -1097,4 +1107,23 @@ async fn test_mirror_with_update_well_known_false_does_not_touch_well_known() {
         !wellknown.exists(),
         ".well-known should not be created when update_well_known=false"
     );
+}
+
+#[tokio::test]
+async fn test_mirror_report_summary_on_success() {
+    use super::utils::{file_url_from_path, testnet_small_archive_path};
+    let src_url = file_url_from_path(&testnet_small_archive_path());
+    let dir = TempDir::new().unwrap();
+    let dst_url = file_url_from_path(dir.path());
+    let report_path = dir.path().join("mirror-report.json");
+
+    run_mirror(MirrorConfig::new(&src_url, &dst_url).report(&report_path))
+        .await
+        .expect("mirror should succeed");
+
+    let report = crate::report::read_from_path(&report_path).unwrap();
+    let summary = report.section.summary;
+    assert_eq!(summary.failed, 0, "clean mirror has no failures");
+    assert!(summary.succeeded > 0, "mirror copied files");
+    assert!(report.section.files.is_empty() && report.section.buckets.is_empty());
 }

--- a/src/tests/mirror_op_test.rs
+++ b/src/tests/mirror_op_test.rs
@@ -1123,3 +1123,86 @@ async fn test_mirror_report_summary_on_success() {
     assert!(summary.succeeded > 0, "mirror copied files");
     assert!(report.section.files.is_empty() && report.section.buckets.is_empty());
 }
+
+#[tokio::test]
+async fn test_mirror_no_overwrite_skips_existing_history() {
+    use super::utils::get_files_by_pattern;
+
+    let src_url = file_url_from_path(&testnet_small_archive_path());
+    let dest_dir = TempDir::new().unwrap();
+    let dest_url = file_url_from_path(dest_dir.path());
+    run_mirror(MirrorConfig::new(&src_url, &dest_url))
+        .await
+        .expect("initial mirror should succeed");
+
+    // Record mtimes of all per-checkpoint history files.
+    let history_files: Vec<_> = get_files_by_pattern(dest_dir.path(), "/history-")
+        .into_iter()
+        .filter(|p| !p.to_string_lossy().contains(".well-known"))
+        .collect();
+    assert!(!history_files.is_empty());
+    let before: Vec<_> = history_files
+        .iter()
+        .map(|p| (p.clone(), std::fs::metadata(p).unwrap().modified().unwrap()))
+        .collect();
+
+    // Delete .well-known so the re-mirror reprocesses every checkpoint in range
+    // (without --overwrite). Existing valid files must be skipped, not rewritten.
+    std::fs::remove_file(dest_dir.path().join(".well-known/stellar-history.json")).unwrap();
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    run_mirror(MirrorConfig::new(&src_url, &dest_url))
+        .await
+        .expect("re-mirror should succeed");
+
+    for (path, before_mtime) in &before {
+        let after_mtime = std::fs::metadata(path).unwrap().modified().unwrap();
+        assert_eq!(
+            *before_mtime, after_mtime,
+            "history file {} must not be rewritten on a no-overwrite re-mirror",
+            path.display()
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_mirror_no_overwrite_replaces_broken_history() {
+    use super::utils::get_files_by_pattern;
+
+    let src_path = testnet_small_archive_path();
+    let src_url = file_url_from_path(&src_path);
+    let dest_dir = TempDir::new().unwrap();
+    let dest_url = file_url_from_path(dest_dir.path());
+    run_mirror(MirrorConfig::new(&src_url, &dest_url))
+        .await
+        .expect("initial mirror should succeed");
+
+    // Corrupt a per-checkpoint history file on the destination (still present,
+    // but unparseable) and capture the canonical source bytes.
+    let history_file = get_files_by_pattern(dest_dir.path(), "/history-")
+        .into_iter()
+        .find(|p| !p.to_string_lossy().contains(".well-known"))
+        .expect("a per-checkpoint history file");
+    let rel = history_file
+        .strip_prefix(dest_dir.path())
+        .unwrap()
+        .to_path_buf();
+    let source_content = std::fs::read(src_path.join(&rel)).unwrap();
+    std::fs::write(&history_file, b"{ broken json }}").unwrap();
+
+    // Delete .well-known so the re-mirror reprocesses every checkpoint in range
+    // (without --overwrite). The broken history must NOT be skipped.
+    std::fs::remove_file(dest_dir.path().join(".well-known/stellar-history.json")).unwrap();
+
+    run_mirror(MirrorConfig::new(&src_url, &dest_url))
+        .await
+        .expect("re-mirror should succeed");
+
+    // The broken history must have been replaced with the source content.
+    assert_eq!(
+        std::fs::read(&history_file).unwrap(),
+        source_content,
+        "broken destination history must be replaced from source"
+    );
+}

--- a/src/tests/mirror_op_test.rs
+++ b/src/tests/mirror_op_test.rs
@@ -1032,3 +1032,68 @@ async fn test_mirror_verify_does_not_advance_well_known_on_verification_failure(
         baseline_ledger, after_ledger
     );
 }
+
+/// Mirror constructed with `update_well_known=false` must not write or advance
+/// the destination's `.well-known/stellar-history.json` even when it successfully
+/// mirrors checkpoint data. This is the contract repair's retry pipeline relies
+/// on: re-mirroring a disjoint subset of cps must not advertise partial coverage
+/// in the dst archive.
+#[tokio::test]
+async fn test_mirror_with_update_well_known_false_does_not_touch_well_known() {
+    use crate::mirror_operation::MirrorOperation;
+    use crate::pipeline::{Pipeline, PipelineConfig};
+    use crate::storage::from_url_with_config;
+
+    let src_archive = testnet_small_archive_path();
+    let src_url = file_url_from_path(&src_archive);
+
+    let temp_dir = TempDir::new().unwrap();
+    let dest_path = temp_dir.path().join("mirror_dest");
+    let dst_url = file_url_from_path(&dest_path);
+
+    let storage_config = test_storage_config();
+    let src_store = from_url_with_config(&src_url, &storage_config).unwrap();
+    let dst_store = from_url_with_config(&dst_url, &storage_config).unwrap();
+
+    let mirror_op = MirrorOperation::new(
+        dst_store.clone(),
+        /*overwrite=*/ true,
+        Some(64),
+        Some(127),
+        /*allow_mirror_gaps=*/ true,
+        &storage_config,
+        /*update_well_known=*/ false,
+    );
+
+    let pipeline = Pipeline::new(
+        mirror_op,
+        PipelineConfig {
+            concurrency: 4,
+            skip_optional: true,
+            verify: false,
+            storage_config: storage_config.clone(),
+        },
+        src_store,
+        Some(dst_store),
+    );
+
+    pipeline.run().await.expect("Mirror should succeed");
+
+    // At least one per-cp file must have been copied (proves the mirror actually ran).
+    let ledger_files: Vec<_> = WalkDir::new(&dest_path)
+        .into_iter()
+        .filter_map(std::result::Result::ok)
+        .filter(|e| e.file_type().is_file() && e.path().to_string_lossy().contains("ledger-"))
+        .collect();
+    assert!(
+        !ledger_files.is_empty(),
+        "expected ledger files to be mirrored to dst"
+    );
+
+    // But the .well-known file must NOT have been created.
+    let wellknown = dest_path.join(".well-known/stellar-history.json");
+    assert!(
+        !wellknown.exists(),
+        ".well-known should not be created when update_well_known=false"
+    );
+}

--- a/src/tests/mirror_op_test.rs
+++ b/src/tests/mirror_op_test.rs
@@ -1064,29 +1064,25 @@ async fn test_mirror_with_update_well_known_false_does_not_touch_well_known() {
     let src_store = from_url_with_config(&src_url, &storage_config).unwrap();
     let dst_store = from_url_with_config(&dst_url, &storage_config).unwrap();
 
+    let pipeline_config = PipelineConfig {
+        concurrency: 4,
+        skip_optional: true,
+        skip_history_and_buckets: false,
+        verify: false,
+        storage_config: storage_config.clone(),
+    };
+
     let mirror_op = MirrorOperation::new(
         dst_store.clone(),
         /*overwrite=*/ true,
         Some(64),
         Some(127),
         /*allow_mirror_gaps=*/ true,
-        &storage_config,
+        pipeline_config.clone(),
         /*update_well_known=*/ false,
     );
 
-    let pipeline = Pipeline::new(
-        mirror_op,
-        PipelineConfig {
-            concurrency: 4,
-            skip_optional: true,
-            skip_history_and_buckets: false,
-            verify: false,
-            storage_config: storage_config.clone(),
-        },
-        src_store,
-        Some(dst_store),
-        None,
-    );
+    let pipeline = Pipeline::new(mirror_op, pipeline_config, src_store, Some(dst_store), None);
 
     pipeline.run().await.expect("Mirror should succeed");
 

--- a/src/tests/mirror_op_test.rs
+++ b/src/tests/mirror_op_test.rs
@@ -1073,7 +1073,8 @@ async fn test_mirror_with_update_well_known_false_does_not_touch_well_known() {
     };
 
     let mirror_op = MirrorOperation::new(
-        dst_store.clone(),
+        src_store,
+        dst_store,
         /*overwrite=*/ true,
         Some(64),
         Some(127),
@@ -1082,7 +1083,7 @@ async fn test_mirror_with_update_well_known_false_does_not_touch_well_known() {
         /*update_well_known=*/ false,
     );
 
-    let pipeline = Pipeline::new(mirror_op, pipeline_config, src_store, Some(dst_store), None);
+    let pipeline = Pipeline::new(mirror_op, pipeline_config, None);
 
     pipeline.run().await.expect("Mirror should succeed");
 

--- a/src/tests/mirror_op_test.rs
+++ b/src/tests/mirror_op_test.rs
@@ -1160,7 +1160,8 @@ async fn test_mirror_no_overwrite_skips_existing_history() {
     for (path, before_mtime) in &before {
         let after_mtime = std::fs::metadata(path).unwrap().modified().unwrap();
         assert_eq!(
-            *before_mtime, after_mtime,
+            *before_mtime,
+            after_mtime,
             "history file {} must not be rewritten on a no-overwrite re-mirror",
             path.display()
         );

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -13,6 +13,8 @@ mod pipeline_test;
 #[cfg(test)]
 mod repair_op_test;
 #[cfg(test)]
+mod report_test;
+#[cfg(test)]
 mod scan_op_test;
 #[cfg(test)]
 pub(crate) mod utils;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -9,6 +9,8 @@ mod mirror_op_test;
 #[cfg(test)]
 mod path_normalization_test;
 #[cfg(test)]
+mod pipeline_test;
+#[cfg(test)]
 mod repair_op_test;
 #[cfg(test)]
 mod scan_op_test;

--- a/src/tests/pipeline_test.rs
+++ b/src/tests/pipeline_test.rs
@@ -1,0 +1,320 @@
+//! Unit tests for `Pipeline::run_checkpoints` and `Pipeline::stats()`.
+//!
+//! Uses a minimal `TestOperation` implementing the `Operation` trait. The test
+//! operation does no real I/O: `fetch_history_buffer` returns a fatal error
+//! (so the pipeline records HISTORY failure and falls through to per-cp file
+//! processing), `process_object` records each invocation, and
+//! `finalize_checkpoint` / `finalize` record their respective calls.
+//!
+//! Per-cp file count under `skip_optional=true`: 3 files (ledger,
+//! transactions, results) → 3 `process_object` calls per cp.
+
+use crate::pipeline::{async_trait, Operation, Pipeline, PipelineConfig, ProcessOutcome};
+use crate::storage::{Error as StorageError, StorageConfig, StorageRef};
+use crate::utils::ArchiveStats;
+use opendal::{Buffer, Reader};
+use std::collections::BTreeSet;
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+//=============================================================================
+// Stub storage — fills the StorageRef slot; never actually used by TestOperation
+//=============================================================================
+
+struct StubStorage;
+
+#[async_trait::async_trait]
+impl crate::storage::Storage for StubStorage {
+    async fn open_reader(&self, _object: &str) -> Result<Reader, StorageError> {
+        Err(StorageError::not_found())
+    }
+    async fn exists(&self, _object: &str) -> Result<bool, StorageError> {
+        Ok(false)
+    }
+}
+
+fn stub_storage() -> StorageRef {
+    Arc::new(StubStorage)
+}
+
+//=============================================================================
+// TestOperation
+//=============================================================================
+
+#[derive(Default)]
+struct TestOperationState {
+    /// `(checkpoint_context, path)` for each `process_object` call.
+    process_object_calls: Vec<(u32, String)>,
+    /// `Some(highest_checkpoint)` if `finalize()` was invoked.
+    finalize_highest_checkpoint: Option<u32>,
+    /// Live set of cps currently in flight (added on first `process_object`
+    /// for that cp, removed when its last `process_object` returns).
+    in_flight_cps: BTreeSet<u32>,
+    /// Max size of `in_flight_cps` observed during the run.
+    peak_in_flight_cps: usize,
+}
+
+struct TestOperation {
+    state: Arc<Mutex<TestOperationState>>,
+    bounds: (u32, u32),
+    /// Optional delay inside `process_object` to keep cps in flight long
+    /// enough for the peak-concurrency assertion to observe overlap.
+    delay_per_object: Option<Duration>,
+}
+
+impl TestOperation {
+    fn new(bounds: (u32, u32)) -> (Self, Arc<Mutex<TestOperationState>>) {
+        let state = Arc::new(Mutex::new(TestOperationState::default()));
+        (
+            Self {
+                state: state.clone(),
+                bounds,
+                delay_per_object: None,
+            },
+            state,
+        )
+    }
+
+    fn with_delay(mut self, d: Duration) -> Self {
+        self.delay_per_object = Some(d);
+        self
+    }
+}
+
+#[async_trait]
+impl Operation for TestOperation {
+    async fn get_checkpoint_bounds(
+        &self,
+        _source: &StorageRef,
+    ) -> Result<(u32, u32), crate::pipeline::Error> {
+        Ok(self.bounds)
+    }
+
+    async fn process_object(
+        &self,
+        path: &str,
+        _src_store: &StorageRef,
+        _manager: Option<&crate::xdr_verify::XdrVerificationManager>,
+    ) -> Result<ProcessOutcome, StorageError> {
+        // `skip_optional=true` in `make_config` => 3 per-cp files. First call
+        // for a cp inserts into in_flight; third call removes. Tracks peak
+        // cp-level concurrency.
+        const FILES_PER_CP: usize = 3;
+        let checkpoint = crate::history_format::checkpoint_from_path(path)
+            .expect("test paths always carry a checkpoint");
+        {
+            let mut s = self.state.lock().unwrap();
+            s.process_object_calls.push((checkpoint, path.to_string()));
+            let per_cp_count = s
+                .process_object_calls
+                .iter()
+                .filter(|(c, _)| *c == checkpoint)
+                .count();
+            if per_cp_count == 1 {
+                s.in_flight_cps.insert(checkpoint);
+                let n = s.in_flight_cps.len();
+                if n > s.peak_in_flight_cps {
+                    s.peak_in_flight_cps = n;
+                }
+            }
+        }
+        if let Some(d) = self.delay_per_object {
+            tokio::time::sleep(d).await;
+        }
+        {
+            let mut s = self.state.lock().unwrap();
+            let per_cp_count = s
+                .process_object_calls
+                .iter()
+                .filter(|(c, _)| *c == checkpoint)
+                .count();
+            if per_cp_count >= FILES_PER_CP {
+                s.in_flight_cps.remove(&checkpoint);
+            }
+        }
+        Ok(ProcessOutcome::Processed)
+    }
+
+    async fn finalize(
+        &self,
+        highest_checkpoint: u32,
+        _stats: &ArchiveStats,
+    ) -> Result<(), crate::pipeline::Error> {
+        self.state.lock().unwrap().finalize_highest_checkpoint = Some(highest_checkpoint);
+        Ok(())
+    }
+
+    async fn fetch_history_buffer(
+        &self,
+        _history_path: &str,
+        _src_store: &StorageRef,
+        _dst_store: Option<&StorageRef>,
+    ) -> Result<Buffer, StorageError> {
+        // Fatal so `with_retries` returns immediately; pipeline records HISTORY
+        // failure and falls through to per-cp file processing.
+        Err(StorageError::fatal("test stub: no history"))
+    }
+
+    async fn process_buffer(
+        &self,
+        _path: &str,
+        _buffer: Buffer,
+    ) -> Result<ProcessOutcome, StorageError> {
+        // Not invoked because `fetch_history_buffer` always fails.
+        Ok(ProcessOutcome::Processed)
+    }
+}
+
+fn make_config(concurrency: usize) -> PipelineConfig {
+    let storage_config = StorageConfig::new(
+        0, // max_retries = 0 (no retries → fast tests)
+        Duration::from_millis(1),
+        Duration::from_secs(1),
+        16,
+        Duration::from_secs(1),
+        Duration::from_secs(1),
+        0,
+        false,
+    );
+    PipelineConfig {
+        concurrency,
+        skip_optional: true, // 3 per-cp files (no SCP)
+        verify: false,
+        storage_config,
+    }
+}
+
+//=============================================================================
+// Tests
+//=============================================================================
+
+#[tokio::test]
+async fn test_run_checkpoints_empty_iter_is_noop() {
+    let (op, state) = TestOperation::new((63, 63));
+    let pipeline = Pipeline::new(op, make_config(1), stub_storage(), None);
+
+    pipeline
+        .run_checkpoints(Vec::<u32>::new())
+        .await
+        .expect("empty run should succeed");
+
+    let s = state.lock().unwrap();
+    assert!(
+        s.process_object_calls.is_empty(),
+        "no per-cp work should run for empty iter"
+    );
+    assert!(
+        s.finalize_highest_checkpoint.is_none(),
+        "empty input should skip finalize"
+    );
+}
+
+#[tokio::test]
+async fn test_run_checkpoints_single_cp() {
+    let (op, state) = TestOperation::new((63, 63));
+    let pipeline = Pipeline::new(op, make_config(1), stub_storage(), None);
+
+    pipeline.run_checkpoints(vec![63]).await.unwrap();
+
+    let s = state.lock().unwrap();
+    // skip_optional=true → 3 per-cp files (ledger, transactions, results).
+    assert_eq!(
+        s.process_object_calls.len(),
+        3,
+        "one cp should produce 3 process_object calls"
+    );
+    assert!(
+        s.process_object_calls.iter().all(|(cp, _)| *cp == 63),
+        "all calls should be for cp=63"
+    );
+    assert!(
+        s.finalize_highest_checkpoint.is_none(),
+        "run_checkpoints must NOT call operation.finalize"
+    );
+}
+
+#[tokio::test]
+async fn test_run_checkpoints_disjoint_cps() {
+    let (op, state) = TestOperation::new((0, 0)); // bounds unused by this test
+    let pipeline = Pipeline::new(op, make_config(2), stub_storage(), None);
+
+    // Disjoint, non-consecutive cps.
+    pipeline.run_checkpoints(vec![63, 575, 4095]).await.unwrap();
+
+    let s = state.lock().unwrap();
+    assert_eq!(s.process_object_calls.len(), 9, "3 cps × 3 files = 9 calls");
+
+    let process_cps: BTreeSet<u32> = s.process_object_calls.iter().map(|(cp, _)| *cp).collect();
+    let expected: BTreeSet<u32> = [63, 575, 4095].into_iter().collect();
+    assert_eq!(process_cps, expected);
+
+    assert!(
+        s.finalize_highest_checkpoint.is_none(),
+        "run_checkpoints must NOT call operation.finalize"
+    );
+}
+
+#[tokio::test]
+async fn test_run_checkpoints_does_not_call_finalize() {
+    let (op, state) = TestOperation::new((0, 0));
+    let pipeline = Pipeline::new(op, make_config(1), stub_storage(), None);
+
+    pipeline.run_checkpoints(vec![63, 127]).await.unwrap();
+
+    let s = state.lock().unwrap();
+    assert!(
+        s.finalize_highest_checkpoint.is_none(),
+        "run_checkpoints must not invoke operation.finalize; that's pipeline.finish's job"
+    );
+}
+
+#[tokio::test]
+async fn test_pipeline_finish_calls_finalize_with_supplied_highest() {
+    let (op, state) = TestOperation::new((0, 0));
+    let pipeline = Pipeline::new(op, make_config(1), stub_storage(), None);
+
+    pipeline.finish(8191).await.expect("finish should succeed");
+
+    let s = state.lock().unwrap();
+    assert_eq!(
+        s.finalize_highest_checkpoint,
+        Some(8191),
+        "pipeline.finish must call operation.finalize with the supplied highest cp"
+    );
+}
+
+#[tokio::test]
+async fn test_run_checkpoints_respects_concurrency() {
+    let (op, state) = TestOperation::new((0, 0));
+    let op = op.with_delay(Duration::from_millis(50));
+    let pipeline = Pipeline::new(op, make_config(2), stub_storage(), None);
+
+    // 4 cps with concurrency=2 → peak in-flight should be exactly 2.
+    pipeline
+        .run_checkpoints(vec![63, 127, 191, 255])
+        .await
+        .unwrap();
+
+    let s = state.lock().unwrap();
+    assert_eq!(
+        s.peak_in_flight_cps, 2,
+        "peak in-flight cps should equal configured concurrency"
+    );
+}
+
+#[tokio::test]
+async fn test_stats_accessor_returns_live_ref() {
+    let (op, _state) = TestOperation::new((0, 0));
+    let pipeline = Pipeline::new(op, make_config(1), stub_storage(), None);
+
+    // Mutations through the accessor must be visible on subsequent reads.
+    pipeline.stats().record_success("foo");
+    pipeline.stats().record_success("bar");
+
+    assert_eq!(
+        pipeline.stats().successful_files.load(Ordering::Relaxed),
+        2,
+        "stats() should return a live reference"
+    );
+}

--- a/src/tests/pipeline_test.rs
+++ b/src/tests/pipeline_test.rs
@@ -1,7 +1,7 @@
 //! Unit tests for `Pipeline::run_checkpoints` and `Pipeline::stats()`.
 //!
 //! Uses a minimal `TestOperation` implementing the `Operation` trait. The test
-//! operation does no real I/O: `fetch_history_buffer` returns a fatal error
+//! operation does no real I/O: `process_history` returns a fatal error
 //! (so the pipeline records HISTORY failure and falls through to per-cp file
 //! processing), `process_object` records each invocation, and
 //! `finalize_checkpoint` / `finalize` record their respective calls.
@@ -10,11 +10,11 @@
 //! transactions, results) → 3 `process_object` calls per cp.
 
 use crate::pipeline::{
-    async_trait, HistoryFetch, Operation, Pipeline, PipelineConfig, ProcessOutcome,
+    async_trait, HistoryOutcome, Operation, Pipeline, PipelineConfig, ProcessOutcome,
 };
 use crate::storage::{Error as StorageError, StorageConfig, StorageRef};
 use crate::utils::ArchiveStats;
-use opendal::{Buffer, Reader};
+use opendal::Reader;
 use std::collections::BTreeSet;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
@@ -148,24 +148,14 @@ impl Operation for TestOperation {
         Ok(())
     }
 
-    async fn fetch_history_buffer(
-        &self,
-        _history_path: &str,
-        _src_store: &StorageRef,
-        _dst_store: Option<&StorageRef>,
-    ) -> Result<HistoryFetch, StorageError> {
-        // Fatal so `with_retries` returns immediately; pipeline records HISTORY
-        // failure and falls through to per-cp file processing.
-        Err(StorageError::fatal("test stub: no history"))
-    }
-
-    async fn process_buffer(
+    async fn process_history(
         &self,
         _path: &str,
-        _buffer: Buffer,
-    ) -> Result<ProcessOutcome, StorageError> {
-        // Not invoked because `fetch_history_buffer` always fails.
-        Ok(ProcessOutcome::Processed)
+        _src_store: &StorageRef,
+    ) -> Result<HistoryOutcome, StorageError> {
+        // Fatal so `with_retries` returns immediately; the pipeline records the
+        // HISTORY failure and per-cp file processing still runs via process_object.
+        Err(StorageError::fatal("test stub: no history"))
     }
 }
 

--- a/src/tests/pipeline_test.rs
+++ b/src/tests/pipeline_test.rs
@@ -180,6 +180,7 @@ fn make_config(concurrency: usize) -> PipelineConfig {
     PipelineConfig {
         concurrency,
         skip_optional: true, // 3 per-cp files (no SCP)
+        skip_history_and_buckets: false,
         verify: false,
         storage_config,
     }

--- a/src/tests/pipeline_test.rs
+++ b/src/tests/pipeline_test.rs
@@ -9,7 +9,9 @@
 //! Per-cp file count under `skip_optional=true`: 3 files (ledger,
 //! transactions, results) → 3 `process_object` calls per cp.
 
-use crate::pipeline::{async_trait, Operation, Pipeline, PipelineConfig, ProcessOutcome};
+use crate::pipeline::{
+    async_trait, HistoryFetch, Operation, Pipeline, PipelineConfig, ProcessOutcome,
+};
 use crate::storage::{Error as StorageError, StorageConfig, StorageRef};
 use crate::utils::ArchiveStats;
 use opendal::{Buffer, Reader};
@@ -150,7 +152,7 @@ impl Operation for TestOperation {
         _history_path: &str,
         _src_store: &StorageRef,
         _dst_store: Option<&StorageRef>,
-    ) -> Result<Buffer, StorageError> {
+    ) -> Result<HistoryFetch, StorageError> {
         // Fatal so `with_retries` returns immediately; pipeline records HISTORY
         // failure and falls through to per-cp file processing.
         Err(StorageError::fatal("test stub: no history"))

--- a/src/tests/pipeline_test.rs
+++ b/src/tests/pipeline_test.rs
@@ -142,6 +142,7 @@ impl Operation for TestOperation {
         &self,
         highest_checkpoint: u32,
         _stats: &ArchiveStats,
+        _report_path: Option<&std::path::Path>,
     ) -> Result<(), crate::pipeline::Error> {
         self.state.lock().unwrap().finalize_highest_checkpoint = Some(highest_checkpoint);
         Ok(())
@@ -195,7 +196,7 @@ fn make_config(concurrency: usize) -> PipelineConfig {
 #[tokio::test]
 async fn test_run_checkpoints_empty_iter_is_noop() {
     let (op, state) = TestOperation::new((63, 63));
-    let pipeline = Pipeline::new(op, make_config(1), stub_storage(), None);
+    let pipeline = Pipeline::new(op, make_config(1), stub_storage(), None, None);
 
     pipeline
         .run_checkpoints(Vec::<u32>::new())
@@ -216,7 +217,7 @@ async fn test_run_checkpoints_empty_iter_is_noop() {
 #[tokio::test]
 async fn test_run_checkpoints_single_cp() {
     let (op, state) = TestOperation::new((63, 63));
-    let pipeline = Pipeline::new(op, make_config(1), stub_storage(), None);
+    let pipeline = Pipeline::new(op, make_config(1), stub_storage(), None, None);
 
     pipeline.run_checkpoints(vec![63]).await.unwrap();
 
@@ -240,7 +241,7 @@ async fn test_run_checkpoints_single_cp() {
 #[tokio::test]
 async fn test_run_checkpoints_disjoint_cps() {
     let (op, state) = TestOperation::new((0, 0)); // bounds unused by this test
-    let pipeline = Pipeline::new(op, make_config(2), stub_storage(), None);
+    let pipeline = Pipeline::new(op, make_config(2), stub_storage(), None, None);
 
     // Disjoint, non-consecutive cps.
     pipeline.run_checkpoints(vec![63, 575, 4095]).await.unwrap();
@@ -261,7 +262,7 @@ async fn test_run_checkpoints_disjoint_cps() {
 #[tokio::test]
 async fn test_run_checkpoints_does_not_call_finalize() {
     let (op, state) = TestOperation::new((0, 0));
-    let pipeline = Pipeline::new(op, make_config(1), stub_storage(), None);
+    let pipeline = Pipeline::new(op, make_config(1), stub_storage(), None, None);
 
     pipeline.run_checkpoints(vec![63, 127]).await.unwrap();
 
@@ -275,7 +276,7 @@ async fn test_run_checkpoints_does_not_call_finalize() {
 #[tokio::test]
 async fn test_pipeline_finish_calls_finalize_with_supplied_highest() {
     let (op, state) = TestOperation::new((0, 0));
-    let pipeline = Pipeline::new(op, make_config(1), stub_storage(), None);
+    let pipeline = Pipeline::new(op, make_config(1), stub_storage(), None, None);
 
     pipeline.finish(8191).await.expect("finish should succeed");
 
@@ -291,7 +292,7 @@ async fn test_pipeline_finish_calls_finalize_with_supplied_highest() {
 async fn test_run_checkpoints_respects_concurrency() {
     let (op, state) = TestOperation::new((0, 0));
     let op = op.with_delay(Duration::from_millis(50));
-    let pipeline = Pipeline::new(op, make_config(2), stub_storage(), None);
+    let pipeline = Pipeline::new(op, make_config(2), stub_storage(), None, None);
 
     // 4 cps with concurrency=2 → peak in-flight should be exactly 2.
     pipeline
@@ -309,7 +310,7 @@ async fn test_run_checkpoints_respects_concurrency() {
 #[tokio::test]
 async fn test_stats_accessor_returns_live_ref() {
     let (op, _state) = TestOperation::new((0, 0));
-    let pipeline = Pipeline::new(op, make_config(1), stub_storage(), None);
+    let pipeline = Pipeline::new(op, make_config(1), stub_storage(), None, None);
 
     // Mutations through the accessor must be visible on subsequent reads.
     pipeline.stats().record_success("foo");

--- a/src/tests/pipeline_test.rs
+++ b/src/tests/pipeline_test.rs
@@ -12,33 +12,12 @@
 use crate::pipeline::{
     async_trait, HistoryOutcome, Operation, Pipeline, PipelineConfig, ProcessOutcome,
 };
-use crate::storage::{Error as StorageError, StorageConfig, StorageRef};
+use crate::storage::{Error as StorageError, StorageConfig};
 use crate::utils::ArchiveStats;
-use opendal::Reader;
 use std::collections::BTreeSet;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-
-//=============================================================================
-// Stub storage — fills the StorageRef slot; never actually used by TestOperation
-//=============================================================================
-
-struct StubStorage;
-
-#[async_trait::async_trait]
-impl crate::storage::Storage for StubStorage {
-    async fn open_reader(&self, _object: &str) -> Result<Reader, StorageError> {
-        Err(StorageError::not_found())
-    }
-    async fn exists(&self, _object: &str) -> Result<bool, StorageError> {
-        Ok(false)
-    }
-}
-
-fn stub_storage() -> StorageRef {
-    Arc::new(StubStorage)
-}
 
 //=============================================================================
 // TestOperation
@@ -86,17 +65,13 @@ impl TestOperation {
 
 #[async_trait]
 impl Operation for TestOperation {
-    async fn get_checkpoint_bounds(
-        &self,
-        _source: &StorageRef,
-    ) -> Result<(u32, u32), crate::pipeline::Error> {
+    async fn get_checkpoint_bounds(&self) -> Result<(u32, u32), crate::pipeline::Error> {
         Ok(self.bounds)
     }
 
     async fn process_object(
         &self,
         path: &str,
-        _src_store: &StorageRef,
         _manager: Option<&crate::xdr_verify::XdrVerificationManager>,
     ) -> Result<ProcessOutcome, StorageError> {
         // `skip_optional=true` in `make_config` => 3 per-cp files. First call
@@ -148,11 +123,7 @@ impl Operation for TestOperation {
         Ok(())
     }
 
-    async fn process_history(
-        &self,
-        _path: &str,
-        _src_store: &StorageRef,
-    ) -> Result<HistoryOutcome, StorageError> {
+    async fn process_history(&self, _path: &str) -> Result<HistoryOutcome, StorageError> {
         // Fatal so `with_retries` returns immediately; the pipeline records the
         // HISTORY failure and per-cp file processing still runs via process_object.
         Err(StorageError::fatal("test stub: no history"))
@@ -186,7 +157,7 @@ fn make_config(concurrency: usize) -> PipelineConfig {
 #[tokio::test]
 async fn test_run_checkpoints_empty_iter_is_noop() {
     let (op, state) = TestOperation::new((63, 63));
-    let pipeline = Pipeline::new(op, make_config(1), stub_storage(), None, None);
+    let pipeline = Pipeline::new(op, make_config(1), None);
 
     pipeline
         .run_checkpoints(Vec::<u32>::new())
@@ -207,7 +178,7 @@ async fn test_run_checkpoints_empty_iter_is_noop() {
 #[tokio::test]
 async fn test_run_checkpoints_single_cp() {
     let (op, state) = TestOperation::new((63, 63));
-    let pipeline = Pipeline::new(op, make_config(1), stub_storage(), None, None);
+    let pipeline = Pipeline::new(op, make_config(1), None);
 
     pipeline.run_checkpoints(vec![63]).await.unwrap();
 
@@ -231,7 +202,7 @@ async fn test_run_checkpoints_single_cp() {
 #[tokio::test]
 async fn test_run_checkpoints_disjoint_cps() {
     let (op, state) = TestOperation::new((0, 0)); // bounds unused by this test
-    let pipeline = Pipeline::new(op, make_config(2), stub_storage(), None, None);
+    let pipeline = Pipeline::new(op, make_config(2), None);
 
     // Disjoint, non-consecutive cps.
     pipeline.run_checkpoints(vec![63, 575, 4095]).await.unwrap();
@@ -252,7 +223,7 @@ async fn test_run_checkpoints_disjoint_cps() {
 #[tokio::test]
 async fn test_run_checkpoints_does_not_call_finalize() {
     let (op, state) = TestOperation::new((0, 0));
-    let pipeline = Pipeline::new(op, make_config(1), stub_storage(), None, None);
+    let pipeline = Pipeline::new(op, make_config(1), None);
 
     pipeline.run_checkpoints(vec![63, 127]).await.unwrap();
 
@@ -266,7 +237,7 @@ async fn test_run_checkpoints_does_not_call_finalize() {
 #[tokio::test]
 async fn test_pipeline_finish_calls_finalize_with_supplied_highest() {
     let (op, state) = TestOperation::new((0, 0));
-    let pipeline = Pipeline::new(op, make_config(1), stub_storage(), None, None);
+    let pipeline = Pipeline::new(op, make_config(1), None);
 
     pipeline.finish(8191).await.expect("finish should succeed");
 
@@ -282,7 +253,7 @@ async fn test_pipeline_finish_calls_finalize_with_supplied_highest() {
 async fn test_run_checkpoints_respects_concurrency() {
     let (op, state) = TestOperation::new((0, 0));
     let op = op.with_delay(Duration::from_millis(50));
-    let pipeline = Pipeline::new(op, make_config(2), stub_storage(), None, None);
+    let pipeline = Pipeline::new(op, make_config(2), None);
 
     // 4 cps with concurrency=2 → peak in-flight should be exactly 2.
     pipeline
@@ -300,7 +271,7 @@ async fn test_run_checkpoints_respects_concurrency() {
 #[tokio::test]
 async fn test_stats_accessor_returns_live_ref() {
     let (op, _state) = TestOperation::new((0, 0));
-    let pipeline = Pipeline::new(op, make_config(1), stub_storage(), None, None);
+    let pipeline = Pipeline::new(op, make_config(1), None);
 
     // Mutations through the accessor must be visible on subsequent reads.
     pipeline.stats().record_success("foo");

--- a/src/tests/repair_op_test.rs
+++ b/src/tests/repair_op_test.rs
@@ -788,7 +788,7 @@ async fn test_repair_http_source_to_filesystem() {
 }
 
 //=============================================================================
-// G. Download Verification (Phase 2 integrity)
+// G. Download Verification (checkpoint-retry integrity)
 //=============================================================================
 
 #[tokio::test]
@@ -1038,4 +1038,284 @@ async fn test_repair_wave1_failure_does_not_block_wave2() {
         !dest_dir.path().join(&deleted_ledger).exists(),
         "Ledger should still be missing (source doesn't have it)"
     );
+}
+
+//=============================================================================
+// M. File-retry HISTORY special case — re-fetches history file AND walks
+// referenced buckets to surface buckets the main pass never probed.
+//=============================================================================
+
+/// Build a `RepairOperation` directly (no pipeline) for in-isolation
+/// testing of `retry_failed_files` / `retry_failed_checkpoints`.
+fn build_repair_op(
+    src_url: &str,
+    dst_url: &str,
+    verify: bool,
+) -> crate::repair_operation::RepairOperation {
+    let storage_config = crate::test_helpers::test_storage_config();
+    let src_store = crate::storage::from_url_with_config(src_url, &storage_config).unwrap();
+    let dst_store = crate::storage::from_url_with_config(dst_url, &storage_config).unwrap();
+    crate::repair_operation::RepairOperation::new(
+        src_store,
+        dst_store,
+        /*low=*/ None,
+        /*high=*/ None,
+        verify,
+        /*dry_run=*/ false,
+        /*concurrency=*/ 4,
+        /*skip_optional=*/ false,
+        &storage_config,
+    )
+}
+
+/// Locate a history file in dst, return (its absolute path, cp, bucket-hashes
+/// it references, those bucket files' absolute paths).
+fn pick_history_with_buckets(
+    dst_dir: &Path,
+) -> (
+    std::path::PathBuf,
+    u32,
+    BTreeSet<String>,
+    Vec<std::path::PathBuf>,
+) {
+    let history_files: Vec<_> = get_files_by_pattern(dst_dir, "/history-")
+        .into_iter()
+        .filter(|p| !p.to_string_lossy().contains(".well-known"))
+        .collect();
+    assert!(
+        !history_files.is_empty(),
+        "need a non-well-known history file"
+    );
+
+    for hf in &history_files {
+        let hashes = buckets_from_history_file(hf);
+        if hashes.is_empty() {
+            continue;
+        }
+        let bucket_paths: Vec<_> = hashes
+            .iter()
+            .filter_map(|h| {
+                let matches = get_files_by_pattern(dst_dir, &format!("bucket-{h}"));
+                matches.into_iter().next()
+            })
+            .collect();
+        if bucket_paths.is_empty() {
+            continue;
+        }
+        let relative = hf
+            .strip_prefix(dst_dir)
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        let cp = history_format::checkpoint_from_path(&relative)
+            .expect("history path should encode a checkpoint");
+        return (hf.clone(), cp, hashes, bucket_paths);
+    }
+    panic!("no history file with discoverable bucket files found");
+}
+
+/// History was failed during main pass (manually marked) AND a referenced
+/// bucket is missing in dst. The file-retry path must:
+///   - re-fetch the history file from src,
+///   - parse it, walk bucket refs,
+///   - re-fetch the missing bucket,
+///   - clear both the HISTORY flag and any bucket failure entry from stats.
+#[tokio::test]
+async fn test_file_retry_history_repair_fetches_history_and_referenced_buckets() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    let (history_abs, cp, _bucket_hashes, bucket_abs) = pick_history_with_buckets(dest_dir.path());
+    let history_relative = history_abs
+        .strip_prefix(dest_dir.path())
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+    let bucket_to_break = &bucket_abs[0];
+    let bucket_relative = bucket_to_break
+        .strip_prefix(dest_dir.path())
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+
+    // Setup the broken state: history + one referenced bucket gone from dst.
+    std::fs::remove_file(&history_abs).expect("delete history");
+    std::fs::remove_file(bucket_to_break).expect("delete bucket");
+
+    // Build a RepairOperation directly; populate a fresh ArchiveStats with
+    // the HISTORY failure (simulating the main pass's outcome).
+    let op = build_repair_op(&src_url, &dest_url, /*verify=*/ true);
+    let parent_stats = crate::utils::ArchiveStats::new();
+    parent_stats.record_failure(cp, &history_relative).await;
+
+    // Drive phase 1 in isolation.
+    let stats = op.retry_failed_files(&parent_stats).await;
+
+    // History file is back.
+    assert!(history_abs.exists(), "history file should be restored");
+    // The deleted bucket is back too (discovered transitively).
+    assert!(
+        bucket_to_break.exists(),
+        "referenced bucket should be restored"
+    );
+
+    // Stats should be clean: HISTORY flag cleared, no bucket failure recorded.
+    let f = stats.failures.lock().await;
+    assert!(!f.files.contains_key(&cp), "HISTORY flag should be cleared");
+    let _ = bucket_relative;
+    assert!(
+        f.buckets.is_empty(),
+        "no bucket failures should remain in stats"
+    );
+}
+
+/// History was failed (manually marked) but its referenced buckets are
+/// already present and valid in dst. The file-retry path re-fetches the history; the
+/// inner mirror also re-fetches the transitively-discovered buckets
+/// (mirror has no dst-first probe), which is wasted but correct work —
+/// `verify_and_write_bucket` hashes-verifies the new content before
+/// commit, so the buckets remain valid. End state: history restored, all
+/// buckets present and valid, phase 1 stats clean.
+#[tokio::test]
+async fn test_file_retry_history_repair_with_intact_buckets() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    let (history_abs, cp, _hashes, bucket_abs) = pick_history_with_buckets(dest_dir.path());
+    let history_relative = history_abs
+        .strip_prefix(dest_dir.path())
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+
+    // Break only the history file; leave buckets intact.
+    std::fs::remove_file(&history_abs).expect("delete history");
+
+    let op = build_repair_op(&src_url, &dest_url, /*verify=*/ true);
+    let parent_stats = crate::utils::ArchiveStats::new();
+    parent_stats.record_failure(cp, &history_relative).await;
+    let stats = op.retry_failed_files(&parent_stats).await;
+
+    assert!(history_abs.exists(), "history file should be restored");
+    for bucket in &bucket_abs {
+        assert!(bucket.exists(), "bucket {bucket:?} should remain present");
+    }
+
+    let f = stats.failures.lock().await;
+    assert!(!f.files.contains_key(&cp), "HISTORY flag should be cleared");
+    assert!(
+        f.buckets.is_empty(),
+        "no bucket failures should remain in stats"
+    );
+}
+
+/// History fetched OK but a referenced bucket can't be fetched (src 404s on
+/// that bucket). The file-retry path must: still restore the history file, record the
+/// bucket failure into stats, return the bucket as a failure for the caller.
+#[tokio::test]
+async fn test_file_retry_history_repair_fails_when_referenced_bucket_unavailable() {
+    // Build a separate src dir so we can selectively delete a bucket from src.
+    let src_dir = TempDir::new().unwrap();
+    copy_testnet_small_archive(src_dir.path()).unwrap();
+    let src_url = file_url_from_path(src_dir.path());
+
+    let dest_dir = TempDir::new().unwrap();
+    let dest_url = file_url_from_path(dest_dir.path());
+    run_mirror(MirrorConfig::new(&src_url, &dest_url))
+        .await
+        .expect("mirror should succeed");
+
+    let (history_abs, cp, hashes, bucket_abs) = pick_history_with_buckets(dest_dir.path());
+    let history_relative = history_abs
+        .strip_prefix(dest_dir.path())
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+    let bucket_to_kill = &bucket_abs[0];
+    let bucket_relative = bucket_to_kill
+        .strip_prefix(dest_dir.path())
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+    let hash_to_kill = hashes.iter().next().unwrap();
+
+    // Delete the bucket from BOTH src and dst — phase 1 will try src and fail.
+    let src_bucket_files = get_files_by_pattern(src_dir.path(), &format!("bucket-{hash_to_kill}"));
+    assert!(!src_bucket_files.is_empty());
+    std::fs::remove_file(&src_bucket_files[0]).expect("delete src bucket");
+    std::fs::remove_file(bucket_to_kill).expect("delete dst bucket");
+    // Also delete dst's history so it's a phase 1 work item.
+    std::fs::remove_file(&history_abs).expect("delete dst history");
+
+    let op = build_repair_op(&src_url, &dest_url, /*verify=*/ true);
+    let parent_stats = crate::utils::ArchiveStats::new();
+    parent_stats.record_failure(cp, &history_relative).await;
+    let stats = op.retry_failed_files(&parent_stats).await;
+
+    // History file is back (src had it).
+    assert!(history_abs.exists(), "history should be restored");
+    // The bucket is still missing in dst.
+    assert!(
+        !bucket_to_kill.exists(),
+        "bucket can't be repaired (src also missing)"
+    );
+
+    // Stats: HISTORY flag cleared (file repair succeeded), bucket failure
+    // recorded so the user sees something is still broken.
+    let f = stats.failures.lock().await;
+    assert!(!f.files.contains_key(&cp));
+    assert!(
+        !f.buckets.is_empty(),
+        "the unrecoverable bucket should be recorded as a failure"
+    );
+    let _ = bucket_relative;
+}
+
+/// Src's history file is corrupt (not valid JSON). The file-retry path must NOT overwrite
+/// dst's history with the corrupt content, and HISTORY must remain in stats
+/// so the run reports failure.
+#[tokio::test]
+async fn test_file_retry_history_repair_corrupt_history_from_src() {
+    // Build separate src/dst so we can corrupt src's history file.
+    let src_dir = TempDir::new().unwrap();
+    copy_testnet_small_archive(src_dir.path()).unwrap();
+    let src_url = file_url_from_path(src_dir.path());
+
+    let dest_dir = TempDir::new().unwrap();
+    let dest_url = file_url_from_path(dest_dir.path());
+    run_mirror(MirrorConfig::new(&src_url, &dest_url))
+        .await
+        .expect("mirror should succeed");
+
+    let (history_abs, cp, _, _) = pick_history_with_buckets(dest_dir.path());
+    let history_relative = history_abs
+        .strip_prefix(dest_dir.path())
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+    let src_history = src_dir.path().join(&history_relative);
+
+    // Corrupt src's history with junk text (won't parse as JSON).
+    std::fs::write(&src_history, b"not valid json at all {").expect("write corrupt src history");
+    // Pre-remove dst's history so phase 1 has to fetch.
+    std::fs::remove_file(&history_abs).expect("delete dst history");
+
+    let op = build_repair_op(&src_url, &dest_url, /*verify=*/ true);
+    let parent_stats = crate::utils::ArchiveStats::new();
+    parent_stats.record_failure(cp, &history_relative).await;
+    let stats = op.retry_failed_files(&parent_stats).await;
+
+    // History file must NOT have been written (parse-before-write contract).
+    assert!(
+        !history_abs.exists(),
+        "dst history should not be overwritten with corrupt src content"
+    );
+
+    // HISTORY flag stays in stats because phase 1 failed.
+    let f = stats.failures.lock().await;
+    let flags = f
+        .files
+        .get(&cp)
+        .expect("HISTORY flag should remain in stats after a failed phase 1 repair");
+    assert!(flags.has(crate::utils::FileFlags::HISTORY));
+    // No buckets touched (we never got past parse).
+    assert!(f.buckets.is_empty());
 }

--- a/src/tests/repair_op_test.rs
+++ b/src/tests/repair_op_test.rs
@@ -1551,10 +1551,7 @@ async fn test_well_known_restored_after_history_retry() {
     let op = build_repair_op(&src_url, &dest_url, /*verify=*/ true);
 
     // Observe the missing dst .well-known so the needs-repair flag is set.
-    let src_store =
-        crate::storage::from_url_with_config(&src_url, &crate::test_helpers::test_storage_config())
-            .unwrap();
-    op.get_checkpoint_bounds(&src_store)
+    op.get_checkpoint_bounds()
         .await
         .expect("bounds via src fallback");
 
@@ -1880,10 +1877,7 @@ async fn test_repair_both_well_known_unreadable_errors() {
     std::fs::remove_file(dest_dir.path().join(".well-known/stellar-history.json")).unwrap();
 
     let op = build_repair_op(&src_url, &dest_url, /*verify=*/ false);
-    let src_store =
-        crate::storage::from_url_with_config(&src_url, &crate::test_helpers::test_storage_config())
-            .unwrap();
-    let result = op.get_checkpoint_bounds(&src_store).await;
+    let result = op.get_checkpoint_bounds().await;
     assert!(
         result.is_err(),
         "get_checkpoint_bounds must error when both .well-known are unreadable"
@@ -2001,14 +1995,12 @@ async fn test_repair_dry_run_verify_surfaces_cross_file_failure() {
     let corrupted_bytes = std::fs::read(&ledger_abs).unwrap();
 
     let storage_config = crate::test_helpers::test_storage_config();
-    let src_store = crate::storage::from_url_with_config(&src_url, &storage_config).unwrap();
-    let dst_store = crate::storage::from_url_with_config(&dest_url, &storage_config).unwrap();
 
     let op = build_repair_op_full(
         &src_url, &dest_url, /*verify=*/ true, /*dry_run=*/ true,
     );
     let (low, high) = op
-        .get_checkpoint_bounds(&src_store)
+        .get_checkpoint_bounds()
         .await
         .expect("bounds from dst .well-known");
 
@@ -2019,7 +2011,7 @@ async fn test_repair_dry_run_verify_surfaces_cross_file_failure() {
         verify: true,
         storage_config,
     };
-    let pipeline = Pipeline::new(op, config, src_store, Some(dst_store), None);
+    let pipeline = Pipeline::new(op, config, None);
     let cps = (low..=high).step_by(history_format::CHECKPOINT_FREQUENCY as usize);
     pipeline
         .run_checkpoints(cps)

--- a/src/tests/repair_op_test.rs
+++ b/src/tests/repair_op_test.rs
@@ -1055,16 +1055,19 @@ fn build_repair_op(
     let storage_config = crate::test_helpers::test_storage_config();
     let src_store = crate::storage::from_url_with_config(src_url, &storage_config).unwrap();
     let dst_store = crate::storage::from_url_with_config(dst_url, &storage_config).unwrap();
+    let pipeline_config = crate::pipeline::PipelineConfig {
+        concurrency: 4,
+        skip_optional: false,
+        verify,
+        storage_config,
+    };
     crate::repair_operation::RepairOperation::new(
         src_store,
         dst_store,
         /*low=*/ None,
         /*high=*/ None,
-        verify,
         /*dry_run=*/ false,
-        /*concurrency=*/ 4,
-        /*skip_optional=*/ false,
-        &storage_config,
+        pipeline_config,
     )
 }
 

--- a/src/tests/repair_op_test.rs
+++ b/src/tests/repair_op_test.rs
@@ -1228,13 +1228,12 @@ async fn test_file_retry_history_repair_fetches_history_and_referenced_buckets()
     );
 }
 
-/// History was failed (manually marked) but its referenced buckets are
-/// already present and valid in dst. The file-retry path re-fetches the history; the
-/// inner mirror also re-fetches the transitively-discovered buckets
-/// (mirror has no dst-first probe), which is wasted but correct work —
-/// `verify_and_write_bucket` hashes-verifies the new content before
-/// commit, so the buckets remain valid. End state: history restored, all
-/// buckets present and valid, `retry_failed_files` stats clean.
+/// History was failed (manually marked) but its referenced buckets are already
+/// present and valid in dst. The HISTORY-retry path re-fetches the history file,
+/// then probes each discovered bucket dst-first and finds them valid — so they
+/// are NOT re-fetched (see
+/// `test_file_retry_history_does_not_refetch_buckets_valid_on_dst`). End state:
+/// history restored, all buckets present and valid, stats clean.
 #[tokio::test]
 async fn test_file_retry_history_repair_with_intact_buckets() {
     let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
@@ -2129,4 +2128,389 @@ async fn test_repair_report_records_well_known_discovery_in_main_pass() {
     // Restoration succeeded → no residual in the retry sections.
     assert!(report.sections["file_retry"].well_known.is_none());
     assert!(report.sections["checkpoint_retry"].well_known.is_none());
+}
+
+/// HISTORY-retry must not re-download buckets already valid on dst. A bucket
+/// referenced by the retried history file is deleted from SRC only (it stays
+/// valid on dst). The old overwrite path would re-fetch it, hit a 404 on src,
+/// and spuriously record a bucket failure; the dst-first probe finds it valid
+/// on dst and skips it — no fetch, no failure.
+#[tokio::test]
+async fn test_file_retry_history_does_not_refetch_buckets_valid_on_dst() {
+    // Separate src dir so we can delete a bucket from src only.
+    let src_dir = TempDir::new().unwrap();
+    copy_testnet_small_archive(src_dir.path()).unwrap();
+    let src_url = file_url_from_path(src_dir.path());
+
+    let dest_dir = TempDir::new().unwrap();
+    let dest_url = file_url_from_path(dest_dir.path());
+    run_mirror(MirrorConfig::new(&src_url, &dest_url))
+        .await
+        .expect("mirror should succeed");
+
+    let (history_abs, cp, hashes, _bucket_abs) = pick_history_with_buckets(dest_dir.path());
+    let history_relative = history_abs
+        .strip_prefix(dest_dir.path())
+        .unwrap()
+        .to_string_lossy()
+        .replace('\\', "/");
+    let hash = hashes.iter().next().unwrap();
+
+    // Delete that bucket from SRC only; dst keeps a valid copy.
+    let src_bucket = get_files_by_pattern(src_dir.path(), &format!("bucket-{hash}"));
+    assert!(!src_bucket.is_empty());
+    std::fs::remove_file(&src_bucket[0]).expect("delete src bucket");
+    // Delete dst history so it's a file-retry work item.
+    std::fs::remove_file(&history_abs).expect("delete dst history");
+
+    let op = build_repair_op(&src_url, &dest_url, /*verify=*/ true);
+    let parent_stats = crate::utils::ArchiveStats::new();
+    parent_stats.record_failure(cp, &history_relative).await;
+    let stats = op.retry_failed_files(&parent_stats).await;
+
+    assert!(history_abs.exists(), "history should be restored");
+    let dst_bucket = get_files_by_pattern(dest_dir.path(), &format!("bucket-{hash}"));
+    assert!(
+        !dst_bucket.is_empty(),
+        "valid dst bucket must remain present"
+    );
+    let f = stats.failures.lock().await;
+    assert!(
+        f.buckets.is_empty(),
+        "a bucket valid on dst must not be re-fetched or recorded as a failure, got: {:?}",
+        f.buckets
+    );
+}
+
+/// A bucket listed in `failures.buckets` (known broken) skips the dst probe and
+/// is fetched directly. We prove the probe was skipped by deleting the bucket
+/// from src while leaving a valid copy on dst: a direct fetch 404s and records a
+/// failure, whereas the dst-first probe (Task 1) would have skipped it. This is
+/// the deliberate inverse of `..._does_not_refetch_buckets_valid_on_dst`.
+#[tokio::test]
+async fn test_file_retry_known_broken_bucket_fetched_directly() {
+    let src_dir = TempDir::new().unwrap();
+    copy_testnet_small_archive(src_dir.path()).unwrap();
+    let src_url = file_url_from_path(src_dir.path());
+
+    let dest_dir = TempDir::new().unwrap();
+    let dest_url = file_url_from_path(dest_dir.path());
+    run_mirror(MirrorConfig::new(&src_url, &dest_url))
+        .await
+        .expect("mirror should succeed");
+
+    let (_history_abs, _cp, hashes, bucket_abs) = pick_history_with_buckets(dest_dir.path());
+    let hash = hashes.iter().next().unwrap().clone();
+    let bucket_rel = bucket_abs[0]
+        .strip_prefix(dest_dir.path())
+        .unwrap()
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    // Delete the bucket from src only; dst keeps a valid copy.
+    let src_bucket = get_files_by_pattern(src_dir.path(), &format!("bucket-{hash}"));
+    std::fs::remove_file(&src_bucket[0]).expect("delete src bucket");
+
+    // Mark the bucket itself as broken (no history work item this time).
+    let op = build_repair_op(&src_url, &dest_url, /*verify=*/ true);
+    let parent_stats = crate::utils::ArchiveStats::new();
+    parent_stats.record_failure(0, &bucket_rel).await;
+    let stats = op.retry_failed_files(&parent_stats).await;
+
+    // The probe was skipped: a direct fetch was attempted, hit src's 404, and
+    // recorded a failure (rather than skipping the valid dst copy).
+    let f = stats.failures.lock().await;
+    assert!(
+        !f.buckets.is_empty(),
+        "a known-broken bucket should be fetched directly (probe skipped), failing on src 404"
+    );
+}
+
+/// HISTORY-retry under `--verify` repairs a referenced bucket that is
+/// present-but-invalid on dst and NOT pre-listed (discovered via the re-walk):
+/// the dst-first probe validates content, fails, and re-fetches from src.
+#[tokio::test]
+async fn test_file_retry_history_repairs_invalid_discovered_bucket_with_verify() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    let (history_abs, cp, _hashes, bucket_abs) = pick_history_with_buckets(dest_dir.path());
+    let history_relative = history_abs
+        .strip_prefix(dest_dir.path())
+        .unwrap()
+        .to_string_lossy()
+        .replace('\\', "/");
+    let bucket_to_corrupt = &bucket_abs[0];
+
+    // Corrupt the bucket on dst (invalid gzip) but keep it present; delete the
+    // dst history so it becomes a file-retry work item. The bucket is NOT in the
+    // failure set — it's discovered by re-walking the repaired history.
+    std::fs::write(bucket_to_corrupt, b"not a valid gzip bucket").expect("corrupt bucket");
+    std::fs::remove_file(&history_abs).expect("delete dst history");
+
+    let op = build_repair_op(&src_url, &dest_url, /*verify=*/ true);
+    let parent_stats = crate::utils::ArchiveStats::new();
+    parent_stats.record_failure(cp, &history_relative).await;
+    let stats = op.retry_failed_files(&parent_stats).await;
+
+    assert!(history_abs.exists(), "history should be restored");
+    run_scan(ScanConfig::new(&dest_url).verify())
+        .await
+        .expect("scan --verify should pass after the invalid bucket is repaired");
+    let f = stats.failures.lock().await;
+    assert!(
+        f.buckets.is_empty(),
+        "invalid discovered bucket should be repaired, not failed"
+    );
+}
+
+/// Plan mode trusts the plan: a listed item is fetched from src directly —
+/// never skipped because dst happens to have a (valid) copy, and never
+/// expensively re-verified on dst. Proven by deleting the listed file from
+/// src: the direct fetch 404s and the repair fails. The failed fetch must
+/// also leave the existing dst copy untouched.
+#[tokio::test]
+async fn test_repair_plan_listed_item_is_refetched_not_skipped() {
+    let src_dir = TempDir::new().unwrap();
+    copy_testnet_small_archive(src_dir.path()).unwrap();
+    let src_url = file_url_from_path(src_dir.path());
+
+    let dest_dir = TempDir::new().unwrap();
+    let dest_url = file_url_from_path(dest_dir.path());
+    run_mirror(MirrorConfig::new(&src_url, &dest_url))
+        .await
+        .expect("mirror should succeed");
+
+    // A ledger that is valid on dst; delete it from src only.
+    let (ledger_abs, cp) = get_files_by_pattern(dest_dir.path(), "/ledger-")
+        .iter()
+        .find_map(|p| {
+            let rel = p
+                .strip_prefix(dest_dir.path())
+                .unwrap()
+                .to_string_lossy()
+                .replace('\\', "/");
+            history_format::checkpoint_from_path(&rel).map(|c| (p.clone(), c))
+        })
+        .expect("a ledger file");
+    let ledger_rel = ledger_abs
+        .strip_prefix(dest_dir.path())
+        .unwrap()
+        .to_string_lossy()
+        .replace('\\', "/");
+    std::fs::remove_file(src_dir.path().join(&ledger_rel)).expect("delete src ledger");
+
+    // A plan listing that (still-valid-on-dst) ledger.
+    let mut tracker = crate::utils::FailureTracker::default();
+    tracker.record_file(cp, crate::utils::FileFlags::LEDGER);
+    let plan = crate::report::ArchiveReport::from_failures_and_summary(
+        &tracker,
+        crate::report::Summary::default(),
+    );
+
+    // Failed-list mode: the listed ledger is fetched from src directly (no
+    // dst probe). src no longer has it, so the repair fails — a listed item
+    // is never silently skipped just because dst has a copy.
+    run_repair(RepairConfig::new(&src_url, &dest_url).verify().plan(plan))
+        .await
+        .expect_err("listed item is re-fetched; missing on src fails the repair");
+    assert!(
+        ledger_abs.exists(),
+        "failed re-fetch must not delete the existing dst copy"
+    );
+}
+
+/// A scan report feeds directly into repair: scan --verify lists a deleted
+/// file AND a corrupt-but-present bucket; applying that report with
+/// `repair --plan` and NO CLI --verify still repairs both, because every
+/// listed item is re-fetched unconditionally (the plan is fully respected —
+/// no mode needs to be carried in it).
+#[tokio::test]
+async fn test_scan_report_feeds_into_repair() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    // Damage dst: delete a ledger and corrupt a bucket (present-but-invalid).
+    delete_first_file(dest_dir.path(), "/ledger-");
+    corrupt_bucket_invalid_gzip(dest_dir.path());
+
+    // Scan --verify writes a report of what's broken.
+    let scan_json = dest_dir.path().join("findings.json");
+    run_scan(ScanConfig::new(&dest_url).verify().report(&scan_json))
+        .await
+        .expect_err("scan --verify should fail on the damaged archive");
+
+    let report = crate::report::read_from_path(&scan_json).unwrap();
+    assert!(
+        !report.section.files.is_empty() || !report.section.buckets.is_empty(),
+        "scan report should list the failures"
+    );
+
+    // Apply the scan report as a repair plan, WITHOUT a CLI --verify. Listed
+    // items are re-fetched unconditionally, so the corrupt-but-present bucket
+    // is repaired too.
+    run_repair(RepairConfig::new(&src_url, &dest_url).plan(report))
+        .await
+        .expect("repair --plan should fix every listed item");
+
+    run_scan(ScanConfig::new(&dest_url).verify())
+        .await
+        .expect("scan --verify should pass after plan-driven repair");
+}
+
+/// A mirror report feeds into repair: mirroring from an incomplete source
+/// records the un-copyable file (mirror writes its report before the failure
+/// gate); applying that report with `repair --plan` against a complete source
+/// restores the file. Confirms mirror output is a valid plan.
+#[tokio::test]
+async fn test_mirror_report_feeds_into_repair() {
+    // Incomplete source: a full archive minus one ledger file.
+    let src_incomplete = TempDir::new().unwrap();
+    copy_testnet_small_archive(src_incomplete.path()).unwrap();
+    let deleted = delete_first_file(src_incomplete.path(), "/ledger-");
+    let src_incomplete_url = file_url_from_path(src_incomplete.path());
+
+    // Complete source for the repair step.
+    let complete_src_url = file_url_from_path(&testnet_small_archive_path());
+
+    let dest_dir = TempDir::new().unwrap();
+    let dest_url = file_url_from_path(dest_dir.path());
+
+    // Mirror from the incomplete source → records the missing ledger; writes the
+    // report even though the run fails.
+    let mirror_json = dest_dir.path().join("mirror.json");
+    run_mirror(MirrorConfig::new(&src_incomplete_url, &dest_url).report(&mirror_json))
+        .await
+        .expect_err("mirror from an incomplete source should fail");
+
+    let report = crate::report::read_from_path(&mirror_json).unwrap();
+    let cp = history_format::checkpoint_from_path(&deleted).unwrap();
+    assert!(
+        report.section.files.contains_key(&cp.to_string()),
+        "mirror report should list the un-copyable ledger's checkpoint: {:?}",
+        report.section.files
+    );
+
+    // Apply the mirror report against the COMPLETE source → restores the ledger.
+    run_repair(RepairConfig::new(&complete_src_url, &dest_url).plan(report))
+        .await
+        .expect("repair --plan should restore the file from the complete source");
+
+    assert!(
+        dest_dir.path().join(&deleted).exists(),
+        "the ledger missing from mirror's source should be restored by repair"
+    );
+}
+
+/// CLI `--verify` works in plan mode exactly as in regular repair: the
+/// re-fetched content is validated before being written. Proven by corrupting
+/// the source copy of a listed-missing file: the verified re-fetch rejects
+/// the corrupt source and repair fails (without --verify it would have been
+/// blind-copied).
+#[tokio::test]
+async fn test_plan_apply_with_cli_verify_validates_source() {
+    // Separate src so we can corrupt it without touching the shared fixture.
+    let src_dir = TempDir::new().unwrap();
+    copy_testnet_small_archive(src_dir.path()).unwrap();
+    let src_url = file_url_from_path(src_dir.path());
+
+    let dest_dir = TempDir::new().unwrap();
+    let dest_url = file_url_from_path(dest_dir.path());
+    run_mirror(MirrorConfig::new(&src_url, &dest_url))
+        .await
+        .expect("mirror should succeed");
+
+    // Delete a ledger on dst (missing → a no-verify scan would list it), then
+    // corrupt that same ledger's content in src so a verified re-fetch rejects it.
+    let deleted = delete_first_file(dest_dir.path(), "/ledger-");
+    let cp = history_format::checkpoint_from_path(&deleted).unwrap();
+    std::fs::write(src_dir.path().join(&deleted), b"not a valid gzip ledger")
+        .expect("corrupt src ledger");
+
+    // A plan listing that ledger.
+    let mut tracker = crate::utils::FailureTracker::default();
+    tracker.record_file(cp, crate::utils::FileFlags::LEDGER);
+    let plan = crate::report::ArchiveReport::from_failures_and_summary(
+        &tracker,
+        crate::report::Summary::default(),
+    );
+
+    // Apply WITH --verify: the corrupt src ledger is rejected on re-fetch and
+    // repair fails.
+    let result = run_repair(RepairConfig::new(&src_url, &dest_url).verify().plan(plan)).await;
+    assert!(
+        result.is_err(),
+        "--verify must validate re-fetched content; corrupt src should be rejected"
+    );
+}
+
+/// `FailureTracker::contains_path` matches per-cp files by (checkpoint, type)
+/// and buckets by content hash — the membership test behind repair's
+/// failed-list mode (listed files are fetched directly, skipping the dst probe).
+#[test]
+fn test_failure_tracker_contains_path() {
+    use crate::utils::{hex_to_hash, FailureTracker, FileFlags};
+
+    let mut t = FailureTracker::default();
+    t.record_file(127, FileFlags::LEDGER);
+
+    let ledger_127 = history_format::checkpoint_path("ledger", 127);
+    let tx_127 = history_format::checkpoint_path("transactions", 127);
+    let ledger_191 = history_format::checkpoint_path("ledger", 191);
+    assert!(t.contains_path(&ledger_127), "recorded (cp, flag) matches");
+    assert!(!t.contains_path(&tx_127), "same cp, different file type");
+    assert!(!t.contains_path(&ledger_191), "different cp");
+    assert!(!t.contains_path("not/an/archive/path"));
+
+    // Buckets are matched by content hash, independent of cp.
+    let hash_hex = "ab".repeat(32);
+    let bucket_path = history_format::bucket_path(&hash_hex).unwrap();
+    assert!(!t.contains_path(&bucket_path), "bucket not recorded yet");
+    t.record_bucket(hex_to_hash(&hash_hex).unwrap());
+    assert!(
+        t.contains_path(&bucket_path),
+        "recorded bucket hash matches"
+    );
+}
+
+/// Direct-fetch semantics: a listed file that is present-but-corrupt on dst is
+/// overwritten from src even when the plan and the CLI are both non-verify —
+/// listed items are re-fetched unconditionally, never existence-skipped.
+#[tokio::test]
+async fn test_plan_refetches_corrupt_present_file_without_verify() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    // Corrupt a transactions file on dst (present but invalid).
+    let (tx_abs, cp) = get_files_by_pattern(dest_dir.path(), "/transactions-")
+        .iter()
+        .find_map(|p| {
+            let rel = p
+                .strip_prefix(dest_dir.path())
+                .unwrap()
+                .to_string_lossy()
+                .replace('\\', "/");
+            history_format::checkpoint_from_path(&rel).map(|c| (p.clone(), c))
+        })
+        .expect("a transactions file");
+    std::fs::write(&tx_abs, b"garbage").expect("corrupt dst transactions");
+
+    // A plan listing it.
+    let mut tracker = crate::utils::FailureTracker::default();
+    tracker.record_file(cp, crate::utils::FileFlags::TRANSACTIONS);
+    let plan = crate::report::ArchiveReport::from_failures_and_summary(
+        &tracker,
+        crate::report::Summary::default(),
+    );
+
+    // No --verify anywhere — the listed file must still be re-fetched.
+    run_repair(RepairConfig::new(&src_url, &dest_url).plan(plan))
+        .await
+        .expect("listed corrupt-present file is re-fetched");
+
+    // The dst copy now matches src again.
+    let rel = tx_abs.strip_prefix(dest_dir.path()).unwrap();
+    let src_file = testnet_small_archive_path().join(rel);
+    assert_eq!(
+        std::fs::read(&tx_abs).unwrap(),
+        std::fs::read(&src_file).unwrap(),
+        "corrupt dst transactions file is overwritten with src content"
+    );
 }

--- a/src/tests/repair_op_test.rs
+++ b/src/tests/repair_op_test.rs
@@ -527,67 +527,133 @@ async fn test_repair_no_verify_ignores_corrupt_xdr() {
 }
 
 //=============================================================================
-// D. Manual Mode
+// D. Plan Mode (--plan)
 //=============================================================================
 
 #[tokio::test]
-async fn test_repair_manual_specific_files() {
+async fn test_repair_plan_round_trip_fixes_archive() {
     let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
 
-    // Delete 3 files
+    // Damage: delete a ledger and corrupt a bucket.
     let deleted_ledger = delete_first_file(dest_dir.path(), "/ledger-");
-    let deleted_tx = delete_first_file(dest_dir.path(), "/transactions-");
-    let _deleted_results = delete_first_file(dest_dir.path(), "/results-");
+    corrupt_bucket_invalid_gzip(dest_dir.path());
 
-    // Only repair 2 of the 3
+    // 1. Dry-run produces a plan.
+    let plan_path = dest_dir.path().join("plan.json");
     run_repair(
         RepairConfig::new(&src_url, &dest_url)
-            .files(vec![deleted_ledger.clone(), deleted_tx.clone()]),
+            .verify()
+            .dry_run()
+            .report(&plan_path),
     )
     .await
-    .expect("Manual repair should succeed");
+    .expect("dry-run ok");
+    let plan = crate::report::read_from_path(&plan_path).unwrap();
 
-    // Ledger and transactions should be restored
-    assert!(dest_dir.path().join(&deleted_ledger).exists());
-    assert!(dest_dir.path().join(&deleted_tx).exists());
-
-    // Results should still be missing (wasn't in the repair list)
-    run_scan(ScanConfig::new(&dest_url))
+    // 2. Apply the plan.
+    run_repair(RepairConfig::new(&src_url, &dest_url).verify().plan(plan))
         .await
-        .expect_err("Results file should still be missing");
+        .expect("plan apply ok");
+
+    // 3. Archive is healthy again.
+    assert!(
+        dest_dir.path().join(&deleted_ledger).exists(),
+        "ledger restored"
+    );
+    run_scan(ScanConfig::new(&dest_url).verify())
+        .await
+        .expect("scan --verify passes after plan repair");
 }
 
 #[tokio::test]
-async fn test_repair_manual_empty_list() {
+async fn test_repair_plan_restores_well_known_from_cp() {
     let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
 
-    delete_first_file(dest_dir.path(), "/ledger-");
+    // Break only the dst .well-known.
+    let wk_path = dest_dir.path().join(".well-known/stellar-history.json");
+    std::fs::remove_file(&wk_path).expect("delete .well-known");
 
-    // Repair with empty file list
-    run_repair(RepairConfig::new(&src_url, &dest_url).files(vec![]))
+    // Dry-run -> plan carrying well_known: Some(K).
+    let plan_path = dest_dir.path().join("plan.json");
+    run_repair(
+        RepairConfig::new(&src_url, &dest_url)
+            .dry_run()
+            .report(&plan_path),
+    )
+    .await
+    .expect("dry-run ok");
+    let plan = crate::report::read_from_path(&plan_path).unwrap();
+    let k = plan.section.well_known.expect("plan flags .well-known");
+
+    // Apply the plan — restoration sources .well-known from the plan's checkpoint.
+    run_repair(RepairConfig::new(&src_url, &dest_url).plan(plan))
         .await
-        .expect("Repair with empty list should succeed (no-op)");
+        .expect("plan apply ok");
 
-    // File should still be missing
+    // .well-known restored and equals history-K on dst.
+    assert!(wk_path.exists(), ".well-known restored");
+    let history_k = dest_dir
+        .path()
+        .join(history_format::checkpoint_path("history", k));
+    assert_eq!(
+        std::fs::read(&wk_path).unwrap(),
+        std::fs::read(&history_k).unwrap(),
+        ".well-known should be a copy of history-K"
+    );
     run_scan(ScanConfig::new(&dest_url))
         .await
-        .expect_err("Deleted file should still be missing");
+        .expect("scan passes after .well-known restored");
 }
 
 #[tokio::test]
-async fn test_repair_manual_nonexistent_source_file() {
+async fn test_repair_rejects_invalid_plan() {
     let (src_url, _dest_dir, dest_url) = mirror_testnet_small().await;
 
-    // Try to repair a file that doesn't exist in source
-    let result = run_repair(RepairConfig::new(&src_url, &dest_url).files(vec![
-        "ledger/00/00/00/ledger-nonexistent.xdr.gz".to_string(),
-    ]))
-    .await;
+    // 100 is not a checkpoint boundary -> into_failures rejects it.
+    let mut bad = crate::report::ArchiveReport::from_failures_and_summary(
+        &crate::utils::FailureTracker::default(),
+        crate::report::Summary::default(),
+    );
+    bad.section.checkpoints.push(100);
+
+    let result = run_repair(RepairConfig::new(&src_url, &dest_url).plan(bad)).await;
+    assert!(result.is_err(), "invalid plan should be rejected");
+}
+
+#[tokio::test]
+async fn test_repair_empty_plan_is_noop() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+    let deleted = delete_first_file(dest_dir.path(), "/ledger-");
+
+    let empty = crate::report::ArchiveReport::from_failures_and_summary(
+        &crate::utils::FailureTracker::default(),
+        crate::report::Summary::default(),
+    );
+    run_repair(RepairConfig::new(&src_url, &dest_url).plan(empty))
+        .await
+        .expect("empty plan is a no-op");
 
     assert!(
-        result.is_err(),
-        "Repair should fail for nonexistent source file"
+        !dest_dir.path().join(&deleted).exists(),
+        "empty plan must not repair anything"
     );
+}
+
+#[tokio::test]
+async fn test_repair_plan_unfetchable_file_fails() {
+    let (src_url, _dest_dir, dest_url) = mirror_testnet_small().await;
+
+    // A well-formed checkpoint boundary beyond the archive: the ledger file is
+    // absent in source, so applying the plan must fail.
+    let mut tracker = crate::utils::FailureTracker::default();
+    tracker.record_file(16383, crate::utils::FileFlags::LEDGER);
+    let plan = crate::report::ArchiveReport::from_failures_and_summary(
+        &tracker,
+        crate::report::Summary::default(),
+    );
+
+    let result = run_repair(RepairConfig::new(&src_url, &dest_url).plan(plan)).await;
+    assert!(result.is_err(), "plan with unfetchable file should fail");
 }
 
 //=============================================================================
@@ -661,26 +727,6 @@ async fn test_repair_dry_run_with_verify() {
     run_scan(ScanConfig::new(&dest_url).verify())
         .await
         .expect_err("Bucket should still be corrupt after dry run");
-}
-
-#[tokio::test]
-async fn test_repair_dry_run_manual_mode() {
-    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
-
-    let deleted = delete_first_file(dest_dir.path(), "/ledger-");
-
-    run_repair(
-        RepairConfig::new(&src_url, &dest_url)
-            .files(vec![deleted.clone()])
-            .dry_run(),
-    )
-    .await
-    .expect("Dry run manual mode should succeed");
-
-    assert!(
-        !dest_dir.path().join(&deleted).exists(),
-        "Dry run should not download anything"
-    );
 }
 
 //=============================================================================

--- a/src/tests/repair_op_test.rs
+++ b/src/tests/repair_op_test.rs
@@ -1189,7 +1189,7 @@ async fn test_file_retry_history_repair_fetches_history_and_referenced_buckets()
         .strip_prefix(dest_dir.path())
         .unwrap()
         .to_string_lossy()
-        .to_string();
+        .replace('\\', "/");
     let bucket_to_break = &bucket_abs[0];
     let bucket_relative = bucket_to_break
         .strip_prefix(dest_dir.path())
@@ -1244,7 +1244,7 @@ async fn test_file_retry_history_repair_with_intact_buckets() {
         .strip_prefix(dest_dir.path())
         .unwrap()
         .to_string_lossy()
-        .to_string();
+        .replace('\\', "/");
 
     // Break only the history file; leave buckets intact.
     std::fs::remove_file(&history_abs).expect("delete history");
@@ -1288,7 +1288,7 @@ async fn test_file_retry_history_repair_fails_when_referenced_bucket_unavailable
         .strip_prefix(dest_dir.path())
         .unwrap()
         .to_string_lossy()
-        .to_string();
+        .replace('\\', "/");
     let bucket_to_kill = &bucket_abs[0];
     let bucket_relative = bucket_to_kill
         .strip_prefix(dest_dir.path())
@@ -1351,7 +1351,7 @@ async fn test_file_retry_history_repair_corrupt_history_from_src() {
         .strip_prefix(dest_dir.path())
         .unwrap()
         .to_string_lossy()
-        .to_string();
+        .replace('\\', "/");
     let src_history = src_dir.path().join(&history_relative);
 
     // Corrupt src's history with junk text (won't parse as JSON).
@@ -1501,7 +1501,7 @@ async fn test_file_retry_keeps_history_when_cp_in_chain_retry() {
         .strip_prefix(dest_dir.path())
         .unwrap()
         .to_string_lossy()
-        .to_string();
+        .replace('\\', "/");
     let bucket_to_break = &bucket_abs[0];
 
     // Break the history file + one referenced bucket on dst.
@@ -1545,7 +1545,7 @@ async fn test_file_retry_skips_nonhistory_file_when_cp_in_chain_retry() {
         .strip_prefix(dest_dir.path())
         .unwrap()
         .to_string_lossy()
-        .to_string();
+        .replace('\\', "/");
 
     // Locate this checkpoint's ledger file.
     let ledger_files = get_files_by_pattern(dest_dir.path(), &format!("ledger-{cp:08x}"));
@@ -1558,7 +1558,7 @@ async fn test_file_retry_skips_nonhistory_file_when_cp_in_chain_retry() {
         .strip_prefix(dest_dir.path())
         .unwrap()
         .to_string_lossy()
-        .to_string();
+        .replace('\\', "/");
 
     // Break the history + ledger on dst (leave buckets intact).
     std::fs::remove_file(&history_abs).expect("delete history");

--- a/src/tests/repair_op_test.rs
+++ b/src/tests/repair_op_test.rs
@@ -1355,6 +1355,90 @@ async fn test_file_retry_history_repair_fetches_history_and_referenced_buckets()
     );
 }
 
+/// A bucket listed directly in `failures.buckets` AND referenced by a failed
+/// HISTORY must be fetched from source exactly once during file-retry — the
+/// direct work item and the HISTORY-discovered sighting must share the bucket
+/// scheduling gate. Counts GET requests only (HEAD probes are irrelevant).
+#[tokio::test]
+async fn test_file_retry_dedupes_bucket_listed_directly_and_via_history() {
+    use super::utils::{start_http_server_with_app, RequestTracker};
+    use axum::{
+        body::Body,
+        http::{Method, Request, StatusCode},
+        response::IntoResponse,
+        routing::any,
+        Router,
+    };
+    use tower::util::ServiceExt;
+    use tower_http::services::ServeDir;
+
+    // Separate src and dst archives (both full copies of testnet-small).
+    let src_dir = TempDir::new().unwrap();
+    copy_testnet_small_archive(src_dir.path()).expect("copy src archive");
+    let dst_dir = TempDir::new().unwrap();
+    copy_testnet_small_archive(dst_dir.path()).expect("copy dst archive");
+
+    // Pick a HISTORY file and one bucket it references.
+    let (history_abs, cp, _hashes, bucket_abs) = pick_history_with_buckets(dst_dir.path());
+    let history_relative = history_abs
+        .strip_prefix(dst_dir.path())
+        .unwrap()
+        .to_string_lossy()
+        .replace('\\', "/");
+    let bucket_relative = bucket_abs[0]
+        .strip_prefix(dst_dir.path())
+        .unwrap()
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    // Break both on dst so the retry must fetch them from source.
+    std::fs::remove_file(&history_abs).expect("delete dst history");
+    std::fs::remove_file(&bucket_abs[0]).expect("delete dst bucket");
+
+    // Serve src over HTTP, counting GET requests per path.
+    let tracker = RequestTracker::new();
+    let tracker_for_app = tracker.clone();
+    let serve = ServeDir::new(src_dir.path());
+    let app = Router::new().fallback(any(move |req: Request<Body>| {
+        let serve = serve.clone();
+        let tracker = tracker_for_app.clone();
+        async move {
+            if req.method() == Method::GET {
+                tracker.increment(req.uri().path().trim_start_matches('/'));
+            }
+            match serve.oneshot(req).await {
+                Ok(resp) => resp.into_response(),
+                Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+            }
+        }
+    }));
+    let (src_url, _handle) = start_http_server_with_app(app).await;
+    let dst_url = file_url_from_path(dst_dir.path());
+
+    // Plan lists BOTH the failed HISTORY and the same bucket directly.
+    let op = build_repair_op(&src_url, &dst_url, /*verify=*/ false);
+    let parent_stats = crate::utils::ArchiveStats::new();
+    parent_stats.record_failure(cp, &history_relative).await;
+    parent_stats.record_failure(0, &bucket_relative).await;
+
+    let stats = op.retry_failed_files(&parent_stats).await;
+
+    // The chosen bucket must have been GETed from source exactly once.
+    let counts = tracker.get_counts();
+    let bucket_gets = counts.get(&bucket_relative).copied().unwrap_or(0);
+    assert_eq!(
+        bucket_gets, 1,
+        "bucket listed directly AND via HISTORY must be fetched once; counts={counts:?}"
+    );
+
+    // Both files restored; retry stats clean.
+    assert!(history_abs.exists(), "history restored");
+    assert!(bucket_abs[0].exists(), "bucket restored");
+    let f = stats.failures.lock().await;
+    assert!(!f.files.contains_key(&cp), "HISTORY flag cleared");
+    assert!(f.buckets.is_empty(), "no bucket failures remain");
+}
+
 /// History was failed (manually marked) but its referenced buckets are already
 /// present and valid in dst. The HISTORY-retry path re-fetches the history file,
 /// then probes each discovered bucket dst-first and finds them valid — so they

--- a/src/tests/repair_op_test.rs
+++ b/src/tests/repair_op_test.rs
@@ -1058,6 +1058,7 @@ fn build_repair_op(
     let pipeline_config = crate::pipeline::PipelineConfig {
         concurrency: 4,
         skip_optional: false,
+        skip_history_and_buckets: false,
         verify,
         storage_config,
     };
@@ -1150,7 +1151,7 @@ async fn test_file_retry_history_repair_fetches_history_and_referenced_buckets()
     let parent_stats = crate::utils::ArchiveStats::new();
     parent_stats.record_failure(cp, &history_relative).await;
 
-    // Drive phase 1 in isolation.
+    // Drive `retry_failed_files` in isolation.
     let stats = op.retry_failed_files(&parent_stats).await;
 
     // History file is back.
@@ -1177,7 +1178,7 @@ async fn test_file_retry_history_repair_fetches_history_and_referenced_buckets()
 /// (mirror has no dst-first probe), which is wasted but correct work —
 /// `verify_and_write_bucket` hashes-verifies the new content before
 /// commit, so the buckets remain valid. End state: history restored, all
-/// buckets present and valid, phase 1 stats clean.
+/// buckets present and valid, `retry_failed_files` stats clean.
 #[tokio::test]
 async fn test_file_retry_history_repair_with_intact_buckets() {
     let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
@@ -1240,12 +1241,13 @@ async fn test_file_retry_history_repair_fails_when_referenced_bucket_unavailable
         .to_string();
     let hash_to_kill = hashes.iter().next().unwrap();
 
-    // Delete the bucket from BOTH src and dst — phase 1 will try src and fail.
+    // Delete the bucket from BOTH src and dst — `retry_failed_files` will
+    // try src and fail.
     let src_bucket_files = get_files_by_pattern(src_dir.path(), &format!("bucket-{hash_to_kill}"));
     assert!(!src_bucket_files.is_empty());
     std::fs::remove_file(&src_bucket_files[0]).expect("delete src bucket");
     std::fs::remove_file(bucket_to_kill).expect("delete dst bucket");
-    // Also delete dst's history so it's a phase 1 work item.
+    // Also delete dst's history so it's a `retry_failed_files` work item.
     std::fs::remove_file(&history_abs).expect("delete dst history");
 
     let op = build_repair_op(&src_url, &dest_url, /*verify=*/ true);
@@ -1298,7 +1300,7 @@ async fn test_file_retry_history_repair_corrupt_history_from_src() {
 
     // Corrupt src's history with junk text (won't parse as JSON).
     std::fs::write(&src_history, b"not valid json at all {").expect("write corrupt src history");
-    // Pre-remove dst's history so phase 1 has to fetch.
+    // Pre-remove dst's history so `retry_failed_files` has to fetch.
     std::fs::remove_file(&history_abs).expect("delete dst history");
 
     let op = build_repair_op(&src_url, &dest_url, /*verify=*/ true);
@@ -1312,12 +1314,12 @@ async fn test_file_retry_history_repair_corrupt_history_from_src() {
         "dst history should not be overwritten with corrupt src content"
     );
 
-    // HISTORY flag stays in stats because phase 1 failed.
+    // HISTORY flag stays in stats because `retry_failed_files` failed.
     let f = stats.failures.lock().await;
     let flags = f
         .files
         .get(&cp)
-        .expect("HISTORY flag should remain in stats after a failed phase 1 repair");
+        .expect("HISTORY flag should remain in stats after a failed retry_failed_files repair");
     assert!(flags.has(crate::utils::FileFlags::HISTORY));
     // No buckets touched (we never got past parse).
     assert!(f.buckets.is_empty());

--- a/src/tests/repair_op_test.rs
+++ b/src/tests/repair_op_test.rs
@@ -4,8 +4,8 @@
 //! manual mode, dry run, error handling, idempotency, and CLI validation.
 
 use super::utils::{
-    copy_testnet_small_archive, file_url_from_path, get_files_by_pattern, start_http_server,
-    testnet_small_archive_path,
+    copy_testnet_small_archive, corrupt_ledger_cross_file_hash, file_url_from_path,
+    get_files_by_pattern, start_http_server, testnet_small_archive_path,
 };
 use crate::history_format;
 use crate::test_helpers::{
@@ -1052,6 +1052,16 @@ fn build_repair_op(
     dst_url: &str,
     verify: bool,
 ) -> crate::repair_operation::RepairOperation {
+    build_repair_op_full(src_url, dst_url, verify, /*dry_run=*/ false)
+}
+
+/// Like [`build_repair_op`], but with an explicit `dry_run` flag.
+fn build_repair_op_full(
+    src_url: &str,
+    dst_url: &str,
+    verify: bool,
+    dry_run: bool,
+) -> crate::repair_operation::RepairOperation {
     let storage_config = crate::test_helpers::test_storage_config();
     let src_store = crate::storage::from_url_with_config(src_url, &storage_config).unwrap();
     let dst_store = crate::storage::from_url_with_config(dst_url, &storage_config).unwrap();
@@ -1067,7 +1077,7 @@ fn build_repair_op(
         dst_store,
         /*low=*/ None,
         /*high=*/ None,
-        /*dry_run=*/ false,
+        dry_run,
         pipeline_config,
     )
 }
@@ -1785,4 +1795,90 @@ async fn test_repair_dry_run_with_verify_leaves_corrupt_history_untouched() {
     run_scan(ScanConfig::new(&dest_url).verify())
         .await
         .expect_err("history should still be corrupt after dry-run");
+}
+
+/// Dry-run + verify must account for cross-file/chain failures, not just the
+/// per-file dst probe. A ledger file is made wrong-but-well-formed: every entry
+/// parses and self-hashes correctly (so the dst probe accepts it and nothing is
+/// added to `needs_repair_count`), but its tx-set hash no longer matches the
+/// transactions file. That mismatch lands in the manager's checkpoint-level
+/// tracker — which `finalize`'s dry-run summary now reports — and a real run
+/// would re-fetch the checkpoint in the checkpoint-retry stage. Dry-run must not
+/// write.
+#[tokio::test]
+async fn test_repair_dry_run_verify_surfaces_cross_file_failure() {
+    use crate::pipeline::{Operation, Pipeline, PipelineConfig};
+
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    // Pick a non-genesis ledger file and break its tx-set hash cross-file.
+    let (ledger_abs, cp) = get_files_by_pattern(dest_dir.path(), "/ledger-")
+        .iter()
+        .filter_map(|p| {
+            let rel = p
+                .strip_prefix(dest_dir.path())
+                .unwrap()
+                .to_string_lossy()
+                .replace('\\', "/");
+            history_format::checkpoint_from_path(&rel).map(|c| (p.clone(), c))
+        })
+        .find(|(_, c)| *c != history_format::GENESIS_CHECKPOINT_LEDGER)
+        .expect("need a non-genesis ledger file");
+
+    corrupt_ledger_cross_file_hash(&ledger_abs, "tx_set");
+    let corrupted_bytes = std::fs::read(&ledger_abs).unwrap();
+
+    let storage_config = crate::test_helpers::test_storage_config();
+    let src_store = crate::storage::from_url_with_config(&src_url, &storage_config).unwrap();
+    let dst_store = crate::storage::from_url_with_config(&dest_url, &storage_config).unwrap();
+
+    let op = build_repair_op_full(
+        &src_url, &dest_url, /*verify=*/ true, /*dry_run=*/ true,
+    );
+    let (low, high) = op
+        .get_checkpoint_bounds(&src_store)
+        .await
+        .expect("bounds from dst .well-known");
+
+    let config = PipelineConfig {
+        concurrency: 4,
+        skip_optional: false,
+        skip_history_and_buckets: false,
+        verify: true,
+        storage_config,
+    };
+    let pipeline = Pipeline::new(op, config, src_store, Some(dst_store));
+    let cps = (low..=high).step_by(history_format::CHECKPOINT_FREQUENCY as usize);
+    pipeline
+        .run_checkpoints(cps)
+        .await
+        .expect("run_checkpoints");
+
+    {
+        let f = pipeline.stats().failures.lock().await;
+        assert!(
+            f.checkpoints.contains(&cp),
+            "cross-file failure for checkpoint {cp} should be tracked at checkpoint level"
+        );
+        // The well-formed ledger was accepted by the per-file probe, so it is
+        // NOT recorded as a per-file failure — this is exactly why the per-file
+        // count alone misses it.
+        assert!(
+            f.files
+                .get(&cp)
+                .is_none_or(|flags| !flags.has(crate::utils::FileFlags::LEDGER)),
+            "wrong-but-well-formed ledger must not be recorded as a per-file failure"
+        );
+    }
+
+    pipeline
+        .finish(high)
+        .await
+        .expect("dry-run finalize should return Ok");
+
+    assert_eq!(
+        std::fs::read(&ledger_abs).unwrap(),
+        corrupted_bytes,
+        "dry-run must not modify dst"
+    );
 }

--- a/src/tests/repair_op_test.rs
+++ b/src/tests/repair_op_test.rs
@@ -1391,7 +1391,7 @@ async fn test_well_known_restored_after_history_retry() {
     let parent_stats = crate::utils::ArchiveStats::new();
     parent_stats.record_failure(k, &history_rel).await;
 
-    op.finalize(k, &parent_stats)
+    op.finalize(k, &parent_stats, None)
         .await
         .expect("finalize should succeed once history-K is restored by retry");
 
@@ -1847,7 +1847,7 @@ async fn test_repair_dry_run_verify_surfaces_cross_file_failure() {
         verify: true,
         storage_config,
     };
-    let pipeline = Pipeline::new(op, config, src_store, Some(dst_store));
+    let pipeline = Pipeline::new(op, config, src_store, Some(dst_store), None);
     let cps = (low..=high).step_by(history_format::CHECKPOINT_FREQUENCY as usize);
     pipeline
         .run_checkpoints(cps)
@@ -1881,4 +1881,140 @@ async fn test_repair_dry_run_verify_surfaces_cross_file_failure() {
         corrupted_bytes,
         "dry-run must not modify dst"
     );
+}
+
+#[tokio::test]
+async fn test_repair_dry_run_report_lists_inventory() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    // Damage: delete a ledger, corrupt a bucket, delete .well-known.
+    let deleted_ledger = delete_first_file(dest_dir.path(), "/ledger-");
+    corrupt_bucket_invalid_gzip(dest_dir.path());
+    std::fs::remove_file(dest_dir.path().join(".well-known/stellar-history.json"))
+        .expect("delete .well-known");
+
+    let report_path = dest_dir.path().join("plan.json");
+    crate::test_helpers::run_repair(
+        crate::test_helpers::RepairConfig::new(&src_url, &dest_url)
+            .verify()
+            .dry_run()
+            .report(&report_path),
+    )
+    .await
+    .expect("dry-run should return Ok");
+
+    let report = crate::report::read_from_path(&report_path).unwrap();
+    assert!(
+        report.section.well_known.is_some(),
+        "missing .well-known should be in the plan"
+    );
+
+    let ledger_cp = history_format::checkpoint_from_path(&deleted_ledger).unwrap();
+    let listed = report
+        .section
+        .files
+        .get(&ledger_cp.to_string())
+        .is_some_and(|types| types.iter().any(|t| t == "ledger"));
+    assert!(
+        listed,
+        "deleted ledger should be in the plan: {:?}",
+        report.section.files
+    );
+    assert!(
+        !report.section.buckets.is_empty(),
+        "corrupt bucket should be in the plan"
+    );
+
+    // Dry-run must not modify dst: the deleted ledger is still gone.
+    assert!(
+        !dest_dir.path().join(&deleted_ledger).exists(),
+        "dry-run must not write to dst"
+    );
+}
+
+#[tokio::test]
+async fn test_repair_dry_run_well_known_records_high_checkpoint() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    // Break only the dst .well-known; everything else stays intact.
+    std::fs::remove_file(dest_dir.path().join(".well-known/stellar-history.json"))
+        .expect("delete .well-known");
+
+    let report_path = dest_dir.path().join("plan.json");
+    crate::test_helpers::run_repair(
+        RepairConfig::new(&src_url, &dest_url)
+            .dry_run()
+            .report(&report_path),
+    )
+    .await
+    .expect("dry-run should return Ok");
+
+    // The plan must carry the checkpoint to restore .well-known from — the
+    // archive's highest checkpoint, sourced from the (canonical) source archive.
+    let src_wk = std::fs::read_to_string(
+        testnet_small_archive_path().join(".well-known/stellar-history.json"),
+    )
+    .unwrap();
+    let src_current_ledger = serde_json::from_str::<serde_json::Value>(&src_wk).unwrap()
+        ["currentLedger"]
+        .as_u64()
+        .unwrap() as u32;
+    let expected_k = history_format::round_to_lower_checkpoint(src_current_ledger);
+
+    let report = crate::report::read_from_path(&report_path).unwrap();
+    assert_eq!(
+        report.section.well_known,
+        Some(expected_k),
+        "plan must record the archive's high checkpoint for .well-known"
+    );
+}
+
+#[tokio::test]
+async fn test_repair_dry_run_well_known_none_when_healthy() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    let report_path = dest_dir.path().join("plan.json");
+    crate::test_helpers::run_repair(
+        RepairConfig::new(&src_url, &dest_url)
+            .dry_run()
+            .report(&report_path),
+    )
+    .await
+    .expect("dry-run should return Ok");
+
+    let report = crate::report::read_from_path(&report_path).unwrap();
+    assert_eq!(
+        report.section.well_known, None,
+        "healthy .well-known must not be flagged"
+    );
+}
+
+#[tokio::test]
+async fn test_repair_report_three_sections_clean_on_success() {
+    use crate::report::MultiSectionReport;
+
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+    delete_first_file(dest_dir.path(), "/ledger-");
+
+    let report_path = dest_dir.path().join("done.json");
+    crate::test_helpers::run_repair(
+        crate::test_helpers::RepairConfig::new(&src_url, &dest_url)
+            .verify()
+            .report(&report_path),
+    )
+    .await
+    .expect("repair should succeed");
+
+    let json = std::fs::read_to_string(&report_path).unwrap();
+    let report: MultiSectionReport =
+        serde_json::from_str(&json).expect("multi-section report parses");
+    assert!(report.sections.contains_key("main_pass"));
+
+    // Retry stages cleared everything they attempted: empty bodies, no failures.
+    let fr = &report.sections["file_retry"];
+    let cr = &report.sections["checkpoint_retry"];
+    assert_eq!(fr.summary.failed, 0);
+    assert_eq!(cr.summary.failed, 0);
+    assert!(fr.files.is_empty() && fr.buckets.is_empty());
+    assert!(cr.checkpoints.is_empty());
 }

--- a/src/tests/repair_op_test.rs
+++ b/src/tests/repair_op_test.rs
@@ -2064,3 +2064,69 @@ async fn test_repair_report_three_sections_clean_on_success() {
     assert!(fr.files.is_empty() && fr.buckets.is_empty());
     assert!(cr.checkpoints.is_empty());
 }
+
+/// A non-dry-run repair whose `.well-known` restoration FAILS must surface that
+/// residual in the report — not just via the exit code. The run exits
+/// `RepairFailed`, but a consumer reading `--report` would otherwise see every
+/// section clean (`well_known: null`, `failed: 0`) with no indication of what
+/// broke. The failed restoration is recorded into the `file_retry` section.
+#[tokio::test]
+async fn test_repair_report_surfaces_failed_well_known_restoration() {
+    use crate::report::MultiSectionReport;
+
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    // Replace .well-known with a directory: discovery flags it for repair, and
+    // the restoring copy in finalize fails because its destination is a dir.
+    let wk_path = dest_dir.path().join(".well-known/stellar-history.json");
+    std::fs::remove_file(&wk_path).expect("delete .well-known file");
+    std::fs::create_dir(&wk_path).expect("create .well-known directory");
+
+    let report_path = dest_dir.path().join("report.json");
+    let result = run_repair(RepairConfig::new(&src_url, &dest_url).report(&report_path)).await;
+    assert!(
+        result.is_err(),
+        "repair must fail when .well-known restoration copy fails"
+    );
+
+    let json = std::fs::read_to_string(&report_path).unwrap();
+    let report: MultiSectionReport =
+        serde_json::from_str(&json).expect("multi-section report parses");
+    assert!(
+        report.sections["file_retry"].well_known.is_some(),
+        "a failed .well-known restoration must be surfaced in the report, got: {json}"
+    );
+}
+
+/// A non-dry-run repair that discovers a broken `.well-known` and successfully
+/// restores it must reflect that discovery in the `main_pass` section (parity
+/// with the dry-run plan, which already carries `well_known`), while the retry
+/// sections stay clean because there is no residual.
+#[tokio::test]
+async fn test_repair_report_records_well_known_discovery_in_main_pass() {
+    use crate::report::MultiSectionReport;
+
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    // Break only the dst .well-known; everything else is intact, so restoration
+    // succeeds.
+    std::fs::remove_file(dest_dir.path().join(".well-known/stellar-history.json"))
+        .expect("delete .well-known");
+
+    let report_path = dest_dir.path().join("report.json");
+    run_repair(RepairConfig::new(&src_url, &dest_url).report(&report_path))
+        .await
+        .expect("repair should succeed once .well-known is restored");
+
+    let json = std::fs::read_to_string(&report_path).unwrap();
+    let report: MultiSectionReport =
+        serde_json::from_str(&json).expect("multi-section report parses");
+
+    assert!(
+        report.sections["main_pass"].well_known.is_some(),
+        "main_pass should record the discovered .well-known break, got: {json}"
+    );
+    // Restoration succeeded → no residual in the retry sections.
+    assert!(report.sections["file_retry"].well_known.is_none());
+    assert!(report.sections["checkpoint_retry"].well_known.is_none());
+}

--- a/src/tests/repair_op_test.rs
+++ b/src/tests/repair_op_test.rs
@@ -1324,3 +1324,465 @@ async fn test_file_retry_history_repair_corrupt_history_from_src() {
     // No buckets touched (we never got past parse).
     assert!(f.buckets.is_empty());
 }
+
+//=============================================================================
+// N. .well-known restoration ordering — restoration copies the highest
+// checkpoint's history file, which the file-retry stage may itself be what
+// restores. Restoration must therefore run after the retry stages.
+//=============================================================================
+
+/// Reproduces the ordering hazard: dst `.well-known` is missing AND the
+/// highest-checkpoint history file was not present after the main pass (as if
+/// its main-pass fetch failed), so it is only restored by the file-retry
+/// stage. Because `.well-known` is restored from that history file, restoration
+/// must run after the retry stage — otherwise it copies from an absent file,
+/// logs an error, and silently leaves `.well-known` missing while repair still
+/// reports success.
+#[tokio::test]
+async fn test_well_known_restored_after_history_retry() {
+    use crate::pipeline::Operation;
+
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    // K = highest checkpoint present on dst; its history file drives .well-known.
+    let (k, history_rel) = get_files_by_pattern(dest_dir.path(), "/history-")
+        .iter()
+        .filter(|p| !p.to_string_lossy().contains(".well-known"))
+        .filter_map(|p| {
+            let rel = p
+                .strip_prefix(dest_dir.path())
+                .unwrap()
+                .to_string_lossy()
+                .replace('\\', "/");
+            history_format::checkpoint_from_path(&rel).map(|cp| (cp, rel))
+        })
+        .max_by_key(|(cp, _)| *cp)
+        .expect("need a non-well-known history file");
+
+    // Broken main-pass state: dst .well-known missing (so get_checkpoint_bounds
+    // flags it for repair) and dst history-K missing (as if its main-pass fetch
+    // failed and only the retry stage can restore it).
+    std::fs::remove_file(dest_dir.path().join(".well-known/stellar-history.json"))
+        .expect("delete .well-known");
+    std::fs::remove_file(dest_dir.path().join(&history_rel)).expect("delete history-K");
+
+    let op = build_repair_op(&src_url, &dest_url, /*verify=*/ true);
+
+    // Observe the missing dst .well-known so the needs-repair flag is set.
+    let src_store =
+        crate::storage::from_url_with_config(&src_url, &crate::test_helpers::test_storage_config())
+            .unwrap();
+    op.get_checkpoint_bounds(&src_store)
+        .await
+        .expect("bounds via src fallback");
+
+    // Simulate the main pass having recorded a HISTORY failure for K — this is
+    // the entry the retry stage acts on to restore history-K.
+    let parent_stats = crate::utils::ArchiveStats::new();
+    parent_stats.record_failure(k, &history_rel).await;
+
+    op.finalize(k, &parent_stats)
+        .await
+        .expect("finalize should succeed once history-K is restored by retry");
+
+    let wk = dest_dir.path().join(".well-known/stellar-history.json");
+    assert!(
+        wk.exists(),
+        ".well-known should be restored after the retry stage repairs history-K"
+    );
+    let wk_bytes = std::fs::read(&wk).unwrap();
+    let history_bytes = std::fs::read(dest_dir.path().join(&history_rel)).unwrap();
+    assert_eq!(
+        wk_bytes, history_bytes,
+        ".well-known must equal the repaired history-K byte-for-byte"
+    );
+}
+
+/// A `.well-known` restoration that fails for a reason other than a missing
+/// history file (here: the destination path is a directory, so the copy
+/// errors) must fail the run rather than reporting success with `.well-known`
+/// still broken. The highest history file stays healthy on dst, so this
+/// failure is NOT visible through the retry stages' stats — repair must surface
+/// it on its own.
+#[tokio::test]
+async fn test_repair_fails_when_well_known_restore_copy_fails() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    // Replace the .well-known file with a directory at the same path. The read
+    // in get_checkpoint_bounds fails (flagging .well-known for repair), every
+    // history file remains intact, and the restoring copy in finalize then
+    // fails because its destination is a directory.
+    let wk_path = dest_dir.path().join(".well-known/stellar-history.json");
+    std::fs::remove_file(&wk_path).expect("delete .well-known file");
+    std::fs::create_dir(&wk_path).expect("create .well-known directory");
+
+    let result = run_repair(RepairConfig::new(&src_url, &dest_url)).await;
+    assert!(
+        result.is_err(),
+        "repair must fail when .well-known restoration copy fails"
+    );
+}
+
+//=============================================================================
+// N. Two-stage retry partitioning — `build_failed_files_work_list` carve-out
+//
+// These exercise the load-bearing invariant of the two-stage retry design:
+// when a checkpoint is in BOTH `failures.files` and `failures.checkpoints`,
+// the file-retry stage keeps the HISTORY entry (it owns bucket discovery) but
+// drops non-HISTORY per-cp files (the checkpoint-retry stage re-mirrors those).
+//=============================================================================
+
+/// HISTORY carve-out: a checkpoint with a HISTORY failure in `failures.files`
+/// that is ALSO flagged in `failures.checkpoints` must still have its history
+/// file re-fetched (and its bucket refs walked) by the file-retry stage, not
+/// deferred entirely to the checkpoint-retry stage.
+#[tokio::test]
+async fn test_file_retry_keeps_history_when_cp_in_chain_retry() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    let (history_abs, cp, _hashes, bucket_abs) = pick_history_with_buckets(dest_dir.path());
+    let history_relative = history_abs
+        .strip_prefix(dest_dir.path())
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+    let bucket_to_break = &bucket_abs[0];
+
+    // Break the history file + one referenced bucket on dst.
+    std::fs::remove_file(&history_abs).expect("delete history");
+    std::fs::remove_file(bucket_to_break).expect("delete bucket");
+
+    // Simulate a main pass that recorded BOTH a HISTORY file failure AND a
+    // chain failure for the same checkpoint.
+    let op = build_repair_op(&src_url, &dest_url, /*verify=*/ true);
+    let parent_stats = crate::utils::ArchiveStats::new();
+    parent_stats.record_failure(cp, &history_relative).await;
+    {
+        let mut f = parent_stats.failures.lock().await;
+        f.record_checkpoint(cp);
+    }
+
+    let _stats = op.retry_failed_files(&parent_stats).await;
+
+    // Despite cp being in the chain-retry set, the file-retry stage repaired
+    // the history file and walked its bucket refs.
+    assert!(
+        history_abs.exists(),
+        "history must be repaired even though cp is in the chain-retry set"
+    );
+    assert!(
+        bucket_to_break.exists(),
+        "the referenced bucket must be repaired via the HISTORY bucket-walk"
+    );
+}
+
+/// Non-HISTORY carve-out: a checkpoint with a non-HISTORY per-cp file failure
+/// (LEDGER here) that is ALSO in `failures.checkpoints` must have that file
+/// SKIPPED by the file-retry stage — the checkpoint-retry stage re-mirrors the
+/// whole cp instead. Only the HISTORY entry survives the carve-out.
+#[tokio::test]
+async fn test_file_retry_skips_nonhistory_file_when_cp_in_chain_retry() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    let (history_abs, cp, _hashes, _bucket_abs) = pick_history_with_buckets(dest_dir.path());
+    let history_relative = history_abs
+        .strip_prefix(dest_dir.path())
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+
+    // Locate this checkpoint's ledger file.
+    let ledger_files = get_files_by_pattern(dest_dir.path(), &format!("ledger-{cp:08x}"));
+    assert!(
+        !ledger_files.is_empty(),
+        "cp {cp} should have a ledger file"
+    );
+    let ledger_abs = ledger_files[0].clone();
+    let ledger_relative = ledger_abs
+        .strip_prefix(dest_dir.path())
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+
+    // Break the history + ledger on dst (leave buckets intact).
+    std::fs::remove_file(&history_abs).expect("delete history");
+    std::fs::remove_file(&ledger_abs).expect("delete ledger");
+
+    let op = build_repair_op(&src_url, &dest_url, /*verify=*/ true);
+    let parent_stats = crate::utils::ArchiveStats::new();
+    parent_stats.record_failure(cp, &history_relative).await;
+    parent_stats.record_failure(cp, &ledger_relative).await;
+    {
+        let mut f = parent_stats.failures.lock().await;
+        f.record_checkpoint(cp);
+    }
+
+    let _stats = op.retry_failed_files(&parent_stats).await;
+
+    // HISTORY is repaired (carve-out keeps it)...
+    assert!(history_abs.exists(), "history must be repaired");
+    // ...but the LEDGER is left for the checkpoint-retry stage.
+    assert!(
+        !ledger_abs.exists(),
+        "ledger must be skipped by file-retry when its cp is in the chain-retry set"
+    );
+}
+
+/// Checkpoint-retry skips HAS + buckets: the cp-retry inner pipeline is built
+/// with `skip_history_and_buckets=true`, so re-mirroring a flagged checkpoint
+/// re-fetches its per-cp xdr files (ledger/tx/results/scp) but NOT the history
+/// file or any bucket. A bucket missing from dst stays missing after cp-retry.
+#[tokio::test]
+async fn test_checkpoint_retry_skips_buckets_and_has() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    let (_history_abs, cp, _hashes, bucket_abs) = pick_history_with_buckets(dest_dir.path());
+    let bucket_to_break = &bucket_abs[0];
+
+    let ledger_files = get_files_by_pattern(dest_dir.path(), &format!("ledger-{cp:08x}"));
+    assert!(
+        !ledger_files.is_empty(),
+        "cp {cp} should have a ledger file"
+    );
+    let ledger_abs = ledger_files[0].clone();
+
+    // Delete the cp's ledger (a per-cp xdr file) AND one referenced bucket.
+    std::fs::remove_file(&ledger_abs).expect("delete ledger");
+    std::fs::remove_file(bucket_to_break).expect("delete bucket");
+
+    // Only a chain/cross-file failure is recorded for cp — no per-file, no
+    // bucket. This routes the work exclusively through `retry_failed_checkpoints`.
+    let op = build_repair_op(&src_url, &dest_url, /*verify=*/ false);
+    let parent_stats = crate::utils::ArchiveStats::new();
+    {
+        let mut f = parent_stats.failures.lock().await;
+        f.record_checkpoint(cp);
+    }
+
+    let _stats = op.retry_failed_checkpoints(&parent_stats).await;
+
+    // The per-cp ledger was re-mirrored...
+    assert!(
+        ledger_abs.exists(),
+        "checkpoint-retry must re-fetch the per-cp ledger file"
+    );
+    // ...but the bucket was NOT (HAS + bucket work is skipped in cp-retry).
+    assert!(
+        !bucket_to_break.exists(),
+        "checkpoint-retry must skip bucket fetches (skip_history_and_buckets)"
+    );
+}
+
+//=============================================================================
+// O. Pure chain failure (no coinciding per-file failure)
+//=============================================================================
+
+/// Tamper a ledger file so it breaks the intra-checkpoint hash chain while
+/// every per-file self-hash still verifies. We bump an innocuous header field
+/// (`total_coins`) on the checkpoint's first ledger and recompute that entry's
+/// self-hash, so the file parses cleanly but the *next* ledger's
+/// `previous_ledger_hash` no longer matches the (now-changed) computed hash.
+/// Returns the affected checkpoint.
+fn tamper_ledger_break_chain(archive_path: &Path) -> u32 {
+    use flate2::read::GzDecoder;
+    use sha2::{Digest, Sha256};
+    use std::io::Read;
+    use stellar_xdr::curr::{
+        Frame, Hash, LedgerHeaderHistoryEntry, Limited, Limits, ReadXdr, WriteXdr,
+    };
+
+    let files = get_files_by_pattern(archive_path, "/ledger-");
+    assert!(!files.is_empty(), "no ledger files found");
+    let file = files[0].clone();
+    let relative = file
+        .strip_prefix(archive_path)
+        .unwrap()
+        .to_string_lossy()
+        .replace('\\', "/");
+    let cp =
+        history_format::checkpoint_from_path(&relative).expect("ledger path encodes a checkpoint");
+
+    // Decompress.
+    let compressed = std::fs::read(&file).unwrap();
+    let mut decoder = GzDecoder::new(&compressed[..]);
+    let mut decompressed = Vec::new();
+    decoder.read_to_end(&mut decompressed).unwrap();
+
+    // Parse every ledger-header entry, in file (ascending-seq) order.
+    let mut limited = Limited::new(std::io::Cursor::new(&decompressed[..]), Limits::none());
+    let mut entries: Vec<LedgerHeaderHistoryEntry> =
+        Frame::<LedgerHeaderHistoryEntry>::read_xdr_iter(&mut limited)
+            .map(|r| r.expect("parse ledger header entry").0)
+            .collect();
+    assert!(
+        entries.len() >= 2,
+        "need >= 2 ledgers for an intra-cp chain window"
+    );
+
+    // Mutate the first entry's header, then recompute its self-hash so the
+    // entry stays internally consistent (still passes the per-file hash check).
+    entries[0].header.total_coins = entries[0].header.total_coins.wrapping_add(1);
+    let header_xdr = entries[0].header.to_xdr(Limits::none()).unwrap();
+    entries[0].hash = Hash(Sha256::digest(&header_xdr).into());
+
+    // Re-encode with RFC 5531 record marking (high bit set + payload length).
+    let mut out = Vec::new();
+    for entry in &entries {
+        let payload = entry.to_xdr(Limits::none()).unwrap();
+        let marker = (payload.len() as u32 | 0x8000_0000).to_be_bytes();
+        out.extend_from_slice(&marker);
+        out.extend_from_slice(&payload);
+    }
+
+    // Recompress and write back.
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&out).unwrap();
+    std::fs::write(&file, encoder.finish().unwrap()).unwrap();
+
+    cp
+}
+
+/// A pure hash-chain failure: the ledger file is structurally valid and
+/// self-consistent (so existence-only scan AND per-file verification both
+/// pass), but the chain is broken. This exercises the `finalize` →
+/// `retry_failed_checkpoints` path for a checkpoint that appears ONLY in
+/// `failures.checkpoints` (no `failures.files` / `failures.buckets` entry) —
+/// the case no byte-corruption test can produce, since corruption also breaks
+/// the file's own self-hash.
+#[tokio::test]
+async fn test_repair_pure_chain_failure() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    tamper_ledger_break_chain(dest_dir.path());
+
+    // Existence-only scan passes: the file is present and structurally valid.
+    run_scan(ScanConfig::new(&dest_url))
+        .await
+        .expect("existence-only scan should pass (file is structurally valid)");
+
+    // Verifying scan fails: the hash chain is broken.
+    run_scan(ScanConfig::new(&dest_url).verify())
+        .await
+        .expect_err("verifying scan should detect the chain break");
+
+    // Repair (with verify) must fix it via the checkpoint-retry stage.
+    run_repair(RepairConfig::new(&src_url, &dest_url).verify())
+        .await
+        .expect("repair --verify should fix a pure chain failure");
+
+    run_scan(ScanConfig::new(&dest_url).verify())
+        .await
+        .expect("verifying scan should pass after repair");
+}
+
+//=============================================================================
+// P. .well-known bounds + restoration failure paths
+//=============================================================================
+
+/// Both src and dst `.well-known` unreadable → `get_checkpoint_bounds` has no
+/// way to determine the range and must return an error.
+#[tokio::test]
+async fn test_repair_both_well_known_unreadable_errors() {
+    use crate::pipeline::Operation;
+
+    let src_dir = TempDir::new().unwrap();
+    copy_testnet_small_archive(src_dir.path()).unwrap();
+    let src_url = file_url_from_path(src_dir.path());
+    let dest_dir = TempDir::new().unwrap();
+    let dest_url = file_url_from_path(dest_dir.path());
+    run_mirror(MirrorConfig::new(&src_url, &dest_url))
+        .await
+        .expect("mirror should succeed");
+
+    std::fs::remove_file(src_dir.path().join(".well-known/stellar-history.json")).unwrap();
+    std::fs::remove_file(dest_dir.path().join(".well-known/stellar-history.json")).unwrap();
+
+    let op = build_repair_op(&src_url, &dest_url, /*verify=*/ false);
+    let src_store =
+        crate::storage::from_url_with_config(&src_url, &crate::test_helpers::test_storage_config())
+            .unwrap();
+    let result = op.get_checkpoint_bounds(&src_store).await;
+    assert!(
+        result.is_err(),
+        "get_checkpoint_bounds must error when both .well-known are unreadable"
+    );
+}
+
+/// `repair_well_known` failure path: when the highest checkpoint's history file
+/// is itself unrecoverable (missing from both src and dst), repair must NOT
+/// fabricate a `.well-known` from a history file it could not restore.
+#[tokio::test]
+async fn test_repair_well_known_not_restored_when_history_missing() {
+    let src_dir = TempDir::new().unwrap();
+    copy_testnet_small_archive(src_dir.path()).unwrap();
+    let src_url = file_url_from_path(src_dir.path());
+    let dest_dir = TempDir::new().unwrap();
+    let dest_url = file_url_from_path(dest_dir.path());
+    run_mirror(MirrorConfig::new(&src_url, &dest_url))
+        .await
+        .expect("mirror should succeed");
+
+    // Determine the highest checkpoint (the one repair_well_known copies from).
+    let wk =
+        std::fs::read_to_string(src_dir.path().join(".well-known/stellar-history.json")).unwrap();
+    let state: history_format::HistoryFileState = serde_json::from_str(&wk).unwrap();
+    let highest_cp = history_format::round_to_lower_checkpoint(state.current_ledger);
+    let history_rel = history_format::checkpoint_path("history", highest_cp);
+
+    // Make the highest history file unavailable in BOTH src and dst, and drop
+    // dst's .well-known so repair attempts to restore it.
+    std::fs::remove_file(src_dir.path().join(&history_rel)).expect("rm src history");
+    std::fs::remove_file(dest_dir.path().join(&history_rel)).expect("rm dst history");
+    std::fs::remove_file(dest_dir.path().join(".well-known/stellar-history.json"))
+        .expect("rm dst .well-known");
+
+    // Repair fails (highest history unrecoverable) and must not restore
+    // .well-known from a history file it couldn't repair.
+    let result = run_repair(RepairConfig::new(&src_url, &dest_url)).await;
+    assert!(
+        result.is_err(),
+        "repair should fail when the highest history file is unrecoverable"
+    );
+    assert!(
+        !dest_dir
+            .path()
+            .join(".well-known/stellar-history.json")
+            .exists(),
+        ".well-known must not be restored when its source history file is missing"
+    );
+}
+
+//=============================================================================
+// Q. Dry-run write suppression with --verify (corrupt history left untouched)
+//=============================================================================
+
+/// Dry-run + verify must detect a corrupt history file but leave it untouched
+/// on dst (the pipeline used to write the src buffer back via `process_buffer`
+/// even in dry-run). Complements `test_repair_dry_run_with_verify`, which only
+/// covered a corrupt bucket.
+#[tokio::test]
+async fn test_repair_dry_run_with_verify_leaves_corrupt_history_untouched() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    let history_files: Vec<_> = get_files_by_pattern(dest_dir.path(), "/history-")
+        .into_iter()
+        .filter(|p| !p.to_string_lossy().contains(".well-known"))
+        .collect();
+    assert!(!history_files.is_empty());
+    let corrupt_content: &[u8] = b"{ not valid history json }}";
+    std::fs::write(&history_files[0], corrupt_content).unwrap();
+
+    run_repair(RepairConfig::new(&src_url, &dest_url).verify().dry_run())
+        .await
+        .expect("dry-run + verify should succeed");
+
+    assert_eq!(
+        std::fs::read(&history_files[0]).unwrap(),
+        corrupt_content,
+        "dry-run + verify must not overwrite a corrupt history file"
+    );
+
+    run_scan(ScanConfig::new(&dest_url).verify())
+        .await
+        .expect_err("history should still be corrupt after dry-run");
+}

--- a/src/tests/repair_op_test.rs
+++ b/src/tests/repair_op_test.rs
@@ -667,8 +667,8 @@ async fn test_repair_dry_run_reports_but_no_download() {
     let deleted = delete_first_file(dest_dir.path(), "/ledger-");
 
     // History files: dry-run must not write history-*.json regardless of
-    // whether dst is missing or corrupt (Pipeline used to write the src
-    // buffer back via process_buffer even in dry-run).
+    // whether dst is missing or corrupt. process_history returns NeedsRepair
+    // (no source fetch, no write) under dry-run.
     let history_files = get_files_by_pattern(dest_dir.path(), "/history-");
     assert!(
         history_files.len() >= 2,
@@ -784,6 +784,133 @@ async fn test_repair_preserves_good_files() {
         good_file_mtime, after_mtime,
         "Good files should not be modified by repair"
     );
+}
+
+#[tokio::test]
+async fn test_repair_preserves_healthy_history_file() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    // Record mtime of a healthy per-checkpoint history file (exclude .well-known).
+    let history_files: Vec<_> = get_files_by_pattern(dest_dir.path(), "/history-")
+        .into_iter()
+        .filter(|p| !p.to_string_lossy().contains(".well-known"))
+        .collect();
+    assert!(!history_files.is_empty(), "need a per-checkpoint history file");
+    let history_file = history_files[0].clone();
+    let before = std::fs::metadata(&history_file).unwrap().modified().unwrap();
+
+    // Sleep so mtime would differ if the file were rewritten.
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Trigger a real repair by deleting an unrelated file.
+    delete_first_file(dest_dir.path(), "/ledger-");
+    run_repair(RepairConfig::new(&src_url, &dest_url))
+        .await
+        .expect("Repair should succeed");
+
+    let after = std::fs::metadata(&history_file).unwrap().modified().unwrap();
+    assert_eq!(
+        before, after,
+        "healthy history file must not be rewritten by repair"
+    );
+
+    run_scan(ScanConfig::new(&dest_url))
+        .await
+        .expect("Scan should pass after repair");
+}
+
+#[tokio::test]
+async fn test_repair_phase1_refetches_listed_history_from_source() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    // Two per-checkpoint history files: one to LIST + tamper, one healthy + UNLISTED.
+    let history_files: Vec<_> = get_files_by_pattern(dest_dir.path(), "/history-")
+        .into_iter()
+        .filter(|p| !p.to_string_lossy().contains(".well-known"))
+        .collect();
+    assert!(history_files.len() >= 2, "need at least two history files");
+    let listed_file = history_files[0].clone();
+    let unlisted_file = history_files[1].clone();
+
+    // Derive the listed file's checkpoint from its (dst-relative) path.
+    let listed_rel = listed_file
+        .strip_prefix(dest_dir.path())
+        .unwrap()
+        .to_string_lossy()
+        .replace('\\', "/");
+    let listed_cp = history_format::checkpoint_from_path(&listed_rel)
+        .expect("history path carries a checkpoint");
+
+    // Tamper the listed file's dst copy: still valid HAS JSON, but marked.
+    {
+        let bytes = std::fs::read(&listed_file).unwrap();
+        let mut state: history_format::HistoryFileState =
+            serde_json::from_slice(&bytes).unwrap();
+        state.server = Some("tampered-by-test".to_string());
+        std::fs::write(&listed_file, serde_json::to_vec(&state).unwrap()).unwrap();
+    }
+    let unlisted_before = std::fs::metadata(&unlisted_file).unwrap().modified().unwrap();
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Plan lists ONLY the tampered history -> drives phase 1 (retry_failed_files).
+    let mut tracker = crate::utils::FailureTracker::default();
+    tracker.record_file(listed_cp, crate::utils::FileFlags::HISTORY);
+    let plan = crate::report::ArchiveReport::from_failures_and_summary(
+        &tracker,
+        crate::report::Summary::default(),
+    );
+
+    run_repair(RepairConfig::new(&src_url, &dest_url).plan(plan))
+        .await
+        .expect("plan repair should succeed");
+
+    // (RED on current) The listed history must be re-fetched from SOURCE, not
+    // kept/rewritten from the tampered dst copy.
+    let after = std::fs::read_to_string(&listed_file).unwrap();
+    assert!(
+        !after.contains("tampered-by-test"),
+        "phase 1 must re-fetch a listed history from source, not keep the dst copy"
+    );
+
+    // (characterization) A healthy, unlisted history must be left untouched.
+    let unlisted_after = std::fs::metadata(&unlisted_file).unwrap().modified().unwrap();
+    assert_eq!(
+        unlisted_before, unlisted_after,
+        "phase 1 must not touch history files that are not in the plan"
+    );
+}
+
+#[tokio::test]
+async fn test_repair_replaces_broken_history_from_source() {
+    let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;
+
+    // Corrupt a per-checkpoint history file on the destination (still present,
+    // but unparseable) and capture the canonical source bytes.
+    let history_file = get_files_by_pattern(dest_dir.path(), "/history-")
+        .into_iter()
+        .find(|p| !p.to_string_lossy().contains(".well-known"))
+        .expect("a per-checkpoint history file");
+    let rel = history_file
+        .strip_prefix(dest_dir.path())
+        .unwrap()
+        .to_path_buf();
+    let source_content = std::fs::read(testnet_small_archive_path().join(&rel)).unwrap();
+    std::fs::write(&history_file, b"{ broken json }}").unwrap();
+
+    run_repair(RepairConfig::new(&src_url, &dest_url))
+        .await
+        .expect("repair should succeed");
+
+    // The broken history must have been replaced with the source content.
+    assert_eq!(
+        std::fs::read(&history_file).unwrap(),
+        source_content,
+        "broken destination history must be replaced from source"
+    );
+
+    run_scan(ScanConfig::new(&dest_url))
+        .await
+        .expect("scan should pass after repair");
 }
 
 //=============================================================================
@@ -1812,9 +1939,9 @@ async fn test_repair_well_known_not_restored_when_history_missing() {
 //=============================================================================
 
 /// Dry-run + verify must detect a corrupt history file but leave it untouched
-/// on dst (the pipeline used to write the src buffer back via `process_buffer`
-/// even in dry-run). Complements `test_repair_dry_run_with_verify`, which only
-/// covered a corrupt bucket.
+/// on dst: `process_history` reports `NeedsRepair` under dry-run without
+/// fetching or writing. Complements `test_repair_dry_run_with_verify`, which
+/// only covered a corrupt bucket.
 #[tokio::test]
 async fn test_repair_dry_run_with_verify_leaves_corrupt_history_untouched() {
     let (src_url, dest_dir, dest_url) = mirror_testnet_small().await;

--- a/src/tests/repair_op_test.rs
+++ b/src/tests/repair_op_test.rs
@@ -795,9 +795,15 @@ async fn test_repair_preserves_healthy_history_file() {
         .into_iter()
         .filter(|p| !p.to_string_lossy().contains(".well-known"))
         .collect();
-    assert!(!history_files.is_empty(), "need a per-checkpoint history file");
+    assert!(
+        !history_files.is_empty(),
+        "need a per-checkpoint history file"
+    );
     let history_file = history_files[0].clone();
-    let before = std::fs::metadata(&history_file).unwrap().modified().unwrap();
+    let before = std::fs::metadata(&history_file)
+        .unwrap()
+        .modified()
+        .unwrap();
 
     // Sleep so mtime would differ if the file were rewritten.
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
@@ -808,7 +814,10 @@ async fn test_repair_preserves_healthy_history_file() {
         .await
         .expect("Repair should succeed");
 
-    let after = std::fs::metadata(&history_file).unwrap().modified().unwrap();
+    let after = std::fs::metadata(&history_file)
+        .unwrap()
+        .modified()
+        .unwrap();
     assert_eq!(
         before, after,
         "healthy history file must not be rewritten by repair"
@@ -844,12 +853,14 @@ async fn test_repair_phase1_refetches_listed_history_from_source() {
     // Tamper the listed file's dst copy: still valid HAS JSON, but marked.
     {
         let bytes = std::fs::read(&listed_file).unwrap();
-        let mut state: history_format::HistoryFileState =
-            serde_json::from_slice(&bytes).unwrap();
+        let mut state: history_format::HistoryFileState = serde_json::from_slice(&bytes).unwrap();
         state.server = Some("tampered-by-test".to_string());
         std::fs::write(&listed_file, serde_json::to_vec(&state).unwrap()).unwrap();
     }
-    let unlisted_before = std::fs::metadata(&unlisted_file).unwrap().modified().unwrap();
+    let unlisted_before = std::fs::metadata(&unlisted_file)
+        .unwrap()
+        .modified()
+        .unwrap();
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
     // Plan lists ONLY the tampered history -> drives phase 1 (retry_failed_files).
@@ -873,7 +884,10 @@ async fn test_repair_phase1_refetches_listed_history_from_source() {
     );
 
     // (characterization) A healthy, unlisted history must be left untouched.
-    let unlisted_after = std::fs::metadata(&unlisted_file).unwrap().modified().unwrap();
+    let unlisted_after = std::fs::metadata(&unlisted_file)
+        .unwrap()
+        .modified()
+        .unwrap();
     assert_eq!(
         unlisted_before, unlisted_after,
         "phase 1 must not touch history files that are not in the plan"

--- a/src/tests/report_test.rs
+++ b/src/tests/report_test.rs
@@ -11,7 +11,7 @@ fn sample_tracker() -> FailureTracker {
     t.record_file(255, FileFlags::HISTORY);
     t.record_bucket(Hash([0xab; 32]));
     t.record_checkpoint(191);
-    t.well_known = true;
+    t.record_well_known(255);
     t
 }
 
@@ -19,7 +19,7 @@ fn sample_tracker() -> FailureTracker {
 fn test_from_failures_projects_all_kinds() {
     let report = ArchiveReport::from_failures_and_summary(&sample_tracker(), Summary::default());
     assert_eq!(report.version, REPORT_VERSION);
-    assert!(report.section.well_known);
+    assert_eq!(report.section.well_known, Some(255));
     assert_eq!(
         report.section.files.get("127").unwrap(),
         &["ledger", "transactions"]
@@ -141,4 +141,70 @@ fn test_section_computes_failed_and_summary() {
     assert_eq!(s.retries, 7);
     // sample_tracker has 3 file failures + 1 bucket = 4 (checkpoints excluded)
     assert_eq!(s.failed, 4);
+}
+
+#[test]
+fn test_record_well_known_stores_checkpoint() {
+    let mut t = FailureTracker::default();
+    assert!(t.is_empty());
+    t.record_well_known(127);
+    assert_eq!(t.well_known, Some(127));
+    assert!(!t.is_empty());
+    t.unrecord_well_known();
+    assert_eq!(t.well_known, None);
+    assert!(t.is_empty());
+}
+
+#[tokio::test]
+async fn test_record_failure_does_not_touch_well_known() {
+    // The root .well-known is no longer routed through record_failure; it is
+    // recorded explicitly via FailureTracker::record_well_known with the
+    // archive's high checkpoint. record_failure on that path is a no-op.
+    let stats = crate::utils::ArchiveStats::new();
+    stats
+        .record_failure(255, crate::history_format::ROOT_WELL_KNOWN_PATH)
+        .await;
+    assert_eq!(stats.failures.lock().await.well_known, None);
+}
+
+#[test]
+fn test_well_known_checkpoint_round_trips() {
+    for wk in [Some(191u32), None] {
+        let mut t = FailureTracker::default();
+        if let Some(cp) = wk {
+            t.record_well_known(cp);
+        }
+        let back = ArchiveReport::from_failures_and_summary(&t, Summary::default())
+            .into_failures()
+            .unwrap();
+        assert_eq!(back.well_known, wk);
+    }
+}
+
+#[test]
+fn test_into_failures_rejects_non_boundary_well_known() {
+    let mut r =
+        ArchiveReport::from_failures_and_summary(&FailureTracker::default(), Summary::default());
+    r.section.well_known = Some(100); // 100 is not a checkpoint boundary
+    let err = r.into_failures().unwrap_err().to_string();
+    assert!(err.contains("checkpoint"), "got: {err}");
+}
+
+#[test]
+fn test_well_known_serializes_as_number_or_null() {
+    let mut t = FailureTracker::default();
+    t.record_well_known(127);
+    let broken = serde_json::to_string(&ArchiveReport::from_failures_and_summary(
+        &t,
+        Summary::default(),
+    ))
+    .unwrap();
+    assert!(broken.contains("\"well_known\":127"), "got: {broken}");
+
+    let healthy = serde_json::to_string(&ArchiveReport::from_failures_and_summary(
+        &FailureTracker::default(),
+        Summary::default(),
+    ))
+    .unwrap();
+    assert!(healthy.contains("\"well_known\":null"), "got: {healthy}");
 }

--- a/src/tests/report_test.rs
+++ b/src/tests/report_test.rs
@@ -1,0 +1,144 @@
+//! Tests for the JSON plan/report schema (`crate::report`).
+
+use crate::report::{ArchiveReport, Summary, REPORT_VERSION};
+use crate::utils::{FailureTracker, FileFlags};
+use stellar_xdr::curr::Hash;
+
+fn sample_tracker() -> FailureTracker {
+    let mut t = FailureTracker::default();
+    t.record_file(127, FileFlags::LEDGER);
+    t.record_file(127, FileFlags::TRANSACTIONS);
+    t.record_file(255, FileFlags::HISTORY);
+    t.record_bucket(Hash([0xab; 32]));
+    t.record_checkpoint(191);
+    t.well_known = true;
+    t
+}
+
+#[test]
+fn test_from_failures_projects_all_kinds() {
+    let report = ArchiveReport::from_failures_and_summary(&sample_tracker(), Summary::default());
+    assert_eq!(report.version, REPORT_VERSION);
+    assert!(report.section.well_known);
+    assert_eq!(
+        report.section.files.get("127").unwrap(),
+        &["ledger", "transactions"]
+    );
+    assert_eq!(report.section.files.get("255").unwrap(), &["history"]);
+    assert_eq!(report.section.buckets, vec!["ab".repeat(32)]);
+    assert_eq!(report.section.checkpoints, vec![191]);
+}
+
+#[test]
+fn test_summary_always_serialized() {
+    let report = ArchiveReport::from_failures_and_summary(
+        &FailureTracker::default(),
+        Summary {
+            succeeded: 5,
+            skipped: 1,
+            failed: 0,
+            retries: 2,
+        },
+    );
+    let json = serde_json::to_string(&report).unwrap();
+    assert!(
+        json.contains("\"summary\""),
+        "summary should always serialize: {json}"
+    );
+}
+
+#[test]
+fn test_round_trip_identity() {
+    let t = sample_tracker();
+    let back = ArchiveReport::from_failures_and_summary(&t, Summary::default())
+        .into_failures()
+        .unwrap();
+    assert_eq!(back.well_known, t.well_known);
+    assert_eq!(back.files, t.files);
+    assert_eq!(back.buckets, t.buckets);
+    assert_eq!(back.checkpoints, t.checkpoints);
+}
+
+#[test]
+fn test_into_failures_rejects_bad_version() {
+    let mut r =
+        ArchiveReport::from_failures_and_summary(&FailureTracker::default(), Summary::default());
+    r.version = 999;
+    assert!(r.into_failures().is_err());
+}
+
+#[test]
+fn test_into_failures_rejects_non_boundary_checkpoint_key() {
+    let mut r =
+        ArchiveReport::from_failures_and_summary(&FailureTracker::default(), Summary::default());
+    r.section
+        .files
+        .insert("100".to_string(), vec!["ledger".to_string()]);
+    let err = r.into_failures().unwrap_err().to_string();
+    assert!(err.contains("checkpoint"), "got: {err}");
+}
+
+#[test]
+fn test_into_failures_rejects_unknown_file_type() {
+    let mut r =
+        ArchiveReport::from_failures_and_summary(&FailureTracker::default(), Summary::default());
+    r.section
+        .files
+        .insert("127".to_string(), vec!["bogus".to_string()]);
+    let err = r.into_failures().unwrap_err().to_string();
+    assert!(
+        err.contains("bogus") || err.contains("file type"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn test_into_failures_rejects_bad_bucket_hash() {
+    let mut r =
+        ArchiveReport::from_failures_and_summary(&FailureTracker::default(), Summary::default());
+    r.section.buckets.push("not-hex".to_string());
+    assert!(r.into_failures().is_err());
+}
+
+#[test]
+fn test_into_failures_rejects_non_boundary_checkpoint_entry() {
+    let mut r =
+        ArchiveReport::from_failures_and_summary(&FailureTracker::default(), Summary::default());
+    r.section.checkpoints.push(100);
+    assert!(r.into_failures().is_err());
+}
+
+#[test]
+fn test_into_failures_ignores_summary() {
+    let mut r =
+        ArchiveReport::from_failures_and_summary(&FailureTracker::default(), Summary::default());
+    r.section.summary = Summary {
+        succeeded: 9,
+        skipped: 9,
+        failed: 9,
+        retries: 9,
+    };
+    assert!(r.into_failures().unwrap().is_empty());
+}
+
+#[test]
+fn test_write_then_read_round_trips_via_disk() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("nested").join("plan.json");
+    let report = ArchiveReport::from_failures_and_summary(&sample_tracker(), Summary::default());
+    crate::report::write_to_path(&path, &report).unwrap();
+    assert!(path.exists(), "parent dirs should be created");
+    let read = crate::report::read_from_path(&path).unwrap();
+    assert_eq!(read, report);
+}
+
+#[test]
+fn test_section_computes_failed_and_summary() {
+    let section = crate::report::section(&sample_tracker(), 100, 3, 7);
+    let s = section.summary;
+    assert_eq!(s.succeeded, 100);
+    assert_eq!(s.skipped, 3);
+    assert_eq!(s.retries, 7);
+    // sample_tracker has 3 file failures + 1 bucket = 4 (checkpoints excluded)
+    assert_eq!(s.failed, 4);
+}

--- a/src/tests/report_test.rs
+++ b/src/tests/report_test.rs
@@ -208,3 +208,22 @@ fn test_well_known_serializes_as_number_or_null() {
     .unwrap();
     assert!(healthy.contains("\"well_known\":null"), "got: {healthy}");
 }
+
+/// A scan/mirror-shaped report (well_known + files + buckets + checkpoints)
+/// is a valid repair plan: into_failures accepts it and reconstructs the
+/// tracker. Guards cross-operation compatibility.
+#[test]
+fn test_scan_shaped_report_is_valid_plan() {
+    let report = ArchiveReport::from_failures_and_summary(&sample_tracker(), Summary::default());
+    let json = serde_json::to_string(&report).unwrap();
+    let parsed: ArchiveReport = serde_json::from_str(&json).unwrap();
+    let tracker = parsed
+        .into_failures()
+        .expect("scan/mirror report must be a valid plan");
+    // FailureTracker is not PartialEq; compare fields (as test_round_trip_identity does).
+    let expected = sample_tracker();
+    assert_eq!(tracker.well_known, expected.well_known);
+    assert_eq!(tracker.files, expected.files);
+    assert_eq!(tracker.buckets, expected.buckets);
+    assert_eq!(tracker.checkpoints, expected.checkpoints);
+}

--- a/src/tests/scan_op_test.rs
+++ b/src/tests/scan_op_test.rs
@@ -97,6 +97,7 @@ async fn remove_bucket_and_verify_scan_fails(
             std::fs::remove_file(bucket_file).expect("Failed to remove bucket file");
 
             let scan_config = ScanConfig {
+                report_path: None,
                 archive: file_url_from_path(archive_path),
                 concurrency: 8,
                 skip_optional: false,
@@ -264,6 +265,7 @@ async fn test_scan_detects_corrupt_files(
     }
 
     let scan_config = ScanConfig {
+        report_path: None,
         archive: file_url_from_path(archive_path),
         concurrency: 8,
         skip_optional: false,
@@ -292,6 +294,7 @@ async fn test_scan_missing_scp_with_optional_flag() {
 
     // First scan with skip_optional: false - should fail
     let scan_required = ScanConfig {
+        report_path: None,
         archive: file_url_from_path(archive_path),
         concurrency: 8,
         skip_optional: false, // SCP files are required
@@ -307,6 +310,7 @@ async fn test_scan_missing_scp_with_optional_flag() {
 
     // Second scan with skip_optional: true - should succeed
     let scan_optional = ScanConfig {
+        report_path: None,
         archive: file_url_from_path(archive_path),
         concurrency: 8,
         skip_optional: true, // SCP files are optional
@@ -328,6 +332,7 @@ async fn test_scan_complete_archive() {
     let test_archive_path = testnet_small_archive_path();
 
     let scan_config = ScanConfig {
+        report_path: None,
         archive: file_url_from_path(&test_archive_path),
         concurrency: 8,
         skip_optional: false,
@@ -354,6 +359,7 @@ async fn test_scan_http_archive() {
     let (server_url, server_handle) = start_http_server(&archive_path).await;
 
     let scan_config = ScanConfig {
+        report_path: None,
         archive: server_url.clone(),
         concurrency: 4,
         skip_optional: false,
@@ -418,4 +424,27 @@ async fn smoke_live_stellar_archive_connection() {
         let buffer: Buffer = chunks.into_iter().flatten().collect();
         assert!(!buffer.is_empty(), "{url_str}: no data received");
     }
+}
+
+#[tokio::test]
+async fn test_scan_report_lists_missing_files() {
+    let dir = TempDir::new().unwrap();
+    copy_testnet_small_archive(dir.path()).unwrap();
+    let url = file_url_from_path(dir.path());
+
+    // Delete one ledger file so the scan reports a missing file.
+    let ledgers = get_files_by_pattern(dir.path(), "/ledger-");
+    std::fs::remove_file(&ledgers[0]).unwrap();
+
+    let report_path = dir.path().join("scan-report.json");
+    let result = run_scan(ScanConfig::new(&url).report(&report_path)).await;
+    assert!(result.is_err(), "scan should fail with a missing file");
+
+    let report = crate::report::read_from_path(&report_path).unwrap();
+    let summary = report.section.summary;
+    assert!(summary.failed >= 1, "summary should count the missing file");
+    assert!(
+        !report.section.files.is_empty(),
+        "report should list the missing ledger checkpoint"
+    );
 }

--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -485,3 +485,93 @@ pub fn parse_transaction_entries(
 ) -> Result<BTreeMap<u32, Hash>, StorageError> {
     parse_transaction_entries_for_checkpoint(decompressed_data, None)
 }
+
+//=============================================================================
+// Ledger-header file corruption helpers
+//
+// Read/recompute/write a gzip'd ledger-header file at the XDR-entry level.
+// Used to construct files that pass per-entry and intra-checkpoint validation
+// but fail cross-file verification, exercising the manager's checkpoint-level
+// failure path.
+//=============================================================================
+
+pub(crate) fn read_and_parse_ledger_file(
+    path: &Path,
+) -> Vec<stellar_xdr::curr::LedgerHeaderHistoryEntry> {
+    use flate2::read::GzDecoder;
+    use std::io::Read as _;
+    use stellar_xdr::curr::{Frame, LedgerHeaderHistoryEntry, Limited, Limits, ReadXdr};
+
+    let data = std::fs::read(path).expect("Failed to read ledger file");
+    let mut decoder = GzDecoder::new(&data[..]);
+    let mut decompressed = Vec::new();
+    decoder
+        .read_to_end(&mut decompressed)
+        .expect("Failed to decompress");
+
+    let cursor = std::io::Cursor::new(&decompressed);
+    let mut limited = Limited::new(cursor, Limits::none());
+
+    Frame::<LedgerHeaderHistoryEntry>::read_xdr_iter(&mut limited)
+        .map(|r| r.expect("Failed to parse ledger-header entry").0)
+        .collect()
+}
+
+pub(crate) fn recompute_entry_hash(entry: &mut stellar_xdr::curr::LedgerHeaderHistoryEntry) {
+    use sha2::{Digest, Sha256};
+    use stellar_xdr::curr::{Limits, WriteXdr};
+
+    let header_xdr = entry
+        .header
+        .to_xdr(Limits::none())
+        .expect("Failed to serialize header");
+    entry.hash = Hash(Sha256::digest(&header_xdr).into());
+}
+
+pub(crate) fn write_ledger_header_entries_to_file(
+    path: &Path,
+    entries: &[stellar_xdr::curr::LedgerHeaderHistoryEntry],
+) {
+    use flate2::write::GzEncoder;
+    use flate2::Compression;
+    use std::io::Write as _;
+    use stellar_xdr::curr::{Limits, WriteXdr};
+
+    let mut data = Vec::new();
+    for entry in entries {
+        let entry_xdr = entry
+            .to_xdr(Limits::none())
+            .expect("Failed to serialize entry");
+        let frame_len = entry_xdr.len() as u32 | 0x8000_0000;
+        data.extend_from_slice(&frame_len.to_be_bytes());
+        data.extend_from_slice(&entry_xdr);
+    }
+
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder
+        .write_all(&data)
+        .expect("Failed to write compressed data");
+    let compressed = encoder.finish().expect("Failed to finish compression");
+    std::fs::write(path, compressed).expect("Failed to write file");
+}
+
+/// Corrupt a single ledger-header file in place so that the named cross-file
+/// hash field (`"tx_set"` or `"result"`) is wrong on every entry, while each
+/// entry's own hash and the intra-checkpoint prev-hash chain are recomputed to
+/// stay valid. The result parses cleanly per-entry; the mismatch surfaces only
+/// during cross-file verification against the transactions/results files.
+pub(crate) fn corrupt_ledger_cross_file_hash(ledger_file: &Path, field: &str) {
+    let mut entries = read_and_parse_ledger_file(ledger_file);
+    for i in 0..entries.len() {
+        match field {
+            "tx_set" => entries[i].header.scp_value.tx_set_hash = Hash([0xDE; 32]),
+            "result" => entries[i].header.tx_set_result_hash = Hash([0xDE; 32]),
+            other => panic!("unknown cross-file hash field: {other}"),
+        }
+        if i > 0 {
+            entries[i].header.previous_ledger_hash = entries[i - 1].hash.clone();
+        }
+        recompute_entry_hash(&mut entries[i]);
+    }
+    write_ledger_header_entries_to_file(ledger_file, &entries);
+}

--- a/src/tests/verify_test.rs
+++ b/src/tests/verify_test.rs
@@ -240,6 +240,7 @@ async fn test_mirror_verify_produces_verifiable_archive() {
     .expect("Mirror with --verify should succeed");
 
     run_scan(ScanConfig {
+        report_path: None,
         archive: mirror_dest,
         concurrency: 4,
         skip_optional: true,

--- a/src/tests/xdr_verification_e2e_test.rs
+++ b/src/tests/xdr_verification_e2e_test.rs
@@ -5,17 +5,17 @@
 //!
 //! Uses pubnet-archive-old-txset which contains V0 TransactionSet format.
 
-use super::utils::get_files_by_pattern;
+use super::utils::{
+    get_files_by_pattern, read_and_parse_ledger_file, recompute_entry_hash,
+    write_ledger_header_entries_to_file,
+};
 use crate::test_helpers::{run_mirror, run_scan, test_storage_config, MirrorConfig, ScanConfig};
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use rstest::rstest;
-use sha2::{Digest, Sha256};
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use stellar_xdr::curr::{
-    Frame, Hash, LedgerHeaderHistoryEntry, Limited, Limits, ReadXdr, WriteXdr,
-};
+use stellar_xdr::curr::Hash;
 use tempfile::TempDir;
 
 fn pubnet_old_txset_archive_path() -> PathBuf {
@@ -899,52 +899,6 @@ async fn test_scan_verify_fails_with_multiple_corrupt_files_same_checkpoint() {
 // (rather than raw bytes), preserving per-entry hash consistency so that
 // failures surface at cross-file or cross-checkpoint verification.
 //=============================================================================
-
-fn read_and_parse_ledger_file(path: &Path) -> Vec<LedgerHeaderHistoryEntry> {
-    use flate2::read::GzDecoder;
-    use std::io::Read as _;
-
-    let data = std::fs::read(path).expect("Failed to read ledger file");
-    let mut decoder = GzDecoder::new(&data[..]);
-    let mut decompressed = Vec::new();
-    decoder
-        .read_to_end(&mut decompressed)
-        .expect("Failed to decompress");
-
-    let cursor = std::io::Cursor::new(&decompressed);
-    let mut limited = Limited::new(cursor, Limits::none());
-
-    Frame::<LedgerHeaderHistoryEntry>::read_xdr_iter(&mut limited)
-        .map(|r| r.expect("Failed to parse ledger-header entry").0)
-        .collect()
-}
-
-fn recompute_entry_hash(entry: &mut LedgerHeaderHistoryEntry) {
-    let header_xdr = entry
-        .header
-        .to_xdr(Limits::none())
-        .expect("Failed to serialize header");
-    entry.hash = Hash(Sha256::digest(&header_xdr).into());
-}
-
-fn write_ledger_header_entries_to_file(path: &Path, entries: &[LedgerHeaderHistoryEntry]) {
-    let mut data = Vec::new();
-    for entry in entries {
-        let entry_xdr = entry
-            .to_xdr(Limits::none())
-            .expect("Failed to serialize entry");
-        let frame_len = entry_xdr.len() as u32 | 0x8000_0000;
-        data.extend_from_slice(&frame_len.to_be_bytes());
-        data.extend_from_slice(&entry_xdr);
-    }
-
-    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
-    encoder
-        .write_all(&data)
-        .expect("Failed to write compressed data");
-    let compressed = encoder.finish().expect("Failed to finish compression");
-    std::fs::write(path, compressed).expect("Failed to write file");
-}
 
 /// Modify all entries in a ledger file: set the specified hash field to a wrong
 /// value, recompute each entry's hash, and fix the internal prev-hash chain so

--- a/src/tests/xdr_verify_test.rs
+++ b/src/tests/xdr_verify_test.rs
@@ -954,7 +954,7 @@ fn test_record_all_errors_empty_manager_is_noop() {
     assert!(failures.checkpoints.is_empty());
     assert!(failures.files.is_empty());
     assert!(failures.buckets.is_empty());
-    assert!(!failures.well_known);
+    assert!(failures.well_known.is_none());
 }
 
 #[test]
@@ -985,7 +985,7 @@ fn test_record_all_errors_drains_each_variant() {
     // cp-level cross-file/chain inconsistencies.
     assert!(failures.files.is_empty());
     assert!(failures.buckets.is_empty());
-    assert!(!failures.well_known);
+    assert!(failures.well_known.is_none());
 }
 
 #[test]

--- a/src/tests/xdr_verify_test.rs
+++ b/src/tests/xdr_verify_test.rs
@@ -4,7 +4,7 @@ use crate::xdr_verify::{
     compute_v1_tx_set_hash, expected_ledger_range, is_empty_tx_set_hash,
     parse_ledger_header_entries_for_checkpoint, parse_result_entries_for_checkpoint,
     parse_scp_entries, parse_transaction_entries_for_checkpoint, LedgerHeaderVerificationData,
-    XdrVerificationManager, EMPTY_XDR_ARRAY_HASH,
+    VerificationErrorType, XdrVerificationManager, EMPTY_XDR_ARRAY_HASH,
 };
 use rstest::rstest;
 use sha2::{Digest, Sha256};
@@ -557,10 +557,10 @@ fn test_chain_break_within_ledger_file(#[case] checkpoint: u32, #[case] corrupte
     manager.record_header_data(checkpoint, header_data);
     manager.verify_and_release(checkpoint);
 
-    assert!(manager
-        .get_errors()
-        .iter()
-        .any(|e| e.ledger_seq == Some(corrupted_ledger) && e.message.contains("hash chain break")),);
+    assert!(manager.get_errors().iter().any(|e| matches!(
+        e.kind,
+        VerificationErrorType::Ledger(seq) if seq == corrupted_ledger
+    ) && e.message.contains("hash chain break")));
 }
 
 #[rstest]
@@ -633,11 +633,13 @@ fn test_cross_checkpoint_chain(#[case] break_chain: bool) {
     manager.verify_and_release(63);
     manager.verify_and_release(127);
 
-    let chain_errors = manager.verify_checkpoint_chain();
+    let errors_before_chain = manager.get_errors().len();
+    manager.verify_checkpoint_chain();
+    let chain_errors_added = manager.get_errors().len() - errors_before_chain;
     if break_chain {
-        assert_eq!(chain_errors.len(), 1);
+        assert_eq!(chain_errors_added, 1);
     } else {
-        assert!(chain_errors.is_empty());
+        assert_eq!(chain_errors_added, 0);
     }
 }
 
@@ -675,11 +677,11 @@ fn test_consecutive_checkpoints_full(#[case] break_chain: bool) {
     manager.verify_and_release(127);
 
     assert!(manager.get_errors().is_empty());
-    let chain_errors = manager.verify_checkpoint_chain();
+    manager.verify_checkpoint_chain();
     if break_chain {
-        assert!(!chain_errors.is_empty());
+        assert!(!manager.get_errors().is_empty());
     } else {
-        assert!(chain_errors.is_empty());
+        assert!(manager.get_errors().is_empty());
     }
 }
 
@@ -692,7 +694,8 @@ fn test_non_consecutive_checkpoint_scanning() {
     manager.verify_and_release(191);
 
     assert!(manager.get_errors().is_empty());
-    assert!(manager.verify_checkpoint_chain().is_empty());
+    manager.verify_checkpoint_chain();
+    assert!(manager.get_errors().is_empty());
 }
 
 #[test]
@@ -705,9 +708,9 @@ fn test_cross_checkpoint_missing_last_ledger_breaks_chain() {
     manager.record_header_data(127, create_complete_checkpoint_data(127, [0; 32]));
     manager.verify_and_release(63);
     manager.verify_and_release(127);
+    manager.verify_checkpoint_chain();
 
-    let total_errors = manager.get_errors().len() + manager.verify_checkpoint_chain().len();
-    assert!(total_errors > 0);
+    assert!(!manager.get_errors().is_empty());
 }
 
 #[test]
@@ -762,14 +765,16 @@ fn test_verify_checkpoint_chain_with_three_consecutive_checkpoints() {
     manager.verify_and_release(63);
     manager.verify_and_release(127);
     manager.verify_and_release(191);
+    manager.verify_checkpoint_chain();
 
-    assert!(manager.verify_checkpoint_chain().is_empty());
+    assert!(manager.get_errors().is_empty());
 }
 
 #[test]
 fn test_verify_checkpoint_chain_empty_manager() {
     let manager = XdrVerificationManager::new();
-    assert!(manager.verify_checkpoint_chain().is_empty());
+    manager.verify_checkpoint_chain();
+    assert!(manager.get_errors().is_empty());
 }
 
 #[test]

--- a/src/tests/xdr_verify_test.rs
+++ b/src/tests/xdr_verify_test.rs
@@ -948,7 +948,7 @@ fn test_record_all_errors_empty_manager_is_noop() {
     let manager = XdrVerificationManager::new();
     let mut failures = crate::utils::FailureTracker::default();
 
-    manager.record_all_errors(&mut failures);
+    manager.drain_all_errors(&mut failures);
 
     assert!(failures.is_empty());
     assert!(failures.checkpoints.is_empty());
@@ -975,7 +975,7 @@ fn test_record_all_errors_drains_each_variant() {
     assert!(!manager.get_errors().is_empty());
 
     let mut failures = crate::utils::FailureTracker::default();
-    manager.record_all_errors(&mut failures);
+    manager.drain_all_errors(&mut failures);
 
     // Checkpoint(127) → cp 127.
     assert!(failures.checkpoints.contains(&127));
@@ -1015,7 +1015,7 @@ fn test_record_all_errors_boundary_inserts_both_cps() {
     manager.verify_checkpoint_chain();
 
     let mut failures = crate::utils::FailureTracker::default();
-    manager.record_all_errors(&mut failures);
+    manager.drain_all_errors(&mut failures);
 
     // Boundary(191) records both 191 and 191-64=127.
     assert!(failures.checkpoints.contains(&191));
@@ -1029,12 +1029,12 @@ fn test_record_all_errors_idempotent() {
     manager.verify_and_release(127);
 
     let mut failures = crate::utils::FailureTracker::default();
-    manager.record_all_errors(&mut failures);
+    manager.drain_all_errors(&mut failures);
     let cps_after_first = failures.checkpoints.clone();
 
-    // Calling again should produce the same set (BTreeSet semantics + manager
-    // retains its accumulated state).
-    manager.record_all_errors(&mut failures);
+    // Calling again is a true no-op: the first call drained the manager's
+    // errors, so the second finds nothing to record and the set is unchanged.
+    manager.drain_all_errors(&mut failures);
     let cps_after_second = failures.checkpoints.clone();
 
     assert_eq!(cps_after_first, cps_after_second);

--- a/src/tests/xdr_verify_test.rs
+++ b/src/tests/xdr_verify_test.rs
@@ -938,3 +938,105 @@ fn test_parse_rejects_ledger_outside_checkpoint_range(#[case] file_type: &str) {
     };
     assert!(err.message.contains("outside expected checkpoint range"));
 }
+
+//=============================================================================
+// record_all_errors — drains manager errors into ArchiveStats.failures.checkpoints
+//=============================================================================
+
+#[test]
+fn test_record_all_errors_empty_manager_is_noop() {
+    let manager = XdrVerificationManager::new();
+    let mut failures = crate::utils::FailureTracker::default();
+
+    manager.record_all_errors(&mut failures);
+
+    assert!(failures.is_empty());
+    assert!(failures.checkpoints.is_empty());
+    assert!(failures.files.is_empty());
+    assert!(failures.buckets.is_empty());
+    assert!(!failures.well_known);
+}
+
+#[test]
+fn test_record_all_errors_drains_each_variant() {
+    let manager = XdrVerificationManager::new();
+
+    // Trigger a `Checkpoint(cp)` error via a completeness failure.
+    manager.record_header_data(127, create_checkpoint_data_missing(127, &[100]));
+    manager.verify_and_release(127);
+
+    // Trigger a `Ledger(seq)` error via an internal chain break.
+    let mut chain_break_data = create_complete_checkpoint_data(191, [0; 32]);
+    chain_break_data.get_mut(&150).unwrap().prev_hash = Hash([0xff; 32]);
+    manager.record_header_data(191, chain_break_data);
+    manager.verify_and_release(191);
+
+    // Sanity: manager has accumulated errors.
+    assert!(!manager.get_errors().is_empty());
+
+    let mut failures = crate::utils::FailureTracker::default();
+    manager.record_all_errors(&mut failures);
+
+    // Checkpoint(127) → cp 127.
+    assert!(failures.checkpoints.contains(&127));
+    // Ledger(150) → round_to_upper_checkpoint(150) = 191.
+    assert!(failures.checkpoints.contains(&191));
+    // Nothing should land in files/buckets/well_known — all manager errors are
+    // cp-level cross-file/chain inconsistencies.
+    assert!(failures.files.is_empty());
+    assert!(failures.buckets.is_empty());
+    assert!(!failures.well_known);
+}
+
+#[test]
+fn test_record_all_errors_boundary_inserts_both_cps() {
+    let manager = XdrVerificationManager::new();
+
+    // Build two adjacent cps (127 and 191) where the boundary hash chain
+    // breaks: cp 127 ends with one computed hash, cp 191's first prev_hash
+    // doesn't match.
+    let data_127 = create_complete_checkpoint_data(127, [0; 32]);
+    manager.record_header_data(127, data_127);
+    manager.verify_and_release(127);
+
+    // cp 191's first ledger (128) has prev_hash that won't match cp 127's last
+    // computed_hash.
+    let mut data_191 = create_complete_checkpoint_data(191, [0xab; 32]);
+    // Make the internal chain self-consistent but mismatched with cp 127.
+    let mut prev_hash = [0xab; 32];
+    for (seq, entry) in &mut data_191 {
+        entry.prev_hash = Hash(prev_hash);
+        prev_hash = entry.computed_hash.0;
+        let _ = seq;
+    }
+    manager.record_header_data(191, data_191);
+    manager.verify_and_release(191);
+
+    manager.verify_checkpoint_chain();
+
+    let mut failures = crate::utils::FailureTracker::default();
+    manager.record_all_errors(&mut failures);
+
+    // Boundary(191) records both 191 and 191-64=127.
+    assert!(failures.checkpoints.contains(&191));
+    assert!(failures.checkpoints.contains(&127));
+}
+
+#[test]
+fn test_record_all_errors_idempotent() {
+    let manager = XdrVerificationManager::new();
+    manager.record_header_data(127, create_checkpoint_data_missing(127, &[100]));
+    manager.verify_and_release(127);
+
+    let mut failures = crate::utils::FailureTracker::default();
+    manager.record_all_errors(&mut failures);
+    let cps_after_first = failures.checkpoints.clone();
+
+    // Calling again should produce the same set (BTreeSet semantics + manager
+    // retains its accumulated state).
+    manager.record_all_errors(&mut failures);
+    let cps_after_second = failures.checkpoints.clone();
+
+    assert_eq!(cps_after_first, cps_after_second);
+    assert!(cps_after_first.contains(&127));
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,11 +1,14 @@
 use bytes::Buf;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::atomic::{AtomicU64, Ordering};
+use stellar_xdr::curr::Hash;
 use thiserror::Error;
 use tracing::{debug, error, info, warn};
 
-use crate::history_format::{self, HistoryFileState};
+use crate::history_format::{self, HistoryFileState, ROOT_WELL_KNOWN_PATH};
 use crate::pipeline;
 use crate::storage::StorageRef;
+use crate::xdr_verify::VerificationErrorType;
 
 //=============================================================================
 // Retryable HTTP Error Codes
@@ -82,31 +85,155 @@ pub fn map_pipeline_error(err: pipeline::Error) -> crate::Error {
     }
 }
 
-/// Shared statistics tracking for archive operations
-/// for consistent reporting across scan and mirror operations
+//=============================================================================
+// FailureTracker — the deterministic source of truth for archive failures.
+//
+// Four orthogonal failure kinds, each indexable by its natural key:
+//   - well_known (singleton .well-known/stellar-history.json)
+//   - files      (per-checkpoint standard files: history/ledger/tx/results/scp)
+//   - buckets    (content-addressed; the same bucket may be referenced by
+//                 many checkpoints, but a failure is identified by its hash)
+//   - checkpoints (any checkpoint-level failure: cross-file verification,
+//                  within-cp chain break, or cross-cp chain break — for the
+//                  last, both cps flanking the break are inserted)
+//
+// Per-checkpoint "file" failures use a bitmask so a single cp can have
+// multiple file-type failures without duplicating the cp key.
+//=============================================================================
+
+/// Bitmask of per-checkpoint standard file types. Bit set = that file is
+/// missing or failed validation.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct FileFlags(u8);
+
+impl FileFlags {
+    pub const HISTORY: u8 = 1 << 0;
+    pub const LEDGER: u8 = 1 << 1;
+    pub const TRANSACTIONS: u8 = 1 << 2;
+    pub const RESULTS: u8 = 1 << 3;
+    pub const SCP: u8 = 1 << 4;
+
+    #[must_use]
+    pub const fn new() -> Self {
+        Self(0)
+    }
+    pub fn set(&mut self, flag: u8) {
+        self.0 |= flag;
+    }
+    pub fn unset(&mut self, flag: u8) {
+        self.0 &= !flag;
+    }
+    #[must_use]
+    pub fn has(&self, flag: u8) -> bool {
+        (self.0 & flag) != 0
+    }
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0 == 0
+    }
+    #[must_use]
+    pub fn count(&self) -> u32 {
+        self.0.count_ones()
+    }
+}
+
+// detailed tracking of which files are broken. and which checkpoints are broken
+#[derive(Debug, Default, Clone)]
+pub struct FailureTracker {
+    pub well_known: bool,
+    pub files: BTreeMap<u32, FileFlags>,
+    pub buckets: BTreeSet<Hash>,
+    pub checkpoints: BTreeSet<u32>,
+}
+
+impl FailureTracker {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        !self.well_known
+            && self.files.is_empty()
+            && self.buckets.is_empty()
+            && self.checkpoints.is_empty()
+    }
+
+    pub fn record_well_known(&mut self) {
+        self.well_known = true;
+    }
+    pub fn unrecord_well_known(&mut self) {
+        self.well_known = false;
+    }
+
+    pub fn record_file(&mut self, cp: u32, flag: u8) {
+        self.files.entry(cp).or_default().set(flag);
+    }
+    pub fn unrecord_file(&mut self, cp: u32, flag: u8) {
+        if let Some(flags) = self.files.get_mut(&cp) {
+            flags.unset(flag);
+            if flags.is_empty() {
+                self.files.remove(&cp);
+            }
+        }
+    }
+
+    pub fn record_bucket(&mut self, hash: Hash) {
+        self.buckets.insert(hash);
+    }
+    pub fn unrecord_bucket(&mut self, hash: &Hash) {
+        self.buckets.remove(hash);
+    }
+
+    pub fn record_checkpoint(&mut self, cp: u32) {
+        self.checkpoints.insert(cp);
+    }
+    pub fn unrecord_checkpoint(&mut self, cp: u32) {
+        self.checkpoints.remove(&cp);
+    }
+
+    /// Number of checkpoints with the given file flag set.
+    #[must_use]
+    pub fn count_files(&self, flag: u8) -> u32 {
+        self.files.values().filter(|f| f.has(flag)).count() as u32
+    }
+
+    /// Total file-failure count across all checkpoints and all flags.
+    #[must_use]
+    pub fn total_file_failures(&self) -> u32 {
+        self.files.values().map(FileFlags::count).sum::<u32>()
+    }
+}
+
+/// Classify a path into a `FileFlags` constant, or `None` if not a recognized
+/// per-checkpoint standard-file path.
+fn path_to_file_flag(path: &str) -> Option<u8> {
+    if history_format::is_history_file(path) {
+        Some(FileFlags::HISTORY)
+    } else if history_format::is_ledger_header_file(path) {
+        Some(FileFlags::LEDGER)
+    } else if history_format::is_transactions_file(path) {
+        Some(FileFlags::TRANSACTIONS)
+    } else if history_format::is_results_file(path) {
+        Some(FileFlags::RESULTS)
+    } else if history_format::is_scp_file(path) {
+        Some(FileFlags::SCP)
+    } else {
+        None
+    }
+}
+
+/// Parse a hex bucket hash (as returned by `bucket_hash_from_path`) into a `Hash`.
+fn hex_to_hash(s: &str) -> Option<Hash> {
+    let bytes = hex::decode(s).ok()?;
+    let arr: [u8; 32] = bytes.try_into().ok()?;
+    Some(Hash(arr))
+}
+
+/// Shared archive operation statistics. The `failures` field is the
+/// deterministic source of truth for the operation's outcome and may be
+/// consulted to drive subsequent decisions (e.g. repair retry planning).
 pub struct ArchiveStats {
-    // Successfully processed files
     pub successful_files: AtomicU64,
-
-    // Failed files (any type of failure)
-    pub failed_files: AtomicU64,
-
-    // Skipped files (already exist in mirror mode)
     pub skipped_files: AtomicU64,
-
-    // Number of retry attempts (not unique files, but total retries)
     pub retry_count: AtomicU64,
-
-    pub missing_required: AtomicU64,
-    pub missing_history: AtomicU64,
-    pub missing_ledger: AtomicU64,
-    pub missing_transactions: AtomicU64,
-    pub missing_results: AtomicU64,
-    pub missing_buckets: AtomicU64,
-    pub missing_scp: AtomicU64,
-
-    // List of all failed/missing files for detailed reporting
-    pub failed_list: tokio::sync::Mutex<Vec<String>>,
+    pub failures: tokio::sync::Mutex<FailureTracker>,
 }
 
 impl Default for ArchiveStats {
@@ -120,17 +247,9 @@ impl ArchiveStats {
     pub fn new() -> Self {
         Self {
             successful_files: AtomicU64::new(0),
-            failed_files: AtomicU64::new(0),
             skipped_files: AtomicU64::new(0),
             retry_count: AtomicU64::new(0),
-            missing_required: AtomicU64::new(0),
-            missing_history: AtomicU64::new(0),
-            missing_ledger: AtomicU64::new(0),
-            missing_transactions: AtomicU64::new(0),
-            missing_results: AtomicU64::new(0),
-            missing_buckets: AtomicU64::new(0),
-            missing_scp: AtomicU64::new(0),
-            failed_list: tokio::sync::Mutex::new(Vec::new()),
+            failures: tokio::sync::Mutex::new(FailureTracker::default()),
         }
     }
 
@@ -138,105 +257,145 @@ impl ArchiveStats {
         self.successful_files.fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Record a skipped file (already exists in mirror mode)
+    /// Record a skipped file (already exists in mirror mode).
     pub fn record_skipped(&self, _path: &str) {
         self.skipped_files.fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Record a retry attempt
+    /// Record a retry attempt.
     pub fn record_retry(&self) {
         self.retry_count.fetch_add(1, Ordering::Relaxed);
     }
 
-    pub async fn record_failure(&self, path: &str) {
-        self.failed_files.fetch_add(1, Ordering::Relaxed);
-
-        if path.contains("history") {
-            self.missing_history.fetch_add(1, Ordering::Relaxed);
-        } else if path.contains("ledger") {
-            self.missing_ledger.fetch_add(1, Ordering::Relaxed);
-        } else if path.contains("transactions") {
-            self.missing_transactions.fetch_add(1, Ordering::Relaxed);
-        } else if path.contains("results") {
-            self.missing_results.fetch_add(1, Ordering::Relaxed);
-        } else if path.contains("bucket") {
-            self.missing_buckets.fetch_add(1, Ordering::Relaxed);
-        } else if path.contains("scp") {
-            self.missing_scp.fetch_add(1, Ordering::Relaxed);
+    /// Record a per-file failure, routing by path to the appropriate
+    /// `FailureTracker` slot. `cp` is the checkpoint context (used as the key
+    /// for per-checkpoint standard files; ignored for buckets and well-known).
+    /// Unrecognized paths are logged and not recorded.
+    pub async fn record_failure(&self, cp: u32, path: &str) {
+        let mut failures = self.failures.lock().await;
+        if path == ROOT_WELL_KNOWN_PATH {
+            failures.record_well_known();
+        } else if let Some(hash_str) = history_format::bucket_hash_from_path(path) {
+            if let Some(hash) = hex_to_hash(&hash_str) {
+                failures.record_bucket(hash);
+            } else {
+                warn!("record_failure: malformed bucket hash in path {path}");
+            }
+        } else if let Some(flag) = path_to_file_flag(path) {
+            failures.record_file(cp, flag);
+        } else {
+            warn!("record_failure: unrecognized path {path}");
         }
-
-        if !path.contains("scp") {
-            self.missing_required.fetch_add(1, Ordering::Relaxed);
-        }
-
-        let mut failed_list = self.failed_list.lock().await;
-        failed_list.push(path.to_string());
     }
 
-    /// Generate and log a complete report of the operation results
+    /// Remove a previously recorded per-file failure (e.g. when retry rescues
+    /// the file). No-op if the path was not present in the tracker.
+    pub async fn unrecord_failure(&self, cp: u32, path: &str) {
+        let mut failures = self.failures.lock().await;
+        if path == ROOT_WELL_KNOWN_PATH {
+            failures.unrecord_well_known();
+        } else if let Some(hash_str) = history_format::bucket_hash_from_path(path) {
+            if let Some(hash) = hex_to_hash(&hash_str) {
+                failures.unrecord_bucket(&hash);
+            }
+        } else if let Some(flag) = path_to_file_flag(path) {
+            failures.unrecord_file(cp, flag);
+        }
+    }
+
+    /// Record a verification failure, dispatching on its kind:
+    /// - `Ledger(seq)` and `Checkpoint(cp)` mark a single checkpoint as
+    ///   problematic.
+    /// - `Boundary(cp)` marks both `cp` and its previous checkpoint, since
+    ///   a chain break implicates both ends.
+    ///
+    /// Repair only needs cp granularity; all variants funnel into the same
+    /// `checkpoints` set in the FailureTracker.
+    pub async fn record_verification_failure(&self, kind: &VerificationErrorType) {
+        let mut failures = self.failures.lock().await;
+        match kind {
+            VerificationErrorType::Ledger(seq) => {
+                failures.record_checkpoint(history_format::round_to_upper_checkpoint(*seq));
+            }
+            VerificationErrorType::Checkpoint(cp) => {
+                failures.record_checkpoint(*cp);
+            }
+            VerificationErrorType::Boundary(cp) => {
+                failures.record_checkpoint(*cp);
+                // Genesis cp (63) has no previous; the chain check can't
+                // produce a boundary error with curr=63 in practice, but
+                // guarded defensively with checked_sub.
+                if let Some(prev) = cp.checked_sub(history_format::CHECKPOINT_FREQUENCY) {
+                    failures.record_checkpoint(prev);
+                }
+            }
+        }
+    }
+
+    /// True iff the tracker holds any failure of any kind.
+    pub async fn has_failures(&self) -> bool {
+        !self.failures.lock().await.is_empty()
+    }
+
+    /// Generate and log a complete report of the operation results.
     pub async fn report(&self, operation: &str) {
         let successful = self.successful_files.load(Ordering::Relaxed);
-        let failed = self.failed_files.load(Ordering::Relaxed);
         let skipped = self.skipped_files.load(Ordering::Relaxed);
         let retries = self.retry_count.load(Ordering::Relaxed);
 
-        if operation == "mirror" {
-            info!(
-                "Mirror completed: {} files copied, {} failed, {} skipped",
-                successful, failed, skipped
-            );
-        } else if operation == "repair" {
-            info!(
-                "Repair completed: {} files processed, {} failed",
-                successful, failed
-            );
-        } else {
-            let missing_required = self.missing_required.load(Ordering::Relaxed);
-            info!(
-                "Scan complete: {} files found, {} missing ({} required)",
-                successful, failed, missing_required
-            );
+        let failures = self.failures.lock().await;
+        let total_file_failures = failures.total_file_failures();
+        let total_bucket_failures = failures.buckets.len() as u32;
+        let checkpoint_failures = failures.checkpoints.len() as u32;
+        let total_failures = total_file_failures + total_bucket_failures;
+
+        match operation {
+            "mirror" => info!(
+                "Mirror completed: {successful} files copied, {total_failures} failed, {skipped} skipped"
+            ),
+            "repair" => info!(
+                "Repair completed: {successful} files processed, {total_failures} failed"
+            ),
+            _ => info!("Scan complete: {successful} files found, {total_failures} missing"),
         }
 
-        // Debug-level stats summary
         debug!(
-            "Stats: {} successful, {} failed, {} skipped, {} retries",
-            successful, failed, skipped, retries
+            "Stats: {successful} successful, {total_failures} failed, {skipped} skipped, {retries} retries"
         );
 
-        if failed == 0 {
+        if failures.is_empty() {
             return;
         }
 
-        let missing_history = self.missing_history.load(Ordering::Relaxed);
-        let missing_ledger = self.missing_ledger.load(Ordering::Relaxed);
-        let missing_transactions = self.missing_transactions.load(Ordering::Relaxed);
-        let missing_results = self.missing_results.load(Ordering::Relaxed);
-        let missing_buckets = self.missing_buckets.load(Ordering::Relaxed);
-        let missing_scp = self.missing_scp.load(Ordering::Relaxed);
-
+        if failures.well_known {
+            error!("Missing or unreadable .well-known/stellar-history.json");
+        }
+        let missing_history = failures.count_files(FileFlags::HISTORY);
+        let missing_ledger = failures.count_files(FileFlags::LEDGER);
+        let missing_transactions = failures.count_files(FileFlags::TRANSACTIONS);
+        let missing_results = failures.count_files(FileFlags::RESULTS);
+        let missing_scp = failures.count_files(FileFlags::SCP);
         if missing_history > 0 {
-            error!("Missing {} history files", missing_history);
+            error!("Missing {missing_history} history files");
         }
         if missing_ledger > 0 {
-            error!("Missing {} ledger files", missing_ledger);
+            error!("Missing {missing_ledger} ledger header files");
         }
         if missing_transactions > 0 {
-            error!("Missing {} transactions files", missing_transactions);
+            error!("Missing {missing_transactions} transactions files");
         }
         if missing_results > 0 {
-            error!("Missing {} results files", missing_results);
+            error!("Missing {missing_results} results files");
         }
-        if missing_buckets > 0 {
-            error!("Missing {} buckets", missing_buckets);
+        if total_bucket_failures > 0 {
+            error!("Missing {total_bucket_failures} bucket files");
         }
         if missing_scp > 0 {
-            warn!("Missing {} optional scp files", missing_scp);
+            warn!("Missing {missing_scp} optional scp files");
         }
-    }
-
-    pub fn has_failures(&self) -> bool {
-        self.failed_files.load(Ordering::Relaxed) > 0
+        if checkpoint_failures > 0 {
+            error!("{checkpoint_failures} checkpoint(s) failed verification (cross-file or chain)");
+        }
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -158,6 +158,24 @@ impl FailureTracker {
             && self.checkpoints.is_empty()
     }
 
+    /// True if `path` identifies a file already recorded as broken: a bucket
+    /// whose content hash is in `buckets`, or a per-checkpoint file whose
+    /// (cp, type) flag is set in `files`. Repair's failed-list mode uses this
+    /// to fetch known-broken files directly instead of probing the destination.
+    #[must_use]
+    pub fn contains_path(&self, path: &str) -> bool {
+        if let Some(hash_str) = history_format::bucket_hash_from_path(path) {
+            return hex_to_hash(&hash_str).is_some_and(|h| self.buckets.contains(&h));
+        }
+        match (
+            history_format::checkpoint_from_path(path),
+            path_to_file_flag(path),
+        ) {
+            (Some(cp), Some(flag)) => self.files.get(&cp).is_some_and(|f| f.has(flag)),
+            _ => false,
+        }
+    }
+
     /// Mark the root `.well-known` as needing restoration from checkpoint `cp`
     /// (the archive's highest checkpoint, which is what `.well-known` advertises).
     pub fn record_well_known(&mut self, cp: u32) {
@@ -345,6 +363,14 @@ impl ArchiveStats {
     /// True iff the tracker holds any failure of any kind.
     pub async fn has_failures(&self) -> bool {
         !self.failures.lock().await.is_empty()
+    }
+
+    /// Number of checkpoints flagged by cross-file or cross-checkpoint
+    /// verification. These are detected *after* the per-cp files are written, so
+    /// a non-zero count means individually-valid files were committed but are
+    /// mutually inconsistent.
+    pub async fn checkpoint_failure_count(&self) -> usize {
+        self.failures.lock().await.checkpoints.len()
     }
 
     /// Generate and log a complete report of the operation results.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,7 @@ use stellar_xdr::curr::Hash;
 use thiserror::Error;
 use tracing::{debug, error, info, warn};
 
-use crate::history_format::{self, HistoryFileState, ROOT_WELL_KNOWN_PATH};
+use crate::history_format::{self, HistoryFileState};
 use crate::pipeline;
 use crate::storage::StorageRef;
 use crate::xdr_verify::VerificationErrorType;
@@ -140,7 +140,10 @@ impl FileFlags {
 // detailed tracking of which files are broken. and which checkpoints are broken
 #[derive(Debug, Default, Clone)]
 pub struct FailureTracker {
-    pub well_known: bool,
+    /// `Some(cp)` when the root `.well-known/stellar-history.json` is broken,
+    /// carrying the checkpoint it should be restored from (the archive's
+    /// highest checkpoint). `None` when healthy.
+    pub well_known: Option<u32>,
     pub files: BTreeMap<u32, FileFlags>,
     pub buckets: BTreeSet<Hash>,
     pub checkpoints: BTreeSet<u32>,
@@ -149,17 +152,19 @@ pub struct FailureTracker {
 impl FailureTracker {
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        !self.well_known
+        self.well_known.is_none()
             && self.files.is_empty()
             && self.buckets.is_empty()
             && self.checkpoints.is_empty()
     }
 
-    pub fn record_well_known(&mut self) {
-        self.well_known = true;
+    /// Mark the root `.well-known` as needing restoration from checkpoint `cp`
+    /// (the archive's highest checkpoint, which is what `.well-known` advertises).
+    pub fn record_well_known(&mut self, cp: u32) {
+        self.well_known = Some(cp);
     }
     pub fn unrecord_well_known(&mut self) {
-        self.well_known = false;
+        self.well_known = None;
     }
 
     pub fn record_file(&mut self, cp: u32, flag: u8) {
@@ -275,6 +280,20 @@ impl ArchiveStats {
         }
     }
 
+    /// Snapshot this stats into a report section (locks failures once + reads
+    /// its counters). The single "stats → section" primitive: operations
+    /// assemble these into a single- or multi-section report and write it.
+    /// Logging is separate ([`report`](Self::report)).
+    pub async fn report_section(&self) -> crate::report::ReportSection {
+        let failures = self.failures.lock().await;
+        crate::report::section(
+            &failures,
+            self.successful_files.load(Ordering::Relaxed),
+            self.skipped_files.load(Ordering::Relaxed),
+            self.retry_count.load(Ordering::Relaxed),
+        )
+    }
+
     pub fn record_success(&self, _path: &str) {
         self.successful_files.fetch_add(1, Ordering::Relaxed);
     }
@@ -291,13 +310,13 @@ impl ArchiveStats {
 
     /// Record a per-file failure, routing by path to the appropriate
     /// `FailureTracker` slot. `cp` is the checkpoint context (used as the key
-    /// for per-checkpoint standard files; ignored for buckets and well-known).
+    /// for per-checkpoint standard files; ignored for buckets). The root
+    /// `.well-known` is not a per-file failure — it is recorded directly via
+    /// [`FailureTracker::record_well_known`] with the archive's high checkpoint.
     /// Unrecognized paths are logged and not recorded.
     pub async fn record_failure(&self, cp: u32, path: &str) {
         let mut failures = self.failures.lock().await;
-        if path == ROOT_WELL_KNOWN_PATH {
-            failures.record_well_known();
-        } else if let Some(hash_str) = history_format::bucket_hash_from_path(path) {
+        if let Some(hash_str) = history_format::bucket_hash_from_path(path) {
             if let Some(hash) = hex_to_hash(&hash_str) {
                 failures.record_bucket(hash);
             } else {
@@ -314,9 +333,7 @@ impl ArchiveStats {
     /// the file). No-op if the path was not present in the tracker.
     pub async fn unrecord_failure(&self, cp: u32, path: &str) {
         let mut failures = self.failures.lock().await;
-        if path == ROOT_WELL_KNOWN_PATH {
-            failures.unrecord_well_known();
-        } else if let Some(hash_str) = history_format::bucket_hash_from_path(path) {
+        if let Some(hash_str) = history_format::bucket_hash_from_path(path) {
             if let Some(hash) = hex_to_hash(&hash_str) {
                 failures.unrecord_bucket(&hash);
             }
@@ -360,8 +377,10 @@ impl ArchiveStats {
             return;
         }
 
-        if failures.well_known {
-            error!("Missing or unreadable .well-known/stellar-history.json");
+        if let Some(cp) = failures.well_known {
+            error!(
+                "Missing or unreadable .well-known/stellar-history.json (restore from checkpoint {cp} / 0x{cp:08x})"
+            );
         }
         let missing_history = failures.count_files(FileFlags::HISTORY);
         let missing_ledger = failures.count_files(FileFlags::LEDGER);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -199,6 +199,28 @@ impl FailureTracker {
     pub fn total_file_failures(&self) -> u32 {
         self.files.values().map(FileFlags::count).sum::<u32>()
     }
+
+    /// Record a verification failure, dispatching on its kind:
+    /// - `Ledger(seq)` and `Checkpoint(cp)` mark a single checkpoint as
+    ///   problematic.
+    /// - `Boundary(cp)` marks both `cp` and its previous checkpoint, since
+    ///   a chain break implicates both ends.
+    pub fn record_verification_failure(&mut self, kind: &VerificationErrorType) {
+        match kind {
+            VerificationErrorType::Ledger(seq) => {
+                self.record_checkpoint(history_format::round_to_upper_checkpoint(*seq));
+            }
+            VerificationErrorType::Checkpoint(cp) => {
+                self.record_checkpoint(*cp);
+            }
+            VerificationErrorType::Boundary(cp) => {
+                self.record_checkpoint(*cp);
+                if let Some(prev) = cp.checked_sub(history_format::CHECKPOINT_FREQUENCY) {
+                    self.record_checkpoint(prev);
+                }
+            }
+        }
+    }
 }
 
 /// Classify a path into a `FileFlags` constant, or `None` if not a recognized
@@ -300,35 +322,6 @@ impl ArchiveStats {
             }
         } else if let Some(flag) = path_to_file_flag(path) {
             failures.unrecord_file(cp, flag);
-        }
-    }
-
-    /// Record a verification failure, dispatching on its kind:
-    /// - `Ledger(seq)` and `Checkpoint(cp)` mark a single checkpoint as
-    ///   problematic.
-    /// - `Boundary(cp)` marks both `cp` and its previous checkpoint, since
-    ///   a chain break implicates both ends.
-    ///
-    /// Repair only needs cp granularity; all variants funnel into the same
-    /// `checkpoints` set in the FailureTracker.
-    pub async fn record_verification_failure(&self, kind: &VerificationErrorType) {
-        let mut failures = self.failures.lock().await;
-        match kind {
-            VerificationErrorType::Ledger(seq) => {
-                failures.record_checkpoint(history_format::round_to_upper_checkpoint(*seq));
-            }
-            VerificationErrorType::Checkpoint(cp) => {
-                failures.record_checkpoint(*cp);
-            }
-            VerificationErrorType::Boundary(cp) => {
-                failures.record_checkpoint(*cp);
-                // Genesis cp (63) has no previous; the chain check can't
-                // produce a boundary error with curr=63 in practice, but
-                // guarded defensively with checked_sub.
-                if let Some(prev) = cp.checked_sub(history_format::CHECKPOINT_FREQUENCY) {
-                    failures.record_checkpoint(prev);
-                }
-            }
         }
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -242,7 +242,7 @@ fn path_to_file_flag(path: &str) -> Option<u8> {
 }
 
 /// Parse a hex bucket hash (as returned by `bucket_hash_from_path`) into a `Hash`.
-fn hex_to_hash(s: &str) -> Option<Hash> {
+pub(crate) fn hex_to_hash(s: &str) -> Option<Hash> {
     let bytes = hex::decode(s).ok()?;
     let arr: [u8; 32] = bytes.try_into().ok()?;
     Some(Hash(arr))

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -18,7 +18,7 @@ const CHANNEL_CAPACITY: usize = 64;
 
 /// Decompress and hash the given reader's content and verify it against the expected hash.
 /// If `writer` is provided, compressed bytes are written to it while verifying.
-async fn verify_bucket_internal(
+async fn verify_bucket_maybe_write(
     path: &str,
     reader: Reader,
     writer: Option<Writer>,
@@ -127,17 +127,32 @@ async fn verify_bucket_internal(
 /// Verify a bucket file's hash (scan operation).
 pub async fn verify_bucket_stream(path: &str, reader: Reader) -> Result<(), StorageError> {
     debug!("Verifying bucket hash for {}", path);
-    verify_bucket_internal(path, reader, None).await
+    verify_bucket_maybe_write(path, reader, None).await
 }
 
 /// Verify and write a bucket file (mirror operation).
 /// Hash is verified before committing the write.
+///
+/// On non-atomic backends the compressed stream is written to a `.tmp`
+/// sibling and renamed to `path` only after the hash verifies — the same
+/// scheme as `verify_and_write_xdr` — so a failed or interrupted write never
+/// disturbs a pre-existing file at `path`. Atomic backends commit on
+/// `close()` internally.
 pub async fn verify_and_write_bucket(
     path: &str,
     reader: Reader,
     dst_store: &StorageRef,
 ) -> Result<(), StorageError> {
     debug!("Verifying and writing bucket {}", path);
-    let writer = dst_store.open_writer(path).await?;
-    verify_bucket_internal(path, reader, Some(writer)).await
+    let write_path: String = if dst_store.uses_atomic_writes() {
+        path.to_string()
+    } else {
+        format!("{path}.tmp")
+    };
+    let writer = dst_store.open_writer(&write_path).await?;
+    if let Err(e) = verify_bucket_maybe_write(path, reader, Some(writer)).await {
+        crate::xdr_verify::cleanup_non_atomic_partial_write(&write_path, dst_store).await;
+        return Err(e);
+    }
+    crate::xdr_verify::commit_non_atomic_write(dst_store, &write_path, path).await
 }

--- a/src/xdr_verify.rs
+++ b/src/xdr_verify.rs
@@ -571,21 +571,25 @@ impl XdrVerificationManager {
 
     /// Snapshot of all verification errors accumulated so far. Each call
     /// returns a fresh `Vec`; the manager retains the underlying state.
+    #[cfg(test)]
     pub fn get_errors(&self) -> Vec<VerificationError> {
         self.errors.lock().unwrap().clone()
     }
 
-    /// Drain accumulated verification errors directly into the supplied
-    /// `FailureTracker` (which the caller already owns mutably — e.g. via
-    /// `stats.failures.get_mut()` inside `Operation::finalize`). All
-    /// variants funnel into the `checkpoints` slot — these are
-    /// cross-file/cross-cp inconsistencies, not per-file failures.
+    /// Drain accumulated verification errors into the supplied `FailureTracker`
+    /// (which the caller already owns mutably — e.g. via `stats.failures`
+    /// inside `Operation::finalize`). All variants funnel into the
+    /// `checkpoints` slot — these are cross-file/cross-cp inconsistencies, not
+    /// per-file failures.
     ///
-    /// Sync because the caller has exclusive `&mut` access and the
-    /// manager's std `Mutex` is held only briefly across the iteration.
-    /// No clone, no `.await`.
-    pub fn record_all_errors(&self, failures: &mut crate::utils::FailureTracker) {
-        let errors = self.errors.lock().unwrap();
+    /// Clears the manager's error list at the end, so a subsequent call is a
+    /// true no-op (idempotent by draining, not by relying on the tracker's set).
+    ///
+    /// Sync because the caller has exclusive `&mut` access and the manager's
+    /// std `Mutex` is held only across the cheap iteration. No clone, no
+    /// `.await`.
+    pub fn drain_all_errors(&self, failures: &mut crate::utils::FailureTracker) {
+        let mut errors = self.errors.lock().unwrap();
         for err in errors.iter() {
             failures.record_verification_failure(&err.kind);
         }
@@ -595,6 +599,7 @@ impl XdrVerificationManager {
                 errors.len()
             );
         }
+        errors.clear();
     }
 }
 

--- a/src/xdr_verify.rs
+++ b/src/xdr_verify.rs
@@ -108,10 +108,27 @@ struct PendingCheckpoint {
     result_hashes: Option<BTreeMap<u32, Hash>>,
 }
 
+/// First/last ledger-header hashes at a checkpoint boundary, used internally
+/// by [`XdrVerificationManager`] to verify hash continuity across
+/// consecutive checkpoints.
 #[derive(Debug, Clone)]
 struct CheckpointBoundary {
     first_prev_hash: Hash,
     last_computed_hash: Hash,
+}
+
+/// Kind of verification failure detected. The associated `u32` is the
+/// identifier most natural for that kind:
+/// - `Ledger`: the failing ledger sequence number (per-ledger failure).
+/// - `Checkpoint`: the checkpoint ledger number (cross-ledger failure
+///   contained within one checkpoint).
+/// - `Boundary`: the curr checkpoint ledger number (cross-checkpoint
+///   chain break between this cp and its previous cp).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VerificationErrorType {
+    Ledger(u32),
+    Checkpoint(u32),
+    Boundary(u32),
 }
 
 /// A verification failure detected during cross-file or chain validation.
@@ -119,11 +136,20 @@ struct CheckpointBoundary {
 /// [`get_errors`](XdrVerificationManager::get_errors).
 #[derive(Debug, Clone)]
 pub struct VerificationError {
-    pub checkpoint: u32,
-    /// The specific ledger sequence that failed, or `None` for checkpoint-level errors
-    /// (e.g. missing ledger data, internal errors).
-    pub ledger_seq: Option<u32>,
+    pub kind: VerificationErrorType,
     pub message: String,
+}
+
+impl VerificationError {
+    /// The checkpoint this error pertains to, regardless of variant.
+    /// `Ledger(seq)` is mapped to its containing checkpoint via
+    /// `history_format::round_to_upper_checkpoint`.
+    pub fn checkpoint(&self) -> u32 {
+        match self.kind {
+            VerificationErrorType::Ledger(seq) => history_format::round_to_upper_checkpoint(seq),
+            VerificationErrorType::Checkpoint(cp) | VerificationErrorType::Boundary(cp) => cp,
+        }
+    }
 }
 
 /// Coordinates cross-file XDR verification across concurrent checkpoint processing.
@@ -190,65 +216,44 @@ impl XdrVerificationManager {
     /// Run all intra-checkpoint verifications and free the pending data.
     ///
     /// Runs (in order): completeness check, tx set hash cross-check, result hash
-    /// cross-check, internal hash chain, then stores the first/last boundary hashes
-    /// for later cross-checkpoint verification. Errors are accumulated in
-    /// [`get_errors`](Self::get_errors) **and** returned to the caller so they can
-    /// observe per-checkpoint outcomes (used by repair to drive its retry phase).
+    /// cross-check, internal hash chain, then stores the first/last boundary
+    /// hashes for later cross-checkpoint verification. All errors are accumulated
+    /// into `self.errors`; retrieve them via [`get_errors`](Self::get_errors).
     ///
-    /// No-op (returns empty Vec) if no data was recorded for this checkpoint.
-    /// If ledger data is missing but tx/result data exists, records a warning
-    /// error and returns it.
-    pub fn verify_and_release(&self, checkpoint: u32) -> Vec<VerificationError> {
+    /// No-op if no data was recorded for this checkpoint. If ledger data is
+    /// missing but tx/result data exists, records a warning error.
+    pub(crate) fn verify_and_release(&self, checkpoint: u32) {
         let data = {
             let mut pending = self.pending.lock().unwrap();
             pending.remove(&checkpoint)
         };
 
         let Some(data) = data else {
-            return Vec::new();
+            return;
         };
 
         let Some(header_data) = data.header_data else {
             let err_msg = "missing ledger verification data for checkpoint";
             warn!("Checkpoint {checkpoint}: skipping cross-verification because {err_msg}");
-            let err = VerificationError {
-                checkpoint,
-                ledger_seq: None,
+            self.errors.lock().unwrap().push(VerificationError {
+                kind: VerificationErrorType::Checkpoint(checkpoint),
                 message: err_msg.to_string(),
-            };
-            self.errors.lock().unwrap().push(err.clone());
-            return vec![err];
+            });
+            return;
         };
 
-        let mut errors = Vec::new();
-        errors.extend(Self::verify_checkpoint_completeness(
-            checkpoint,
-            &header_data,
-        ));
+        self.verify_checkpoint_completeness(checkpoint, &header_data);
 
         if let Some(tx_set_hashes) = data.tx_set_hashes {
-            errors.extend(Self::verify_tx_set_hashes_internal(
-                checkpoint,
-                &header_data,
-                &tx_set_hashes,
-            ));
+            self.verify_tx_set_hashes_internal(&header_data, &tx_set_hashes);
         }
 
         if let Some(result_hashes) = data.result_hashes {
-            errors.extend(Self::verify_result_hashes_internal(
-                checkpoint,
-                &header_data,
-                &result_hashes,
-            ));
+            self.verify_result_hashes_internal(&header_data, &result_hashes);
         }
 
-        errors.extend(Self::verify_internal_chain(checkpoint, &header_data));
+        self.verify_internal_chain(checkpoint, &header_data);
         self.store_boundary(checkpoint, &header_data);
-
-        if !errors.is_empty() {
-            self.errors.lock().unwrap().extend(errors.iter().cloned());
-        }
-        errors
     }
 
     /// Verify that `header_data` covers exactly the ledger sequences expected
@@ -259,9 +264,10 @@ impl XdrVerificationManager {
     /// - **Missing**: ledger sequences in the expected range with no header entry
     ///   (truncated to the first 5 + a count when more than 10 are missing)
     fn verify_checkpoint_completeness(
+        &self,
         checkpoint: u32,
         header_data: &BTreeMap<u32, LedgerHeaderVerificationData>,
-    ) -> Vec<VerificationError> {
+    ) {
         let mut errors = Vec::new();
         let (first_ledger, last_ledger) = expected_ledger_range(checkpoint);
         let range = first_ledger..=last_ledger;
@@ -285,8 +291,7 @@ impl XdrVerificationManager {
             );
             error!("Checkpoint {checkpoint}: {err_msg}");
             errors.push(VerificationError {
-                checkpoint,
-                ledger_seq: unexpected.first().copied(),
+                kind: VerificationErrorType::Checkpoint(checkpoint),
                 message: err_msg,
             });
         }
@@ -310,12 +315,13 @@ impl XdrVerificationManager {
             );
             error!("Checkpoint {checkpoint}: {err_msg}");
             errors.push(VerificationError {
-                checkpoint,
-                ledger_seq: missing.first().copied(),
+                kind: VerificationErrorType::Checkpoint(checkpoint),
                 message: err_msg,
             });
         }
-        errors
+        if !errors.is_empty() {
+            self.errors.lock().unwrap().extend(errors);
+        }
     }
 
     /// Cross-verify per-ledger tx-set hashes from the **transactions** file
@@ -330,10 +336,10 @@ impl XdrVerificationManager {
     ///   sentinels (see [`is_empty_tx_set_hash`]) — stellar-core omits empty
     ///   tx-set entries from the transactions file.
     fn verify_tx_set_hashes_internal(
-        checkpoint: u32,
+        &self,
         header_data: &BTreeMap<u32, LedgerHeaderVerificationData>,
         tx_set_hashes: &BTreeMap<u32, Hash>,
-    ) -> Vec<VerificationError> {
+    ) {
         let mut errors = Vec::new();
         for (&seq, data) in header_data {
             let expected = &data.expected_tx_set_hash;
@@ -362,13 +368,14 @@ impl XdrVerificationManager {
             if let Some(err_msg) = err_msg {
                 error!("Ledger {seq}: {err_msg}");
                 errors.push(VerificationError {
-                    checkpoint,
-                    ledger_seq: Some(seq),
+                    kind: VerificationErrorType::Ledger(seq),
                     message: err_msg,
                 });
             }
         }
-        errors
+        if !errors.is_empty() {
+            self.errors.lock().unwrap().extend(errors);
+        }
     }
 
     /// Cross-verify per-ledger result-set hashes from the **results** file
@@ -380,10 +387,10 @@ impl XdrVerificationManager {
     ///   is non-zero and not [`EMPTY_XDR_ARRAY_HASH`] (those two values mark
     ///   "no result entry expected" and are tolerated as missing).
     fn verify_result_hashes_internal(
-        checkpoint: u32,
+        &self,
         header_data: &BTreeMap<u32, LedgerHeaderVerificationData>,
         result_hashes: &BTreeMap<u32, Hash>,
-    ) -> Vec<VerificationError> {
+    ) {
         let mut errors = Vec::new();
         for (&seq, data) in header_data {
             let expected = &data.expected_result_hash;
@@ -410,13 +417,14 @@ impl XdrVerificationManager {
             if let Some(err_msg) = err_msg {
                 error!("Ledger {seq}: {err_msg}");
                 errors.push(VerificationError {
-                    checkpoint,
-                    ledger_seq: Some(seq),
+                    kind: VerificationErrorType::Ledger(seq),
                     message: err_msg,
                 });
             }
         }
-        errors
+        if !errors.is_empty() {
+            self.errors.lock().unwrap().extend(errors);
+        }
     }
 
     /// Verify the hash chain *within* a single checkpoint.
@@ -429,48 +437,47 @@ impl XdrVerificationManager {
     /// prior checkpoint's last) is handled separately by
     /// [`verify_checkpoint_chain`](Self::verify_checkpoint_chain).
     fn verify_internal_chain(
+        &self,
         checkpoint: u32,
         header_data: &BTreeMap<u32, LedgerHeaderVerificationData>,
-    ) -> Vec<VerificationError> {
+    ) {
         let mut errors = Vec::new();
         let entries: Vec<_> = header_data.iter().collect();
 
         for pair in entries.windows(2) {
-            let mut err_msg: Option<String> = None;
-            let mut ledger_seq: Option<u32> = None;
+            let mut kind_and_msg: Option<(VerificationErrorType, String)> = None;
 
             if let [(&prev_seq, prev_data), (&seq, data)] = pair {
                 if prev_seq.saturating_add(1) != seq {
-                    err_msg = Some(format!(
-                        "missing predecessor ledger {}",
-                        seq.saturating_sub(1),
-                    ));
-                    ledger_seq = Some(seq);
+                    let msg = format!("missing predecessor ledger {}", seq.saturating_sub(1),);
+                    kind_and_msg = Some((VerificationErrorType::Ledger(seq), msg));
                 } else if prev_data.computed_hash != data.prev_hash {
-                    err_msg = Some(format!(
+                    let msg = format!(
                         "hash chain break: previous_ledger_hash {} != computed hash of ledger {} ({})",
                         data.prev_hash.to_hex(),
                         prev_seq,
                         prev_data.computed_hash.to_hex(),
-                    ));
-                    ledger_seq = Some(seq);
+                    );
+                    kind_and_msg = Some((VerificationErrorType::Ledger(seq), msg));
                 }
             } else {
-                err_msg = Some(
+                kind_and_msg = Some((
+                    VerificationErrorType::Checkpoint(checkpoint),
                     "internal error: unexpected window size in chain verification".to_string(),
-                );
+                ));
             }
 
-            if let Some(err_msg) = err_msg {
+            if let Some((kind, err_msg)) = kind_and_msg {
                 error!("Checkpoint {checkpoint}: {err_msg}");
                 errors.push(VerificationError {
-                    checkpoint,
-                    ledger_seq,
+                    kind,
                     message: err_msg,
                 });
             }
         }
-        errors
+        if !errors.is_empty() {
+            self.errors.lock().unwrap().extend(errors);
+        }
     }
 
     /// Stash the first/last ledger hashes of this checkpoint into
@@ -505,12 +512,12 @@ impl XdrVerificationManager {
     }
 
     /// Verify hash chain continuity across consecutive checkpoint boundaries.
-    /// Returns errors directly (not accumulated in `get_errors`) since this runs
-    /// after all per-checkpoint verification is complete.
+    /// Detected errors are pushed into `self.errors`; retrieve via
+    /// [`get_errors`](Self::get_errors).
     ///
     /// Only checks adjacent checkpoints separated by exactly `CHECKPOINT_FREQUENCY` —
     /// non-consecutive checkpoints (from partial or bounded scans) are skipped.
-    pub fn verify_checkpoint_chain(&self) -> Vec<VerificationError> {
+    pub(crate) fn verify_checkpoint_chain(&self) {
         let boundaries = self.boundaries.lock().unwrap();
         let mut chain_errors = Vec::new();
 
@@ -534,14 +541,15 @@ impl XdrVerificationManager {
                 );
                 error!("{err_msg}");
                 chain_errors.push(VerificationError {
-                    checkpoint: curr_checkpoint,
-                    ledger_seq: Some(first_ledger),
+                    kind: VerificationErrorType::Boundary(curr_checkpoint),
                     message: err_msg,
                 });
             }
         }
 
-        chain_errors
+        if !chain_errors.is_empty() {
+            self.errors.lock().unwrap().extend(chain_errors);
+        }
     }
 
     /// Snapshot of all verification errors accumulated so far. Each call

--- a/src/xdr_verify.rs
+++ b/src/xdr_verify.rs
@@ -523,6 +523,7 @@ impl XdrVerificationManager {
 
         let entries: Vec<_> = boundaries.iter().collect();
 
+        // TODO: need to handle corner case of only 1 entry.
         for window in entries.windows(2) {
             let (&prev_checkpoint, prev_boundary) = window[0];
             let (&curr_checkpoint, curr_boundary) = window[1];
@@ -556,6 +557,28 @@ impl XdrVerificationManager {
     /// returns a fresh `Vec`; the manager retains the underlying state.
     pub fn get_errors(&self) -> Vec<VerificationError> {
         self.errors.lock().unwrap().clone()
+    }
+
+    /// Drain accumulated verification errors directly into the supplied
+    /// `FailureTracker` (which the caller already owns mutably — e.g. via
+    /// `stats.failures.get_mut()` inside `Operation::finalize`). All
+    /// variants funnel into the `checkpoints` slot — these are
+    /// cross-file/cross-cp inconsistencies, not per-file failures.
+    ///
+    /// Sync because the caller has exclusive `&mut` access and the
+    /// manager's std `Mutex` is held only briefly across the iteration.
+    /// No clone, no `.await`.
+    pub fn record_all_errors(&self, failures: &mut crate::utils::FailureTracker) {
+        let errors = self.errors.lock().unwrap();
+        for err in errors.iter() {
+            failures.record_verification_failure(&err.kind);
+        }
+        if !errors.is_empty() {
+            error!(
+                "XDR verification found {} cross-file or chain inconsistency error(s)",
+                errors.len()
+            );
+        }
     }
 }
 

--- a/src/xdr_verify.rs
+++ b/src/xdr_verify.rs
@@ -17,7 +17,7 @@
 //! - Cross-checkpoint hash chain: first ledger's `prev_hash` matches prior checkpoint's last hash
 
 use crate::history_format::{self, CHECKPOINT_FREQUENCY, GENESIS_CHECKPOINT_LEDGER};
-use crate::storage::{cleanup_partial_file, from_opendal_error, Error as StorageError, StorageRef};
+use crate::storage::{from_opendal_error, Error as StorageError, StorageRef};
 use async_compression::tokio::bufread::GzipDecoder;
 use bytes::Bytes;
 use futures_util::StreamExt;
@@ -1090,7 +1090,7 @@ async fn decompress_and_write_internal(
 ///   `NotFound` is silently tolerated; other errors are warned but not raised.
 ///
 /// Safe to call on backends without a base path (e.g. HTTP) — does nothing.
-async fn cleanup_non_atomic_partial_write(path: &str, dst_store: &StorageRef) {
+pub(crate) async fn cleanup_non_atomic_partial_write(path: &str, dst_store: &StorageRef) {
     if dst_store.uses_atomic_writes() {
         return;
     }
@@ -1106,6 +1106,38 @@ async fn cleanup_non_atomic_partial_write(path: &str, dst_store: &StorageRef) {
             }
         }
     }
+}
+
+/// Commit a verified write performed at `write_path` to its final `path`.
+///
+/// - **Atomic backends**: `write_path == path` (the backend already committed
+///   via its own temp-to-target rename on `close()`) — no-op.
+/// - **Non-atomic backends**: rename the `.tmp` sibling to the final path.
+///   The temp is removed on rename failure to avoid leaking `.tmp` files;
+///   the pre-existing file at `path` (if any) is only replaced by the rename,
+///   never deleted on failure.
+pub(crate) async fn commit_non_atomic_write(
+    dst_store: &StorageRef,
+    write_path: &str,
+    path: &str,
+) -> Result<(), StorageError> {
+    if write_path == path {
+        return Ok(());
+    }
+    if let Some(base) = dst_store.get_base_path() {
+        let tmp_full = base.join(write_path);
+        let final_full = base.join(path);
+        if let Err(e) = tokio::fs::rename(&tmp_full, &final_full).await {
+            let _ = tokio::fs::remove_file(&tmp_full).await;
+            return Err(StorageError::fatal(format!(
+                "failed to rename {} to {}: {}",
+                tmp_full.display(),
+                final_full.display(),
+                e
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// Decompress, verify XDR structure, and write to destination in a single
@@ -1190,22 +1222,7 @@ pub async fn verify_and_write_xdr(
                 })?;
             }
             // Non-atomic FS backend: rename the temp to the final path.
-            // Removes the temp on rename failure to avoid leaking `.tmp` files.
-            if write_path != path {
-                if let Some(base) = dst_store.get_base_path() {
-                    let tmp_full = base.join(&write_path);
-                    let final_full = base.join(path);
-                    if let Err(e) = tokio::fs::rename(&tmp_full, &final_full).await {
-                        let _ = tokio::fs::remove_file(&tmp_full).await;
-                        return Err(StorageError::fatal(format!(
-                            "failed to rename {} to {}: {}",
-                            tmp_full.display(),
-                            final_full.display(),
-                            e
-                        )));
-                    }
-                }
-            }
+            commit_non_atomic_write(dst_store, &write_path, path).await?;
             Ok(result)
         }
         Err(err) => {
@@ -1229,8 +1246,12 @@ pub async fn verify_and_write_xdr(
 /// - everything else (and the manager-off path) → plain
 ///   [`crate::storage::Storage::copy_from_reader`]
 ///
-/// On any write error, attempts [`cleanup_partial_file`] on `dst_store`
-/// (cleanup failures are logged at error level but not propagated).
+/// Every branch writes via a temp artifact (`.tmp` sibling on non-atomic
+/// backends, the backend's own temp-to-target rename on atomic ones) and
+/// cleans up after itself on failure — a failed fetch never disturbs a
+/// pre-existing file at `path`. Repair's failed-list mode relies on this:
+/// it force-fetches listed files that may still be valid on dst, and a
+/// transient src failure must not destroy that copy.
 pub async fn fetch_verify_and_write(
     src_store: &StorageRef,
     dst_store: &StorageRef,
@@ -1265,18 +1286,8 @@ pub async fn fetch_verify_and_write(
             .map(|()| None)
     };
 
-    match write_result {
-        Ok(parsed) => {
-            if let (Some(parsed), Some(mgr)) = (parsed, manager) {
-                mgr.record(path, parsed);
-            }
-            Ok(())
-        }
-        Err(e) => {
-            if let Err(cleanup_err) = cleanup_partial_file(dst_store, path).await {
-                error!("Failed to cleanup partial file {}: {}", path, cleanup_err);
-            }
-            Err(e)
-        }
+    if let (Some(parsed), Some(mgr)) = (write_result?, manager) {
+        mgr.record(path, parsed);
     }
+    Ok(())
 }

--- a/src/xdr_verify.rs
+++ b/src/xdr_verify.rs
@@ -17,7 +17,7 @@
 //! - Cross-checkpoint hash chain: first ledger's `prev_hash` matches prior checkpoint's last hash
 
 use crate::history_format::{self, CHECKPOINT_FREQUENCY, GENESIS_CHECKPOINT_LEDGER};
-use crate::storage::{from_opendal_error, Error as StorageError, StorageRef};
+use crate::storage::{cleanup_partial_file, from_opendal_error, Error as StorageError, StorageRef};
 use async_compression::tokio::bufread::GzipDecoder;
 use bytes::Bytes;
 use futures_util::StreamExt;
@@ -211,6 +211,22 @@ impl XdrVerificationManager {
         let mut pending = self.pending.lock().unwrap();
         let entry = pending.entry(checkpoint).or_default();
         entry.result_hashes = Some(hashes);
+    }
+
+    /// Dispatch a parsed XDR result to the matching `record_*` method,
+    /// deriving the checkpoint from `path`. No-op when `path` doesn't carry
+    /// a checkpoint (e.g. unrecognized archive file) or the result is
+    /// [`XdrParseResult::None`] (SCP files).
+    pub fn record(&self, path: &str, result: XdrParseResult) {
+        let Some(cp) = history_format::checkpoint_from_path(path) else {
+            return;
+        };
+        match result {
+            XdrParseResult::Ledger(data) => self.record_header_data(cp, data),
+            XdrParseResult::Transactions(hashes) => self.record_tx_set_hashes(cp, hashes),
+            XdrParseResult::Results(hashes) => self.record_result_hashes(cp, hashes),
+            XdrParseResult::None => {}
+        }
     }
 
     /// Run all intra-checkpoint verifications and free the pending data.
@@ -1193,6 +1209,69 @@ pub async fn verify_and_write_xdr(
             // send() so clean up the partial file.
             cleanup_non_atomic_partial_write(&write_path, dst_store).await;
             Err(err)
+        }
+    }
+}
+
+/// Fetch `path` from `src_store`, write to `dst_store`, optionally verifying
+/// the content and recording XDR parse results into `manager`.
+///
+/// Used by mirror's `process_object` (always called) and repair's
+/// `process_object` (called when dst is missing or corrupt). The branching
+/// matches the trait's existing pattern:
+/// - bucket file + manager → [`crate::verify::verify_and_write_bucket`]
+/// - xdr per-cp file + manager → [`verify_and_write_xdr`] + record into manager
+/// - everything else (and the manager-off path) → plain
+///   [`crate::storage::Storage::copy_from_reader`]
+///
+/// On any write error, attempts [`cleanup_partial_file`] on `dst_store`
+/// (cleanup failures are logged at error level but not propagated).
+pub async fn fetch_verify_and_write(
+    src_store: &StorageRef,
+    dst_store: &StorageRef,
+    path: &str,
+    manager: Option<&XdrVerificationManager>,
+) -> Result<(), StorageError> {
+    let reader = src_store.open_reader(path).await?;
+
+    let write_result: Result<Option<XdrParseResult>, StorageError> = if manager.is_some() {
+        if history_format::is_bucket_file(path) {
+            crate::verify::verify_and_write_bucket(path, reader, dst_store)
+                .await
+                .map(|()| None)
+        } else if history_format::is_ledger_header_file(path)
+            || history_format::is_transactions_file(path)
+            || history_format::is_results_file(path)
+            || history_format::is_scp_file(path)
+        {
+            verify_and_write_xdr(path, reader, dst_store)
+                .await
+                .map(Some)
+        } else {
+            dst_store
+                .copy_from_reader(path, reader)
+                .await
+                .map(|()| None)
+        }
+    } else {
+        dst_store
+            .copy_from_reader(path, reader)
+            .await
+            .map(|()| None)
+    };
+
+    match write_result {
+        Ok(parsed) => {
+            if let (Some(parsed), Some(mgr)) = (parsed, manager) {
+                mgr.record(path, parsed);
+            }
+            Ok(())
+        }
+        Err(e) => {
+            if let Err(cleanup_err) = cleanup_partial_file(dst_store, path).await {
+                error!("Failed to cleanup partial file {}: {}", path, cleanup_err);
+            }
+            Err(e)
         }
     }
 }


### PR DESCRIPTION
## What

Follow-up to #21, addressing the residual issues. The main issue was that the pipeline tracked failures as flat counters. That left repair unable to target specific failures (instead was only retrying checkpoints, not individual failed files). It also did not apply `--verify` on retry passes, and retry phase was trusting the src unconditionally. Status reporting was partial, since the tracker couldn't reflect what had actually failed across multiple phases.

### Canonical status tracking
`ArchiveStats` now holds a non-flat **`FailureTracker`** as the single source of truth for pipeline status. It records exactly what failed, at the granularity each failure has:
- per-checkpoint standard files (history / ledger / transactions / results / scp), as a bitmask;
- buckets, by content hash;
- checkpoints with chain or cross-file verification failures.

### Repair as a two-stage retry over the existing pipeline
Repair's retry phase (after the main pipeline pass, during `finish`) now has two stages, at distinct granularities:
- **per file** (`retry_failed_files`): re-fetch the individual failed files and rediscover buckets;
- **per checkpoint** (`retry_failed_checkpoints`): re-mirror checkpoints that had chain / verification failures.

Reusing the pipeline drove two supporting changes: it can now run a discrete set of checkpoints (`run_checkpoints`) rather than only a contiguous range, and it owns XDR verification (`PipelineConfig.verify`) so `--verify` behaves identically in the main pass and in both retry stages. The two stages are partitioned to avoid re-fetching the same files.

### Improved JSON reporting and plan -> repair roundtrip
Reporting now is consistent with the tracker's content (`ArchivalStats` is the single source of truth). Scan/Mirror/Repair-dry-run all have a single-sectioned output. Repair (non-dry-run)'s report is multi-section: one section per pass (main / file-retry / checkpoint-retry), 

Repair's `--dry-run` writes the tracker out as a JSON plan, and `--plan` reads one back in to drive a targeted repair — a report → plan → repair roundtrip.

### Supporting changes
- `.well-known` restoration now runs *after* the retry stages (so it copies from a history file the file-retry stage may have just restored) and reports its own failure instead of swallowing it.
- Consolidated the duplicated fetch/verify/write path and folded repair's config into `PipelineConfig`.

### User-facing
- `--report <path>` (scan / mirror / repair) writes the JSON report.
- Repair **`--plan <file>` replaces `--files`**: reads a plan written by a prior `--dry-run`.
- README documents repair, the JSON formats, and verification scope.