### PR TITLE
Scale verify mode: run XDR decode+parse in spawned tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2609,6 +2609,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hex",
+ "libc",
  "lru",
  "normalize-path",
  "opendal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,20 @@ version = "0.1.0"
 edition = "2021"
 rust-version = "1.91.0"
 
+[lints.rust]
+# `tokio_unstable` is enabled via RUSTFLAGS for opt-in Tokio runtime metrics
+# (perf diagnostics only); register it so it isn't flagged as an unexpected cfg.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
+
 [lib]
 name = "stellar_archivist"
 
 [features]
 default = ["cli", "opendal-all"]
 cli = ["dep:clap", "dep:tracing-subscriber"]
+
+# Perf testing only (NOT for production; off by default, compiled out otherwise).
+perf-metrics = ["dep:libc"]
 
 # OpenDAL-based storage backends (fs and http are always enabled)
 opendal-s3 = ["opendal/services-s3"]
@@ -62,6 +70,8 @@ async-compression = { version = "0.4", features = ["tokio", "gzip"] }
 flate2 = "1.1.9"
 hex = "0.4"
 tokio-stream = "0.1"
+# Perf testing only (optional; pulled in by perf-metrics).
+libc = { version = "0.2", optional = true }
 
 [dev-dependencies]
 tempfile = { version = "3.5.0" }

--- a/src/bin/stellar-archivist/main.rs
+++ b/src/bin/stellar-archivist/main.rs
@@ -1,13 +1,31 @@
+// Pedantic lints accepted for the binary's perf wiring: `doc_markdown` and
+// `cast_possible_truncation` mirror the workspace policy in lib.rs;
+// `struct_field_names` (the Session baseline fields share a `_start` suffix) and
+// `unused_self` (the feature-off no-op `Session::report`) are perf-module local.
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::struct_field_names)]
+#![allow(clippy::unused_self)]
+
+mod perf;
+
 use clap::Error;
 use std::env;
 use stellar_archivist::cli;
 
 #[tokio::main]
 async fn main() {
-    if let Err(e) = cli::run(env::args_os()).await {
-        match e {
-            cli::Error::Clap(e) => e.exit(),
-            _ => Error::raw(clap::error::ErrorKind::ValueValidation, e).exit(),
+    // Feature-gated perf instrumentation; a no-op without `--features perf-metrics`.
+    let perf = perf::start();
+
+    match cli::run(env::args_os()).await {
+        Ok(()) => perf.report(),
+        // clap handled --help / --version / a bad argument: let it print its own
+        // message and set its own exit code, with no perf output polluting it.
+        Err(cli::Error::Clap(e)) => e.exit(),
+        Err(e) => {
+            perf.report();
+            Error::raw(clap::error::ErrorKind::ValueValidation, e).exit();
         }
     }
 }

--- a/src/bin/stellar-archivist/perf.rs
+++ b/src/bin/stellar-archivist/perf.rs
@@ -1,0 +1,164 @@
+//! Binary-local wiring for the feature-gated perf instrumentation.
+//!
+//! All `#[cfg(feature = "perf-metrics")]` / `#[cfg(tokio_unstable)]` gating for
+//! the binary lives here so `main` reads cleanly: it unconditionally calls
+//! [`start`] and [`Session::report`], which compile to no-ops unless built with
+//! `--features perf-metrics`.
+
+#[cfg(feature = "perf-metrics")]
+mod imp {
+    use std::time::{Duration, Instant};
+
+    /// Start-of-window baselines plus the background loggers spawned by [`start`].
+    /// [`Session::report`] emits the final report, windowed to the wall interval
+    /// since `start`.
+    pub struct Session {
+        wall_start: Instant,
+        cpu_start: u64,
+        #[cfg(tokio_unstable)]
+        worker_busy_start: Duration,
+    }
+
+    /// Capture the window baselines and start the perf background tasks.
+    pub fn start() -> Session {
+        let wall_start = Instant::now();
+        // Baseline CPU and worker-busy at the start of the measured window so
+        // cores_avg / worker_cores_avg divide in-window totals by in-window wall
+        // (both underlying counters accumulate from process/runtime start).
+        let cpu_start = stellar_archivist::metrics::process_cpu_nanos();
+        #[cfg(tokio_unstable)]
+        let worker_busy_start = worker_busy_total();
+
+        // The Tokio runtime-metrics logger needs `--cfg tokio_unstable`;
+        // otherwise emit a one-line note pointing at the rebuild flag.
+        #[cfg(tokio_unstable)]
+        start_runtime_metrics_logger();
+        #[cfg(not(tokio_unstable))]
+        eprintln!(
+            "PERF_NOTE tokio_runtime_metrics=disabled reason=missing_tokio_unstable_cfg \
+             rebuild_with='RUSTFLAGS=\"--cfg tokio_unstable\" cargo run --features perf-metrics -- ...'"
+        );
+
+        // Runtime-responsiveness heartbeat. Needs no tokio_unstable — just a
+        // spawned task that times its own wakeups (see metrics::record_heartbeat).
+        start_heartbeat();
+
+        Session {
+            wall_start,
+            cpu_start,
+            #[cfg(tokio_unstable)]
+            worker_busy_start,
+        }
+    }
+
+    impl Session {
+        /// Emit the final PERF / PERF_CPU / PERF_HEARTBEAT / PERF_PHASE report,
+        /// windowing CPU and worker-busy to the wall interval since [`start`].
+        pub fn report(self) {
+            // In-window process CPU (user+sys, all threads): now − baseline.
+            let cpu_ns =
+                stellar_archivist::metrics::process_cpu_nanos().saturating_sub(self.cpu_start);
+            #[cfg(tokio_unstable)]
+            let worker_busy = {
+                // num_workers() is fixed for the runtime's lifetime (only the
+                // blocking pool is dynamically sized), so the worker set can't
+                // have shifted between baseline and now.
+                let nw = tokio::runtime::Handle::current().metrics().num_workers();
+                let busy = worker_busy_total().saturating_sub(self.worker_busy_start);
+                Some((busy, nw))
+            };
+            #[cfg(not(tokio_unstable))]
+            let worker_busy: Option<(Duration, usize)> = None;
+            stellar_archivist::metrics::report(self.wall_start.elapsed(), cpu_ns, worker_busy);
+        }
+    }
+
+    /// Summed `worker_total_busy_duration(i)`: Tokio's cumulative, monotonic
+    /// total of how long each worker has spent *polling tasks* (vs parked/idle)
+    /// since the runtime started, flushed at park/batch boundaries (not
+    /// continuously). Sampled at the call site; the reported figure is
+    /// end − baseline, windowed to wall, giving worker_cores_avg — the mean
+    /// number of Tokio workers concurrently busy (worker-pool occupancy).
+    #[cfg(tokio_unstable)]
+    fn worker_busy_total() -> Duration {
+        let m = tokio::runtime::Handle::current().metrics();
+        (0..m.num_workers())
+            .map(|i| m.worker_total_busy_duration(i))
+            .sum()
+    }
+
+    #[cfg(tokio_unstable)]
+    fn start_runtime_metrics_logger() {
+        let handle = tokio::runtime::Handle::current();
+        tokio::spawn(async move {
+            let m = handle.metrics();
+            let nw = m.num_workers();
+            loop {
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                let inj = m.global_queue_depth();
+                let locq: usize = (0..nw).map(|i| m.worker_local_queue_depth(i)).sum();
+                let dec = stellar_archivist::metrics::ACTIVE_DECODES
+                    .load(std::sync::atomic::Ordering::Relaxed);
+                // worker_mean_poll_time(i): Tokio's exponentially-weighted moving
+                // average of how long one `Future::poll` on worker `i` runs
+                // before yielding — per-poll duration, NOT cumulative busy time.
+                // We report the max across workers: a rising value means tasks
+                // run long without yielding (CPU-bound work monopolizing the
+                // worker pool) — the signal such work might belong on the
+                // blocking pool. (Cumulative occupancy is the PERF_CPU
+                // worker_cores_avg field instead.)
+                let max_poll_us = (0..nw)
+                    .map(|i| m.worker_mean_poll_time(i).as_micros() as u64)
+                    .max()
+                    .unwrap_or(0);
+                eprintln!(
+                    "RTM active_decodes={} runnable_q={} (inject={} local={}) max_poll_us={}",
+                    dec,
+                    inj + locq,
+                    inj,
+                    locq,
+                    max_poll_us
+                );
+            }
+        });
+    }
+
+    fn start_heartbeat() {
+        let tick = Duration::from_millis(stellar_archivist::metrics::HEARTBEAT_TICK_MS);
+        tokio::spawn(async move {
+            loop {
+                let t0 = Instant::now();
+                tokio::time::sleep(tick).await;
+                stellar_archivist::metrics::record_heartbeat(t0.elapsed().saturating_sub(tick));
+            }
+        });
+    }
+}
+
+#[cfg(feature = "perf-metrics")]
+pub use imp::Session;
+
+/// Capture the window baselines and start the perf background tasks.
+#[cfg(feature = "perf-metrics")]
+pub fn start() -> Session {
+    imp::start()
+}
+
+// ---- No-op surface when perf-metrics is off (everything inlines away). ----
+
+/// Zero-sized stand-in so `main` can call `perf::start()` / `Session::report()`
+/// unconditionally; both compile to nothing without `--features perf-metrics`.
+#[cfg(not(feature = "perf-metrics"))]
+pub struct Session;
+
+#[cfg(not(feature = "perf-metrics"))]
+#[inline]
+pub fn start() -> Session {
+    Session
+}
+
+#[cfg(not(feature = "perf-metrics"))]
+impl Session {
+    #[inline]
+    pub fn report(self) {}
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -81,7 +81,7 @@ struct Cli {
     retry_max_delay_secs: u64,
 
     /// Maximum concurrent I/O operations per storage backend (source and destination each have their own limit)
-    #[arg(long, global = true, default_value_t = 64)]
+    #[arg(long, global = true, default_value_t = 128)]
     max_concurrent: usize,
 
     /// Request timeout in seconds (for metadata operations)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@
 #![allow(clippy::doc_markdown)]
 
 pub mod history_format;
+pub mod metrics;
 pub mod mirror_operation;
 pub mod pipeline;
 pub mod repair_operation;
@@ -43,6 +44,15 @@ pub mod xdr_verify;
 
 #[cfg(feature = "cli")]
 pub mod cli;
+
+/// Scoped phase timer. Always binds a `metrics::Guard`: a real RAII timer under
+/// `--features perf-metrics`, or a zero-sized no-op guard otherwise (compiled out).
+#[macro_export]
+macro_rules! phase {
+    ($p:expr) => {
+        $crate::metrics::Guard::new($p)
+    };
+}
 
 use thiserror::Error;
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,467 @@
+//! Lightweight, feature-gated performance instrumentation.
+//!
+//! Compiled to no-ops unless built with `--features perf-metrics`. Phase timers
+//! aggregate elapsed time across concurrent tasks via atomics. Phase times can
+//! overlap, so percentages are a profiler-style breakdown rather than a
+//! wall-clock critical path.
+
+#[repr(usize)]
+#[derive(Clone, Copy, Debug)]
+pub enum Phase {
+    HistoryFetch,
+    HistoryParse,
+    BucketStream,
+    XdrDecompress,
+    XdrParseLedger,
+    XdrParseTx,
+    XdrParseResult,
+    XdrParseScp,
+    CrossFileVerify,
+    ChainVerify,
+    Copy,
+}
+
+impl Phase {
+    /// One past the last variant. The enum uses the default contiguous
+    /// discriminants (`0..COUNT`), so this is the variant count; it sizes the
+    /// per-phase `NAMES`/`PHASES` arrays. Keep `Copy` last (or update this).
+    pub const COUNT: usize = Self::Copy as usize + 1;
+}
+
+/// Heartbeat probe tick. A spawned task sleeps this long each beat and records
+/// how much later than this it actually woke (scheduler/timer lag); a growing
+/// tail means the worker pool is too busy to promptly poll a ready task.
+pub const HEARTBEAT_TICK_MS: u64 = 10;
+
+/// Diagnostic gauge for Tokio runtime metrics: number of decode tasks (gzip+SHA
+/// bucket `hash_task` and gzip XDR `decompress_task`) currently alive.
+#[cfg(all(feature = "perf-metrics", tokio_unstable))]
+pub static ACTIVE_DECODES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// RAII guard for [`ACTIVE_DECODES`]: `enter()` at decode-task start, decrement on drop.
+pub struct DecodeGuard;
+impl DecodeGuard {
+    #[inline]
+    pub fn enter() -> Self {
+        #[cfg(all(feature = "perf-metrics", tokio_unstable))]
+        ACTIVE_DECODES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        DecodeGuard
+    }
+}
+impl Drop for DecodeGuard {
+    fn drop(&mut self) {
+        #[cfg(all(feature = "perf-metrics", tokio_unstable))]
+        ACTIVE_DECODES.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+#[cfg(feature = "perf-metrics")]
+const NAMES: [&str; Phase::COUNT] = [
+    "history_fetch",
+    "history_parse",
+    "bucket_stream",
+    "xdr_decompress",
+    "xdr_parse_ledger",
+    "xdr_parse_tx",
+    "xdr_parse_result",
+    "xdr_parse_scp",
+    "cross_file_verify",
+    "chain_verify",
+    "copy",
+];
+
+#[cfg(feature = "perf-metrics")]
+mod imp {
+    use super::{Phase, NAMES};
+    use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
+    use std::time::{Duration, Instant};
+
+    struct PhaseMetrics {
+        elapsed_ns: AtomicU64, // wall time summed over concurrent calls
+        calls: AtomicU64,
+        bytes: AtomicU64,
+    }
+    impl PhaseMetrics {
+        const fn new() -> Self {
+            Self {
+                elapsed_ns: AtomicU64::new(0),
+                calls: AtomicU64::new(0),
+                bytes: AtomicU64::new(0),
+            }
+        }
+
+        fn record_elapsed(&self, elapsed: Duration) {
+            self.elapsed_ns
+                .fetch_add(elapsed.as_nanos() as u64, Relaxed);
+            self.calls.fetch_add(1, Relaxed);
+        }
+
+        fn record_bytes(&self, bytes: u64) {
+            self.bytes.fetch_add(bytes, Relaxed);
+        }
+    }
+
+    struct FileObservations {
+        count: AtomicU64,
+        bytes: AtomicU64,
+    }
+    impl FileObservations {
+        const fn new() -> Self {
+            Self {
+                count: AtomicU64::new(0),
+                bytes: AtomicU64::new(0),
+            }
+        }
+
+        fn record(&self, bytes: u64) {
+            self.count.fetch_add(1, Relaxed);
+            self.bytes.fetch_add(bytes, Relaxed);
+        }
+
+        fn snapshot(&self) -> (u64, u64) {
+            (self.count.load(Relaxed), self.bytes.load(Relaxed))
+        }
+    }
+
+    static PHASES: [PhaseMetrics; Phase::COUNT] = [const { PhaseMetrics::new() }; Phase::COUNT];
+    static FILE_OBSERVATIONS: FileObservations = FileObservations::new();
+
+    fn phase_metrics(phase: Phase) -> &'static PhaseMetrics {
+        &PHASES[phase as usize]
+    }
+
+    /// Total process CPU time (user + system) in nanoseconds, across all threads,
+    /// accumulated since process start. Uses POSIX `getrusage` (Linux, macOS,
+    /// BSD); on non-Unix targets (e.g. Windows) it returns 0, so the feature
+    /// still builds there with CPU metrics reported as 0.
+    #[cfg(unix)]
+    pub fn process_cpu_nanos() -> u64 {
+        let mut ru = std::mem::MaybeUninit::<libc::rusage>::uninit();
+        unsafe {
+            if libc::getrusage(libc::RUSAGE_SELF, ru.as_mut_ptr()) != 0 {
+                return 0;
+            }
+            let ru = ru.assume_init();
+            // getrusage times are non-negative; try_from (vs `as`) makes that
+            // explicit — a negative would clamp to 0 rather than wrap huge.
+            let to_ns = |tv: libc::timeval| {
+                u64::try_from(tv.tv_sec)
+                    .unwrap_or(0)
+                    .wrapping_mul(1_000_000_000)
+                    .wrapping_add(u64::try_from(tv.tv_usec).unwrap_or(0).wrapping_mul(1000))
+            };
+            to_ns(ru.ru_utime).wrapping_add(to_ns(ru.ru_stime))
+        }
+    }
+
+    /// Non-Unix fallback: `getrusage` is unavailable (e.g. Windows), report 0.
+    #[cfg(not(unix))]
+    pub fn process_cpu_nanos() -> u64 {
+        0
+    }
+
+    /// RAII timer: records elapsed wall time plus a call count, on drop.
+    pub struct Guard {
+        phase: Phase,
+        start: Instant,
+    }
+    impl Guard {
+        pub fn new(phase: Phase) -> Self {
+            Self {
+                phase,
+                start: Instant::now(),
+            }
+        }
+
+        /// Record one completed file observed by this phase. The byte unit is
+        /// phase-specific: copy phases count compressed bytes streamed, while
+        /// verify/decode phases count decompressed bytes.
+        pub fn record_file(&self, bytes: u64) {
+            phase_metrics(self.phase).record_bytes(bytes);
+            FILE_OBSERVATIONS.record(bytes);
+        }
+    }
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            phase_metrics(self.phase).record_elapsed(self.start.elapsed());
+        }
+    }
+
+    // Heartbeat (runtime-responsiveness) accumulators. lag = how much later than
+    // HEARTBEAT_TICK_MS a beat actually woke; the over_*ms tails are the signal
+    // that the worker pool is too saturated to promptly poll a ready task.
+    static HB_BEATS: AtomicU64 = AtomicU64::new(0);
+    static HB_SUM_NS: AtomicU64 = AtomicU64::new(0);
+    static HB_MAX_NS: AtomicU64 = AtomicU64::new(0);
+    static HB_OVER_1MS: AtomicU64 = AtomicU64::new(0);
+    static HB_OVER_10MS: AtomicU64 = AtomicU64::new(0);
+    static HB_OVER_100MS: AtomicU64 = AtomicU64::new(0);
+
+    /// Record one heartbeat's scheduling lag (actual wake delay beyond the tick).
+    pub fn record_heartbeat(lag: Duration) {
+        let ns = lag.as_nanos() as u64;
+        HB_BEATS.fetch_add(1, Relaxed);
+        HB_SUM_NS.fetch_add(ns, Relaxed);
+        HB_MAX_NS.fetch_max(ns, Relaxed);
+        if ns >= 1_000_000 {
+            HB_OVER_1MS.fetch_add(1, Relaxed);
+        }
+        if ns >= 10_000_000 {
+            HB_OVER_10MS.fetch_add(1, Relaxed);
+        }
+        if ns >= 100_000_000 {
+            HB_OVER_100MS.fetch_add(1, Relaxed);
+        }
+    }
+
+    /// Snapshot: (beats, sum_ns, max_ns, over_1ms, over_10ms, over_100ms).
+    pub fn heartbeat_snapshot() -> (u64, u64, u64, u64, u64, u64) {
+        (
+            HB_BEATS.load(Relaxed),
+            HB_SUM_NS.load(Relaxed),
+            HB_MAX_NS.load(Relaxed),
+            HB_OVER_1MS.load(Relaxed),
+            HB_OVER_10MS.load(Relaxed),
+            HB_OVER_100MS.load(Relaxed),
+        )
+    }
+
+    /// Peak resident set size in **bytes**, normalized across platforms. Uses
+    /// POSIX `getrusage`; `ru_maxrss` is bytes on macOS and kilobytes on Linux.
+    /// On non-Unix targets (e.g. Windows) it returns 0.
+    #[cfg(unix)]
+    pub fn peak_rss_bytes() -> u64 {
+        let mut ru = std::mem::MaybeUninit::<libc::rusage>::uninit();
+        let max = unsafe {
+            if libc::getrusage(libc::RUSAGE_SELF, ru.as_mut_ptr()) != 0 {
+                return 0;
+            }
+            // ru_maxrss is non-negative; try_from avoids a sign-loss `as` cast.
+            u64::try_from(ru.assume_init().ru_maxrss).unwrap_or(0)
+        };
+        #[cfg(target_os = "macos")]
+        {
+            max // already bytes
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            max.saturating_mul(1024) // Linux & other POSIX report kibibytes
+        }
+    }
+
+    /// Non-Unix fallback: `getrusage` is unavailable (e.g. Windows), report 0.
+    #[cfg(not(unix))]
+    pub fn peak_rss_bytes() -> u64 {
+        0
+    }
+
+    /// Format the ` worker_cores_avg=... workers=...` suffix appended to the
+    /// `PERF_CPU` line. `worker_busy` is `Some((in-window summed
+    /// worker_total_busy_duration, num_workers))` when built with
+    /// `--cfg tokio_unstable`; otherwise it is `None` and the suffix is empty.
+    /// `worker_cores_avg = busy / wall`: the mean number of Tokio workers
+    /// concurrently inside a poll (worker-pool occupancy, not CPU cores).
+    pub(crate) fn worker_cores_suffix(
+        wall: Duration,
+        worker_busy: Option<(Duration, usize)>,
+    ) -> String {
+        match worker_busy {
+            Some((busy, nw)) => {
+                let wca = if wall.as_secs_f64() > 0.0 {
+                    busy.as_secs_f64() / wall.as_secs_f64()
+                } else {
+                    0.0
+                };
+                format!(" worker_cores_avg={wca:.2} workers={nw}")
+            }
+            None => String::new(),
+        }
+    }
+
+    /// `cpu_ns`: process CPU time (user+sys, all threads) consumed during the
+    /// measured window. `worker_busy`: `Some((in-window summed
+    /// worker_total_busy_duration, num_workers))` under `--cfg tokio_unstable`,
+    /// else `None` (see [`worker_cores_suffix`]).
+    // u64 counters (nanos/bytes/counts) -> f64 for ms/MB/MB/s/%/cores_avg
+    // display math; precision loss above 2^53 is irrelevant for these readouts.
+    #[allow(clippy::cast_precision_loss)]
+    pub fn report(wall: Duration, cpu_ns: u64, worker_busy: Option<(Duration, usize)>) {
+        let total_ns: u64 = (0..Phase::COUNT)
+            .map(|i| PHASES[i].elapsed_ns.load(Relaxed))
+            .sum();
+        let peak_mb = peak_rss_bytes() as f64 / 1e6;
+        let (files, bytes) = FILE_OBSERVATIONS.snapshot();
+        let mbps = if wall.as_secs_f64() > 0.0 {
+            (bytes as f64 / 1e6) / wall.as_secs_f64()
+        } else {
+            0.0
+        };
+        let cores_avg = if wall.as_secs_f64() > 0.0 {
+            cpu_ns as f64 / 1e9 / wall.as_secs_f64()
+        } else {
+            0.0
+        };
+        eprintln!(
+            "PERF wall_ms={} peak_rss_mb={:.1} files_measured={} measured_bytes={} measured_mb_per_s={:.1}",
+            wall.as_millis(),
+            peak_mb,
+            files,
+            bytes,
+            mbps
+        );
+        let worker_str = worker_cores_suffix(wall, worker_busy);
+        eprintln!(
+            "PERF_CPU total_cpu_ms={:.1} cores_avg={:.2}{}",
+            cpu_ns as f64 / 1e6,
+            cores_avg,
+            worker_str
+        );
+        // Runtime responsiveness. Counts only — scripts derive percentages
+        // (e.g. over_10ms / beats). over_10ms/over_100ms are the real signal;
+        // sub-ms lag is mostly timer granularity.
+        let (hb_beats, hb_sum_ns, hb_max_ns, hb_1, hb_10, hb_100) = heartbeat_snapshot();
+        let hb_mean_us = if hb_beats > 0 {
+            hb_sum_ns as f64 / 1000.0 / hb_beats as f64
+        } else {
+            0.0
+        };
+        eprintln!(
+            "PERF_HEARTBEAT beats={} tick_ms={} mean_us={:.1} max_us={:.1} over_1ms={} over_10ms={} over_100ms={}",
+            hb_beats,
+            super::HEARTBEAT_TICK_MS,
+            hb_mean_us,
+            hb_max_ns as f64 / 1000.0,
+            hb_1,
+            hb_10,
+            hb_100
+        );
+        // Columns: name, elapsed_ms, elapsed_pct, calls, phase_mb, phase_mb_per_s.
+        // Elapsed time includes .await wait for async-scoped phases.
+        for i in 0..Phase::COUNT {
+            let ns = PHASES[i].elapsed_ns.load(Relaxed);
+            let pct = if total_ns > 0 {
+                ns as f64 * 100.0 / total_ns as f64
+            } else {
+                0.0
+            };
+            let mb = PHASES[i].bytes.load(Relaxed) as f64 / 1e6;
+            let secs = ns as f64 / 1e9;
+            let phase_mbps = if secs > 0.0 { mb / secs } else { 0.0 };
+            eprintln!(
+                "PERF_PHASE {},{:.1},{:.1},{},{:.1},{:.1}",
+                NAMES[i],
+                ns as f64 / 1e6,
+                pct,
+                PHASES[i].calls.load(Relaxed),
+                mb,
+                phase_mbps
+            );
+        }
+    }
+}
+
+#[cfg(feature = "perf-metrics")]
+pub use imp::{
+    heartbeat_snapshot, peak_rss_bytes, process_cpu_nanos, record_heartbeat, report, Guard,
+};
+
+/// Zero-sized stand-in for the timing [`imp::Guard`] when the feature is off, so
+/// the `phase!` macro binds a real value (no unit-binding lints) and inlines away.
+#[cfg(not(feature = "perf-metrics"))]
+pub struct Guard;
+#[cfg(not(feature = "perf-metrics"))]
+impl Guard {
+    #[inline]
+    pub fn new(_phase: Phase) -> Self {
+        Guard
+    }
+
+    #[inline]
+    pub fn record_file(&self, _bytes: u64) {}
+}
+
+#[cfg(all(test, feature = "perf-metrics"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[allow(clippy::cast_precision_loss)] // bytes -> MB for the log line
+    fn guard_records_and_rss_is_sane() {
+        {
+            let bucket_phase = Guard::new(Phase::BucketStream);
+            bucket_phase.record_file(4096);
+        }
+        let rss = peak_rss_bytes();
+        // On Unix a live process must have a positive peak RSS of a plausible
+        // magnitude (1 MB–100 GB) — catches unit mistakes. On non-Unix it's the
+        // 0 fallback (no getrusage).
+        #[cfg(unix)]
+        {
+            assert!(
+                rss > 1_000_000,
+                "peak RSS too small ({rss} bytes) — unit bug?"
+            );
+            assert!(
+                rss < 100_000_000_000,
+                "peak RSS implausibly large ({rss} bytes) — unit bug?"
+            );
+            eprintln!("peak_rss_bytes() = {rss} ({:.1} MB)", rss as f64 / 1e6);
+        }
+        #[cfg(not(unix))]
+        assert_eq!(rss, 0, "non-Unix peak_rss_bytes() is the 0 fallback");
+    }
+
+    #[test]
+    fn worker_cores_suffix_formats_and_is_bounded() {
+        use std::time::Duration;
+        // No worker metrics (built without tokio_unstable) -> empty suffix.
+        assert_eq!(
+            super::imp::worker_cores_suffix(Duration::from_secs(1), None),
+            ""
+        );
+        // busy == num_workers × wall -> worker_cores_avg == num_workers exactly:
+        // the bound holds with equality and never overshoots.
+        assert_eq!(
+            super::imp::worker_cores_suffix(
+                Duration::from_secs(2),
+                Some((Duration::from_secs(20), 10))
+            ),
+            " worker_cores_avg=10.00 workers=10"
+        );
+        // Half the workers busy on average over the window.
+        assert_eq!(
+            super::imp::worker_cores_suffix(
+                Duration::from_secs(2),
+                Some((Duration::from_secs(10), 10))
+            ),
+            " worker_cores_avg=5.00 workers=10"
+        );
+        // wall == 0 -> no division by zero.
+        assert_eq!(
+            super::imp::worker_cores_suffix(Duration::ZERO, Some((Duration::from_secs(5), 8))),
+            " worker_cores_avg=0.00 workers=8"
+        );
+    }
+
+    #[test]
+    fn heartbeat_records_lags_and_buckets() {
+        let (beats_before, _, _, _, ten_ms_before, hundred_ms_before) = heartbeat_snapshot();
+        record_heartbeat(std::time::Duration::from_micros(200)); // < 1ms
+        record_heartbeat(std::time::Duration::from_millis(5)); //   >= 1ms
+        record_heartbeat(std::time::Duration::from_millis(50)); //  >= 10ms
+        record_heartbeat(std::time::Duration::from_millis(500)); // >= 100ms
+        let (beats_after, _, max_ns, _, ten_ms_after, hundred_ms_after) = heartbeat_snapshot();
+        // This is the only test that records heartbeats, so deltas are
+        // attributable even under parallel execution.
+        assert_eq!(beats_after - beats_before, 4);
+        assert!(
+            ten_ms_after - ten_ms_before >= 2,
+            "the 50ms and 500ms beats exceed 10ms"
+        );
+        assert!(
+            hundred_ms_after - hundred_ms_before >= 1,
+            "the 500ms beat exceeds 100ms"
+        );
+        assert!(max_ns >= 500_000_000, "max captures the 500ms beat");
+    }
+}

--- a/src/mirror_operation.rs
+++ b/src/mirror_operation.rs
@@ -426,10 +426,18 @@ impl Operation for MirrorOperation {
             }
         }
 
-        let buffer = storage::download_buffer(&self.src_store, path).await?;
+        let buffer = {
+            let fetch_phase = crate::phase!(crate::metrics::Phase::HistoryFetch);
+            let buffer = storage::download_buffer(&self.src_store, path).await?;
+            fetch_phase.record_file(buffer.len() as u64);
+            buffer
+        };
         // Parse-before-write: never commit an unparseable HAS to the destination.
-        let state = history_format::parse_history(&buffer, path)
-            .map_err(|e| StorageError::fatal(format!("failed to parse history {path}: {e}")))?;
+        let state = {
+            let _g = crate::phase!(crate::metrics::Phase::HistoryParse);
+            history_format::parse_history(&buffer, path)
+        }
+        .map_err(|e| StorageError::fatal(format!("failed to parse history {path}: {e}")))?;
         storage::write_buffer_with_cleanup(&self.dst_store, path, buffer).await?;
         Ok(HistoryOutcome {
             outcome: ProcessOutcome::Processed,

--- a/src/repair_operation.rs
+++ b/src/repair_operation.rs
@@ -703,9 +703,17 @@ impl Operation for RepairOperation {
         }
 
         // Fetch from source, parse (before writing), then write to destination.
-        let buffer = storage::download_buffer(&self.src_store, path).await?;
-        let state = history_format::parse_history(&buffer, path)
-            .map_err(|e| StorageError::fatal(format!("failed to parse history {path}: {e}")))?;
+        let buffer = {
+            let fetch_phase = crate::phase!(crate::metrics::Phase::HistoryFetch);
+            let buffer = storage::download_buffer(&self.src_store, path).await?;
+            fetch_phase.record_file(buffer.len() as u64);
+            buffer
+        };
+        let state = {
+            let _g = crate::phase!(crate::metrics::Phase::HistoryParse);
+            history_format::parse_history(&buffer, path)
+        }
+        .map_err(|e| StorageError::fatal(format!("failed to parse history {path}: {e}")))?;
         storage::write_buffer_with_cleanup(&self.dst_store, path, buffer).await?;
         Ok(HistoryOutcome {
             outcome: ProcessOutcome::Processed,

--- a/src/scan_operation.rs
+++ b/src/scan_operation.rs
@@ -164,9 +164,17 @@ impl Operation for ScanOperation {
     /// Scan reads the history file from the source and parses it for bucket
     /// discovery; it never writes.
     async fn process_history(&self, path: &str) -> Result<HistoryOutcome, StorageError> {
-        let buffer = crate::storage::download_buffer(&self.src_store, path).await?;
-        let state = crate::history_format::parse_history(&buffer, path)
-            .map_err(|e| StorageError::fatal(format!("failed to parse history {path}: {e}")))?;
+        let buffer = {
+            let fetch_phase = crate::phase!(crate::metrics::Phase::HistoryFetch);
+            let buffer = crate::storage::download_buffer(&self.src_store, path).await?;
+            fetch_phase.record_file(buffer.len() as u64);
+            buffer
+        };
+        let state = {
+            let _g = crate::phase!(crate::metrics::Phase::HistoryParse);
+            crate::history_format::parse_history(&buffer, path)
+        }
+        .map_err(|e| StorageError::fatal(format!("failed to parse history {path}: {e}")))?;
         Ok(HistoryOutcome {
             outcome: ProcessOutcome::Processed,
             state: Some(state),

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -63,6 +63,34 @@ impl Error {
 
 pub type StorageRef = Arc<dyn Storage + Send + Sync>;
 
+/// Stream all bytes from `reader` into `writer`, returning the number of bytes
+/// copied. Each chunk is parked into the sink with `feed` (start_send under
+/// poll_ready backpressure) without an intermediate flush; the single `close()`
+/// then flushes the buffered data and finalizes the write (uploads the final
+/// part / fsync+rename). This matches `Sink::send_all`'s deferred-flush
+/// behavior — avoiding a flush per chunk — while exposing the byte count.
+async fn copy_reader_to_writer(reader: Reader, writer: Writer, object: &str) -> Result<u64, Error> {
+    let mut stream = reader
+        .into_stream(..)
+        .await
+        .map_err(|e| from_opendal_error(e, &format!("Failed to create stream for {object}")))?;
+
+    let mut copied_bytes = 0u64;
+    let mut sink = writer.into_sink();
+    while let Some(result) = stream.next().await {
+        let buffer = result
+            .map_err(|e| from_opendal_error(e, &format!("Failed to read data for {object}")))?;
+        copied_bytes += buffer.len() as u64;
+        sink.feed(buffer)
+            .await
+            .map_err(|e| from_opendal_error(e, &format!("Failed to write data to {object}")))?;
+    }
+    sink.close()
+        .await
+        .map_err(|e| from_opendal_error(e, &format!("Failed to close writer for {object}")))?;
+    Ok(copied_bytes)
+}
+
 /// Core unified storage trait for all backends
 #[async_trait]
 pub trait Storage: Send + Sync {
@@ -101,22 +129,10 @@ pub trait Storage: Send + Sync {
     /// Streams data in chunks without buffering the entire file in memory.
     /// Only supported by writable backends (e.g., filesystem).
     async fn copy_from_reader(&self, object: &str, reader: Reader) -> Result<(), Error> {
+        let copy_phase = crate::phase!(crate::metrics::Phase::Copy);
         let writer = self.open_writer(object).await?;
-
-        // Convert reader to a stream of Buffer chunks (zero-copy)
-        // The range `..` means read all data
-        let mut stream = reader
-            .into_stream(..)
-            .await
-            .map_err(|e| from_opendal_error(e, &format!("Failed to create stream for {object}")))?;
-
-        let mut sink = writer.into_sink();
-        sink.send_all(&mut stream)
-            .await
-            .map_err(|e| from_opendal_error(e, &format!("Failed to write data to {object}")))?;
-        sink.close()
-            .await
-            .map_err(|e| from_opendal_error(e, &format!("Failed to close writer for {object}")))?;
+        let copied_bytes = copy_reader_to_writer(reader, writer, object).await?;
+        copy_phase.record_file(copied_bytes);
         Ok(())
     }
 
@@ -297,7 +313,7 @@ impl OpendalStore {
         root_path: &Path,
         object: &str,
         reader: Reader,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         let object = object.trim_start_matches('/');
         let file_path = root_path.join(object);
         let tmp_path = file_path.with_added_extension("tmp");
@@ -323,10 +339,12 @@ impl OpendalStore {
             .await
             .map_err(|e| from_opendal_error(e, &format!("Failed to create stream for {object}")))?;
 
-        let write_result: Result<(), Error> = async {
+        let write_result: Result<u64, Error> = async {
+            let mut copied_bytes = 0u64;
             while let Some(result) = stream.next().await {
                 let buffer =
                     result.map_err(|e| from_opendal_error(e, "Failed to read from source"))?;
+                copied_bytes += buffer.len() as u64;
                 for bytes in buffer {
                     file.write_all(&bytes).await.map_err(|e| {
                         from_io_error(e, &format!("Failed to write to {}", tmp_path.display()))
@@ -336,14 +354,17 @@ impl OpendalStore {
             file.flush().await.map_err(|e| {
                 from_io_error(e, &format!("Failed to flush {}", tmp_path.display()))
             })?;
-            Ok(())
+            Ok(copied_bytes)
         }
         .await;
 
-        if let Err(e) = write_result {
-            let _ = tokio::fs::remove_file(&tmp_path).await;
-            return Err(e);
-        }
+        let copied_bytes = match write_result {
+            Ok(copied_bytes) => copied_bytes,
+            Err(e) => {
+                let _ = tokio::fs::remove_file(&tmp_path).await;
+                return Err(e);
+            }
+        };
 
         if let Err(e) = tokio::fs::rename(&tmp_path, &file_path).await {
             let _ = tokio::fs::remove_file(&tmp_path).await;
@@ -357,7 +378,7 @@ impl OpendalStore {
             ));
         }
 
-        Ok(())
+        Ok(copied_bytes)
     }
 
     // ===== Filesystem Backend =====
@@ -741,34 +762,23 @@ impl Storage for OpendalStore {
     }
 
     async fn copy_from_reader(&self, object: &str, reader: Reader) -> Result<(), Error> {
+        let copy_phase = crate::phase!(crate::metrics::Phase::Copy);
         // If we have a filesystem root and atomic writes are disabled, use direct tokio::fs writes
         // to bypass OpenDAL's WriteGenerator buffering and avoid the fsync in close().
         if let Some(root_path) = &self.root_path {
             if !self.atomic_file_writes {
-                return self
+                let copied_bytes = self
                     .copy_from_reader_direct(root_path, object, reader)
-                    .await;
+                    .await?;
+                copy_phase.record_file(copied_bytes);
+                return Ok(());
             }
         }
 
         // Otherwise use OpenDAL's writer (required for non-filesystem backends or when atomic writes are enabled)
         let writer = self.open_writer(object).await?;
-        // Convert reader to a stream of Buffer chunks (zero-copy)
-        // The range `..` means read all data
-        let mut stream = reader
-            .into_stream(..)
-            .await
-            .map_err(|e| from_opendal_error(e, &format!("Failed to create stream for {object}")))?;
-
-        let mut sink = writer.into_sink();
-        sink.send_all(&mut stream)
-            .await
-            .map_err(|e| from_opendal_error(e, &format!("Failed to write data to {object}")))?;
-
-        // Always call close() when using OpenDAL writer - it's required to flush internal buffers
-        sink.close()
-            .await
-            .map_err(|e| from_opendal_error(e, &format!("Failed to close writer for {object}")))?;
+        let copied_bytes = copy_reader_to_writer(reader, writer, object).await?;
+        copy_phase.record_file(copied_bytes);
         Ok(())
     }
 

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -23,6 +23,7 @@ async fn verify_bucket_maybe_write(
     reader: Reader,
     writer: Option<Writer>,
 ) -> Result<(), StorageError> {
+    let bucket_phase = crate::phase!(crate::metrics::Phase::BucketStream);
     use futures_util::SinkExt;
 
     let expected = bucket_hash_from_path(path)
@@ -37,6 +38,7 @@ async fn verify_bucket_maybe_write(
     let (tx, rx) = tokio::sync::mpsc::channel::<Bytes>(CHANNEL_CAPACITY);
 
     let hash_task = tokio::spawn(async move {
+        let _dg = crate::metrics::DecodeGuard::enter();
         let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
         let stream = stream.map(Ok::<_, std::io::Error>);
         let stream_reader = tokio_util::io::StreamReader::new(stream);
@@ -44,6 +46,7 @@ async fn verify_bucket_maybe_write(
 
         let mut hasher = Sha256::new();
         let mut buf = vec![0u8; HASH_BUFFER_SIZE];
+        let mut decompressed_bytes: u64 = 0;
 
         loop {
             let n = decoder.read(&mut buf).await?;
@@ -51,9 +54,10 @@ async fn verify_bucket_maybe_write(
                 break;
             }
             hasher.update(&buf[..n]);
+            decompressed_bytes += n as u64;
         }
 
-        Ok::<_, std::io::Error>(hex::encode(hasher.finalize()))
+        Ok::<_, std::io::Error>((hex::encode(hasher.finalize()), decompressed_bytes))
     });
 
     futures_util::pin_mut!(stream);
@@ -102,7 +106,7 @@ async fn verify_bucket_maybe_write(
         return Err(err);
     }
 
-    let actual = hash_task
+    let (actual, decompressed_bytes) = hash_task
         .await
         .map_err(|e| StorageError::fatal(format!("Hash task panicked for {}: {}", path, e)))?
         .map_err(|e| StorageError::retry(format!("Failed to decompress {}: {}", path, e)))?;
@@ -121,10 +125,16 @@ async fn verify_bucket_maybe_write(
             .map_err(|e| from_opendal_error(e, &format!("Failed to close {}", path)))?;
     }
 
+    bucket_phase.record_file(decompressed_bytes);
+
     Ok(())
 }
 
 /// Verify a bucket file's hash (scan operation).
+///
+/// Delegates to the production async streaming path
+/// ([`verify_bucket_maybe_write`] with no writer), the shipped decode used by
+/// scan-verify.
 pub async fn verify_bucket_stream(path: &str, reader: Reader) -> Result<(), StorageError> {
     debug!("Verifying bucket hash for {}", path);
     verify_bucket_maybe_write(path, reader, None).await

--- a/src/xdr_verify.rs
+++ b/src/xdr_verify.rs
@@ -239,6 +239,7 @@ impl XdrVerificationManager {
     /// No-op if no data was recorded for this checkpoint. If ledger data is
     /// missing but tx/result data exists, records a warning error.
     pub(crate) fn verify_and_release(&self, checkpoint: u32) {
+        let _g = crate::phase!(crate::metrics::Phase::CrossFileVerify);
         let data = {
             let mut pending = self.pending.lock().unwrap();
             pending.remove(&checkpoint)
@@ -534,6 +535,7 @@ impl XdrVerificationManager {
     /// Only checks adjacent checkpoints separated by exactly `CHECKPOINT_FREQUENCY` —
     /// non-consecutive checkpoints (from partial or bounded scans) are skipped.
     pub(crate) fn verify_checkpoint_chain(&self) {
+        let _g = crate::phase!(crate::metrics::Phase::ChainVerify);
         let boundaries = self.boundaries.lock().unwrap();
         let mut chain_errors = Vec::new();
 
@@ -622,6 +624,7 @@ pub(crate) fn parse_ledger_header_entries_for_checkpoint(
     decompressed_data: &[u8],
     checkpoint: Option<u32>,
 ) -> Result<BTreeMap<u32, LedgerHeaderVerificationData>, StorageError> {
+    let _g = crate::phase!(crate::metrics::Phase::XdrParseLedger);
     let cursor = Cursor::new(decompressed_data);
     let mut limited = Limited::new(cursor, Limits::none());
     let mut data = BTreeMap::new();
@@ -780,6 +783,7 @@ pub(crate) fn parse_result_entries_for_checkpoint(
     decompressed_data: &[u8],
     checkpoint: Option<u32>,
 ) -> Result<BTreeMap<u32, Hash>, StorageError> {
+    let _g = crate::phase!(crate::metrics::Phase::XdrParseResult);
     let cursor = Cursor::new(decompressed_data);
     let mut limited = Limited::new(cursor, Limits::none());
     let mut hashes = BTreeMap::new();
@@ -833,26 +837,16 @@ pub(crate) fn parse_result_entries_for_checkpoint(
     Ok(hashes)
 }
 
-/// Decompress a gzipped reader into an in-memory `Vec<u8>`. No write side —
-/// thin wrapper over [`decompress_and_write_internal`] with `writer = None`.
-async fn decompress_to_buffer(path: &str, reader: Reader) -> Result<Vec<u8>, StorageError> {
-    // the writer is None, thus the return sink is also None, which is safe to
-    // be discarded
-    let (decompressed, _) = decompress_and_write_internal(path, reader, None).await?;
-    Ok(decompressed)
-}
-
-/// Decompress a gzipped ledger file from a reader and parse it.
-/// Infers the checkpoint number from the file path for range validation.
 pub async fn parse_ledger_header_stream(
     path: &str,
     reader: Reader,
 ) -> Result<BTreeMap<u32, LedgerHeaderVerificationData>, StorageError> {
-    let decompressed = decompress_to_buffer(path, reader).await?;
-    parse_ledger_header_entries_for_checkpoint(
-        &decompressed,
-        history_format::checkpoint_from_path(path),
-    )
+    let cp = history_format::checkpoint_from_path(path);
+    Ok(decompress_then(path, reader, None, move |b| {
+        parse_ledger_header_entries_for_checkpoint(b, cp)
+    })
+    .await?
+    .0)
 }
 
 /// Decompress a gzipped result file from a reader and parse it.
@@ -861,8 +855,12 @@ pub async fn parse_results_stream(
     path: &str,
     reader: Reader,
 ) -> Result<BTreeMap<u32, Hash>, StorageError> {
-    let decompressed = decompress_to_buffer(path, reader).await?;
-    parse_result_entries_for_checkpoint(&decompressed, history_format::checkpoint_from_path(path))
+    let cp = history_format::checkpoint_from_path(path);
+    Ok(decompress_then(path, reader, None, move |b| {
+        parse_result_entries_for_checkpoint(b, cp)
+    })
+    .await?
+    .0)
 }
 
 /// Parse decompressed transaction XDR data, computing content hashes per ledger.
@@ -877,6 +875,7 @@ pub(crate) fn parse_transaction_entries_for_checkpoint(
     decompressed_data: &[u8],
     checkpoint: Option<u32>,
 ) -> Result<BTreeMap<u32, Hash>, StorageError> {
+    let _g = crate::phase!(crate::metrics::Phase::XdrParseTx);
     let cursor = Cursor::new(decompressed_data);
     let mut limited = Limited::new(cursor, Limits::none());
     let mut hashes = BTreeMap::new();
@@ -928,6 +927,7 @@ pub(crate) fn parse_transaction_entries_for_checkpoint(
 /// Validate SCP history XDR frame structure. Only checks that frames deserialize
 /// correctly — no hashes are computed or returned. Fatal error on malformed XDR.
 pub fn parse_scp_entries(decompressed_data: &[u8]) -> Result<(), StorageError> {
+    let _g = crate::phase!(crate::metrics::Phase::XdrParseScp);
     let cursor = Cursor::new(decompressed_data);
     let mut limited = Limited::new(cursor, Limits::none());
 
@@ -945,17 +945,19 @@ pub async fn parse_transactions_stream(
     path: &str,
     reader: Reader,
 ) -> Result<BTreeMap<u32, Hash>, StorageError> {
-    let decompressed = decompress_to_buffer(path, reader).await?;
-    parse_transaction_entries_for_checkpoint(
-        &decompressed,
-        history_format::checkpoint_from_path(path),
-    )
+    let cp = history_format::checkpoint_from_path(path);
+    Ok(decompress_then(path, reader, None, move |b| {
+        parse_transaction_entries_for_checkpoint(b, cp)
+    })
+    .await?
+    .0)
 }
 
 /// Decompress a gzipped SCP file from a reader and validate its frame structure.
 pub async fn parse_scp_stream(path: &str, reader: Reader) -> Result<(), StorageError> {
-    let decompressed = decompress_to_buffer(path, reader).await?;
-    parse_scp_entries(&decompressed)
+    decompress_then(path, reader, None, parse_scp_entries)
+        .await
+        .map(|(parsed, _sink)| parsed)
 }
 
 /// Result of parsing an XDR archive file during a verified mirror write.
@@ -968,34 +970,28 @@ pub enum XdrParseResult {
     None,
 }
 
-/// Streaming core: read gzipped bytes from `reader`, optionally tee-write the
-/// raw (still-compressed) bytes to `writer`, and return the fully decompressed
-/// payload alongside the **unclosed** sink.
+/// Streaming core for every XDR file: read gzipped bytes from `reader`,
+/// optionally tee the still-compressed bytes to `writer`, gzip-decode to a
+/// buffer, and run `parse` on it ALL inside one spawned task (gzip decode AND
+/// the XDR parse/hash leave the orchestration task; the caller only feeds
+/// chunks). Returns the parse result alongside the **unclosed** sink (`None`
+/// when `writer` is `None`); the caller commits a write only after `parse`
+/// succeeds (parse-before-commit), so a parse failure never leaves committed
+/// corrupt data.
 ///
-/// Pipeline:
-/// 1. Pull gzipped chunks from `reader`'s opendal stream.
-/// 2. For each chunk: forward the compressed bytes to `sink` (if present), and
-///    push them through an mpsc channel into a spawned decompression task.
-/// 3. The decompression task feeds the channel through a `GzipDecoder` and
-///    accumulates the decompressed bytes into a `Vec<u8>`.
-/// 4. When the source stream ends, the channel closes and the decompression
-///    task returns.
-///
-/// **Sink lifecycle**: the returned sink is *not* closed. The caller closes it
-/// only after additional verification (e.g. XDR parse) succeeds — that way a
-/// post-write verification failure can `drop(sink)` and avoid committing
-/// corrupt data on atomic-write backends. On non-atomic backends, partial data
-/// is already on disk via `sink.send`, so the caller must additionally call
-/// [`cleanup_non_atomic_partial_write`] on failure.
-///
-/// Errors:
-/// - **Retry**: malformed gzip framing (decompression error)
-/// - **Fatal**: storage I/O error on read or write, or decompress task panic
-async fn decompress_and_write_internal(
+/// Error classes (the pipeline retries only `ErrorClass::Retry`): gzip framing
+/// → `retry`; XDR parse/hash → whatever `parse` returns (`fatal` in practice);
+/// storage I/O → opendal-classified; channel-closed or task panic → `fatal`.
+async fn decompress_then<T>(
     path: &str,
     reader: Reader,
     writer: Option<Writer>,
-) -> Result<(Vec<u8>, Option<opendal::BufferSink>), StorageError> {
+    parse: impl FnOnce(&[u8]) -> Result<T, StorageError> + Send + 'static,
+) -> Result<(T, Option<opendal::BufferSink>), StorageError>
+where
+    T: Send + 'static,
+{
+    let decompress_phase = crate::phase!(crate::metrics::Phase::XdrDecompress);
     use futures_util::SinkExt;
 
     let stream = reader
@@ -1004,25 +1000,30 @@ async fn decompress_and_write_internal(
         .map_err(|e| from_opendal_error(e, &format!("failed to create stream for {}", path)))?;
 
     let (tx, rx) = tokio::sync::mpsc::channel::<Bytes>(CHANNEL_CAPACITY);
+    let path_owned = path.to_string();
 
-    let decompress_task = tokio::spawn(async move {
-        let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-        let stream = stream.map(Ok::<_, std::io::Error>);
-        let stream_reader = StreamReader::new(stream);
-        let mut decoder = GzipDecoder::new(BufReader::new(stream_reader));
+    // Decode then parse, both inside the spawned task. Returns the parse result
+    // plus the decompressed length so the parent records byte metrics exactly once.
+    let task = tokio::spawn(async move {
+        let _dg = crate::metrics::DecodeGuard::enter();
+        let stream = tokio_stream::wrappers::ReceiverStream::new(rx).map(Ok::<_, std::io::Error>);
+        let mut decoder = GzipDecoder::new(BufReader::new(StreamReader::new(stream)));
 
         let mut decompressed = Vec::new();
         let mut buf = vec![0u8; DECOMPRESS_BUFFER_SIZE];
-
         loop {
-            let n = decoder.read(&mut buf).await?;
+            let n = decoder.read(&mut buf).await.map_err(|e| {
+                StorageError::retry(format!("failed to decompress {}: {}", path_owned, e))
+            })?;
             if n == 0 {
                 break;
             }
             decompressed.extend_from_slice(&buf[..n]);
         }
 
-        Ok::<_, std::io::Error>(decompressed)
+        let len = decompressed.len() as u64;
+        let parsed = parse(&decompressed)?; // parse carries its own phase!(XdrParse*)
+        Ok::<(T, u64), StorageError>((parsed, len))
     });
 
     futures_util::pin_mut!(stream);
@@ -1066,19 +1067,20 @@ async fn decompress_and_write_internal(
     drop(tx);
 
     if let Some(err) = streaming_error {
-        decompress_task.abort();
-        return Err(err);
+        task.abort();
+        return Err(err); // sink dropped here unclosed — caller cleans up
     }
 
-    let decompressed = decompress_task
-        .await
-        .map_err(|e| StorageError::fatal(format!("decompress task panicked for {}: {}", path, e)))?
-        .map_err(|e| StorageError::retry(format!("failed to decompress {}: {}", path, e)))?;
+    let (parsed, len) = task.await.map_err(|e| {
+        StorageError::fatal(format!(
+            "decompress/parse task panicked for {}: {}",
+            path, e
+        ))
+    })??;
 
-    // Return the unclosed sink — caller is responsible for closing it only after
-    // verification succeeds, preventing corrupt data from being committed on
-    // atomic backends.
-    Ok((decompressed, sink))
+    decompress_phase.record_file(len);
+
+    Ok((parsed, sink))
 }
 
 /// Remove a partially-written file after a verified-write fails.
@@ -1177,45 +1179,30 @@ pub async fn verify_and_write_xdr(
     };
 
     let writer = dst_store.open_writer(&write_path).await?;
-    let (decompressed, sink) =
-        match decompress_and_write_internal(&write_path, reader, Some(writer)).await {
-            Ok(result) => result,
-            Err(e) => {
-                // Decompression or I/O error — sink was dropped inside
-                // decompress_and_write_internal without close. Clean up any
-                // partial data on non-atomic backends.
-                cleanup_non_atomic_partial_write(&write_path, dst_store).await;
-                return Err(e);
-            }
-        };
 
-    let parse_result = if crate::history_format::is_ledger_header_file(path) {
-        parse_ledger_header_entries_for_checkpoint(
-            &decompressed,
-            history_format::checkpoint_from_path(path),
-        )
-        .map(XdrParseResult::Ledger)
-    } else if crate::history_format::is_results_file(path) {
-        parse_result_entries_for_checkpoint(
-            &decompressed,
-            history_format::checkpoint_from_path(path),
-        )
-        .map(XdrParseResult::Results)
-    } else if crate::history_format::is_transactions_file(path) {
-        parse_transaction_entries_for_checkpoint(
-            &decompressed,
-            history_format::checkpoint_from_path(path),
-        )
-        .map(XdrParseResult::Transactions)
-    } else if crate::history_format::is_scp_file(path) {
-        parse_scp_entries(&decompressed).map(|()| XdrParseResult::None)
-    } else {
-        Ok(XdrParseResult::None)
+    // Decode + parse run together in the spawned task. The closure captures
+    // only owned data (the logical `path` for file-type detection and `cp`) so
+    // it is `Send + 'static`. Classify on `path`, NOT `write_path`, so a `.tmp`
+    // sibling is never misread as an unrecognized type.
+    let cp = history_format::checkpoint_from_path(path);
+    let path_owned = path.to_string();
+    let parse = move |b: &[u8]| -> Result<XdrParseResult, StorageError> {
+        if crate::history_format::is_ledger_header_file(&path_owned) {
+            parse_ledger_header_entries_for_checkpoint(b, cp).map(XdrParseResult::Ledger)
+        } else if crate::history_format::is_results_file(&path_owned) {
+            parse_result_entries_for_checkpoint(b, cp).map(XdrParseResult::Results)
+        } else if crate::history_format::is_transactions_file(&path_owned) {
+            parse_transaction_entries_for_checkpoint(b, cp).map(XdrParseResult::Transactions)
+        } else if crate::history_format::is_scp_file(&path_owned) {
+            parse_scp_entries(b).map(|()| XdrParseResult::None)
+        } else {
+            Ok(XdrParseResult::None)
+        }
     };
 
-    match parse_result {
-        Ok(result) => {
-            // Verification passed — close sink to commit the write
+    match decompress_then(&write_path, reader, Some(writer), parse).await {
+        Ok((result, sink)) => {
+            // Parse passed — close the sink to commit the write.
             if let Some(mut s) = sink {
                 s.close().await.map_err(|e| {
                     from_opendal_error(e, &format!("failed to close {}", write_path))
@@ -1225,12 +1212,12 @@ pub async fn verify_and_write_xdr(
             commit_non_atomic_write(dst_store, &write_path, path).await?;
             Ok(result)
         }
-        Err(err) => {
-            // Verification failed — don't close sink, prevents committing corrupt data
-            // on atomic backends. For non-atomic backends, data is already on disk via
-            // send() so clean up the partial file.
+        Err(e) => {
+            // Decode or parse failed — `decompress_then` dropped the sink unclosed
+            // (no commit on atomic backends). On non-atomic backends partial data
+            // may be on disk via send(), so remove it.
             cleanup_non_atomic_partial_write(&write_path, dst_store).await;
-            Err(err)
+            Err(e)
         }
     }
 }


### PR DESCRIPTION
## What

**The core fix:** move gzip decode and XDR parse/hash into one `tokio::spawn` per file, instead of running them inline on the single orchestration task.

**A side fix:** raise default `--max-concurrent` from 64 to 128 

Plus a`perf-metrics` feature (off by default) that captures per-phase timing/throughput, process CPU + peak RSS, a responsiveness heartbeat, and Tokio worker-pool occupancy. Emits them to stderr at exit.

## Why

In verify mode (`scan/mirror/repair --verify`) the single orchestration task ("main") drove gzip decode and XDR parse/hash inline. That work is CPU-bound, so verify throughput was bottlenecked by it. As a result, `scan --verify` did not scale beyond 4 CPU cores.
This PR fixes it by moving gzip decode and XDR parse/hash into separate worker tasks, therefore freeing the main task, that allows more bytes-processing throughout.
(The attached plot shows near linear scaling for both cpu and bytes throughput up to 32 cores.)

<img width="1549" height="619" alt="scaling_graph" src="https://github.com/user-attachments/assets/be46bc0b-6ccd-4970-bf4a-2555450d1077" />

In non-verify mode, the scaling bottleneck is concurrent backend connections (configured by `--max-concurrent`) we allow. Raising it from 64 to 128 allows efficient concurrent processing of 32 checkpoints (`-c = 32`), without any noticeable impact on the backend (e.g. delay or retry from the archive server). 

The `metrics` and `perf` module was used for the optimization and has been included in, it is gated with`perf-metrics` feature and compiled out by default. 