### PR TITLE
Support cloud object stores as mirror/repair destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ stellar-archivist scan https://history.stellar.org/prd/core-testnet/core_testnet
 
 ### Mirror an archive
 
-Copy files from a source archive to a local filesystem:
+Copy files from a source archive to a local filesystem or a cloud object store:
 
 ```bash
 # Mirror an entire archive
@@ -89,11 +89,14 @@ stellar-archivist mirror https://history.stellar.org/prd/core-testnet/core_testn
 
 # Skip optional files (scp)
 stellar-archivist mirror https://history.stellar.org/prd/core-testnet/core_testnet_001 file:///local/mirror --skip-optional
+
+# Mirror to a cloud object store (s3://, gcs://, azblob://, b2://, swift://; credentials via standard env vars)
+stellar-archivist mirror https://history.stellar.org/prd/core-testnet/core_testnet_001 s3://my-bucket/testnet-mirror
 ```
 
 ### Repair an archive
 
-Fixes a **local** archive in place by re-fetching broken or
+Fixes a **local or cloud-hosted** archive in place by re-fetching broken or
 missing files from a **known-good source** archive.
 
 ```bash
@@ -105,6 +108,9 @@ stellar-archivist repair https://history.stellar.org/... file:///local/archive -
 
 # Repair only a range
 stellar-archivist repair https://history.stellar.org/... file:///local/archive --low 1000 --high 5000
+
+# Repair an archive hosted in a cloud object store
+stellar-archivist repair https://history.stellar.org/... s3://my-bucket/testnet-mirror --verify
 ```
 
 **Dry-run and plans.** A dry-run writes a JSON **plan** of everything it

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,8 +14,8 @@ history. The CLI has three modes, all built on the same pipeline:
   with `--verify`, validates their contents.
 - **`mirror`**: copy from a source archive to a writable destination, with
   resume support.
-- **`repair`**: fix a local destination archive by re-fetching missing or corrupt
-  files from a known-good source.
+- **`repair`**: fix a local or cloud-hosted destination archive by re-fetching
+  missing or corrupt files from a known-good source.
 
 ## Archive Format
 
@@ -112,8 +112,8 @@ the highest successfully mirrored history file when appropriate.
 
 ### Repair
 
-`RepairOperation` fixes a local destination against a known-good source. It is a
-small multi-phase workflow:
+`RepairOperation` fixes a local or cloud-hosted destination against a known-good
+source. It is a small multi-phase workflow:
 
 1. Discover missing or corrupt destination files. In `--dry-run`, stop here and
    write a plan/report.
@@ -158,24 +158,46 @@ agree as a set, so repair may re-fetch the whole checkpoint.
 
 ## Storage
 
-`storage.rs` exposes a `Storage` trait with reader, existence, writer, and copy
-operations. Backends are selected from URL schemes by `from_url_with_config`.
+`storage.rs` exposes a `Storage` trait with reader, existence, staged-write, and
+copy operations. Backends are selected from URL schemes by
+`from_url_with_config`.
 
 | Scheme | Backend | Writable |
 |---|---|---|
 | `file://` | local filesystem | yes |
+| `s3://`, `gcs://`/`gs://`, `azblob://`/`azure://`, `b2://`, `swift://` | feature-gated cloud object stores | yes |
 | `http://`, `https://` | HTTP/HTTPS | no |
-| `s3://`, `gcs://`/`gs://`, `azblob://`/`azure://`, `b2://`, `swift://`, `sftp://` | feature-gated cloud backends | no |
+| `sftp://` | feature-gated SFTP | no |
 
 Each backend is built as an OpenDAL operator with common layers: timeout,
 concurrency limit, logging, an HTTP client where needed, and optional bandwidth
 throttling.
 
-Filesystem writes are the only supported destination writes. With
-`--atomic-file-writes`, OpenDAL handles atomic writes with fsync. Without it,
-the filesystem destination write path uses direct `tokio::fs` writes to a temp
-file followed by rename, which avoids OpenDAL writer overhead but bypasses
-OpenDAL layers on the destination write side.
+### Writes
+
+Every archive write — plain copies, verified bucket and XDR writes, and
+`.well-known` updates — goes through `Storage::open_staged_writer` and the
+`StagedWriter` it returns. A staged writer is fed chunks and then either
+committed, which makes the bytes visible at the final path, or aborted, which
+leaves nothing there. Dropping one without committing is equivalent to aborting.
+Callers never build temp paths or clean up partial files themselves; that is the
+writer's job, and it is what lets verification decide to commit only after the
+content has passed its checks.
+
+Two staging mechanisms sit behind that single interface:
+
+- **Commit on close**: cloud object stores, where the object appears only when
+  the upload completes, and filesystem destinations run with
+  `--atomic-file-writes`, where OpenDAL's `atomic_write_dir` does its own
+  temp-file-plus-rename with fsync.
+- **`.tmp` sibling**: plain filesystem destinations, which write directly with
+  `tokio::fs` to `<path>.tmp` and rename on commit, without fsync.
+
+`--atomic-file-writes` therefore chooses between the two filesystem mechanisms
+and has no effect on object-store destinations. Plain filesystem staging talks
+to the file directly rather than through the operator, so the layers listed
+above apply to reads and to atomic-mode writes, but not to plain filesystem
+writes.
 
 ## Concurrency
 

--- a/src/cli/mirror.rs
+++ b/src/cli/mirror.rs
@@ -12,7 +12,8 @@ pub struct MirrorCmd {
     /// Source archive URL (http://, https://, file://)
     pub src: String,
 
-    /// Destination path (must be file://)
+    /// Destination archive URL (writable backend: file://, s3://, gcs://,
+    /// azblob://, b2://, swift://)
     pub dst: String,
 
     /// Mirror starting from this ledger (rounds down to previous checkpoint unless already one)
@@ -47,7 +48,7 @@ impl MirrorCmd {
 
         if !dst_store.supports_writes() {
             return Err(Error::Other(format!(
-                "Destination does not support writes: {}",
+                "Destination does not support writes: {} (writable backends: file://, s3://, gcs://, azblob://, b2://, swift://)",
                 self.dst
             )));
         }

--- a/src/cli/repair.rs
+++ b/src/cli/repair.rs
@@ -13,7 +13,8 @@ pub struct RepairCmd {
     /// Source archive URL (known-good archive to fetch repairs from)
     pub src: String,
 
-    /// Destination archive path to repair (must be file://)
+    /// Destination archive URL to repair (writable backend: file://, s3://,
+    /// gcs://, azblob://, b2://, swift://)
     pub dst: String,
 
     /// Repair starting from this ledger (rounds down to previous checkpoint unless already one)
@@ -55,7 +56,7 @@ impl RepairCmd {
 
         if !dst_store.supports_writes() {
             return Err(Error::Other(format!(
-                "Destination does not support writes: {}",
+                "Destination does not support writes: {} (writable backends: file://, s3://, gcs://, azblob://, b2://, swift://)",
                 self.dst
             )));
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,7 +315,7 @@ pub mod test_helpers {
 
         if !dst_store.supports_writes() {
             return Err(crate::Error::Other(format!(
-                "Destination does not support writes: {}",
+                "Destination does not support writes: {} (writable backends: file://, s3://, gcs://, azblob://, b2://, swift://)",
                 config.dst
             )));
         }
@@ -448,7 +448,7 @@ pub mod test_helpers {
 
         if !dst_store.supports_writes() {
             return Err(crate::Error::Other(format!(
-                "Destination does not support writes: {}",
+                "Destination does not support writes: {} (writable backends: file://, s3://, gcs://, azblob://, b2://, swift://)",
                 config.dst
             )));
         }

--- a/src/mirror_operation.rs
+++ b/src/mirror_operation.rs
@@ -411,7 +411,7 @@ impl Operation for MirrorOperation {
             history_format::parse_history(&buffer, path)
         }
         .map_err(|e| StorageError::fatal(format!("failed to parse history {path}: {e}")))?;
-        storage::write_buffer_with_cleanup(&self.dst_store, path, buffer).await?;
+        self.dst_store.write(path, buffer).await?;
         Ok(HistoryOutcome {
             outcome: ProcessOutcome::Processed,
             state: Some(state),

--- a/src/mirror_operation.rs
+++ b/src/mirror_operation.rs
@@ -154,58 +154,25 @@ impl MirrorOperation {
         if should_update {
             // Copy the history file at the specified checkpoint to be our .well-known file
             let history_path = history_format::checkpoint_path("history", highest_checkpoint);
-            let well_known_path = ".well-known/stellar-history.json";
-
-            let dst_base = self.dst_store.get_base_path().ok_or_else(|| {
-                std::io::Error::new(
-                    std::io::ErrorKind::Unsupported,
-                    "Destination storage backend does not have a filesystem path",
-                )
-            })?;
-
-            let src_file = dst_base.join(&history_path);
-            let dst_file = dst_base.join(well_known_path);
 
             // Check if the history file exists (it might not if the mirror had failures)
-            if !tokio::fs::try_exists(&src_file).await.unwrap_or(false) {
+            if !self.dst_store.exists(&history_path).await? {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::NotFound,
                     format!(
                         "Cannot update .well-known: history file at checkpoint {} (0x{:08x}) was not successfully mirrored ({})",
-                        highest_checkpoint, highest_checkpoint,
-                        src_file.display()
+                        highest_checkpoint, highest_checkpoint, history_path
                     ),
                 )
                 .into());
             }
 
-            // Ensure the .well-known directory exists
-            if let Some(parent) = dst_file.parent() {
-                tokio::fs::create_dir_all(parent).await.map_err(|e| {
-                    std::io::Error::new(
-                        e.kind(),
-                        format!("Failed to create directory {}: {}", parent.display(), e),
-                    )
-                })?;
-            }
-
-            crate::utils::write_well_known_from_history(
-                &src_file,
-                &dst_file,
+            crate::utils::update_well_known_from_history(
+                &self.dst_store,
+                &history_path,
                 self.pipeline_config.source_network_passphrase.as_deref(),
             )
-            .await
-            .map_err(|e| {
-                std::io::Error::new(
-                    e.kind(),
-                    format!(
-                        "Failed to write .well-known {} from {}: {}",
-                        dst_file.display(),
-                        src_file.display(),
-                        e
-                    ),
-                )
-            })?;
+            .await?;
 
             info!(
                 "Updated destination .well-known to checkpoint {} (0x{:08x})",

--- a/src/repair_operation.rs
+++ b/src/repair_operation.rs
@@ -496,44 +496,36 @@ impl RepairOperation {
     }
 
     /// Restore `.well-known/stellar-history.json` by copying the highest
-    /// checkpoint's history file on the destination — a local dst-to-dst copy,
-    /// not a fetch from the source.
+    /// checkpoint's history file on the destination — a dst-to-dst copy
+    /// through the Storage trait, not a fetch from the source.
     ///
-    /// Returns `true` if `.well-known` is in its intended state (restored, or a
-    /// no-op on a non-filesystem backend) and `false` if a needed restoration
-    /// failed, so the caller can fail the run rather than report success with
-    /// `.well-known` still broken.
+    /// Returns `true` if `.well-known` was restored and `false` if a needed
+    /// restoration failed, so the caller can fail the run rather than report
+    /// success with `.well-known` still broken.
     async fn repair_well_known(&self, highest_checkpoint: u32) -> bool {
         let history_path = history_format::checkpoint_path("history", highest_checkpoint);
-        let well_known_path = history_format::ROOT_WELL_KNOWN_PATH;
 
-        let Some(base_path) = self.dst_store.get_base_path() else {
-            // Non-filesystem backend: nothing to copy locally. R-3.11 permits
-            // a silent no-op (no writable non-filesystem backend exists today).
-            return true;
-        };
-
-        let src_file = base_path.join(&history_path);
-        let dst_file = base_path.join(well_known_path);
-
-        if !tokio::fs::try_exists(&src_file).await.unwrap_or(false) {
-            error!(
-                "Cannot repair .well-known: history file at checkpoint {} not found",
-                highest_checkpoint
-            );
-            return false;
-        }
-
-        if let Some(parent) = dst_file.parent() {
-            if let Err(e) = tokio::fs::create_dir_all(parent).await {
-                error!("Failed to create .well-known directory: {}", e);
+        match self.dst_store.exists(&history_path).await {
+            Ok(true) => {}
+            Ok(false) => {
+                error!(
+                    "Cannot repair .well-known: history file at checkpoint {} not found",
+                    highest_checkpoint
+                );
+                return false;
+            }
+            Err(e) => {
+                error!(
+                    "Cannot repair .well-known: failed to probe history file at checkpoint {}: {}",
+                    highest_checkpoint, e
+                );
                 return false;
             }
         }
 
-        match crate::utils::write_well_known_from_history(
-            &src_file,
-            &dst_file,
+        match crate::utils::update_well_known_from_history(
+            &self.dst_store,
+            &history_path,
             self.pipeline_config.source_network_passphrase.as_deref(),
         )
         .await

--- a/src/repair_operation.rs
+++ b/src/repair_operation.rs
@@ -712,7 +712,7 @@ impl Operation for RepairOperation {
             history_format::parse_history(&buffer, path)
         }
         .map_err(|e| StorageError::fatal(format!("failed to parse history {path}: {e}")))?;
-        storage::write_buffer_with_cleanup(&self.dst_store, path, buffer).await?;
+        self.dst_store.write(path, buffer).await?;
         Ok(HistoryOutcome {
             outcome: ProcessOutcome::Processed,
             state: Some(state),

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -241,13 +241,6 @@ pub trait Storage: Send + Sync {
         Err(Error::fatal("Write not supported by this backend"))
     }
 
-    /// Open an `OpenDAL` writer for the object with buffering enabled.
-    /// Only supported by writable backends (filesystem and cloud object stores).
-    /// Caller is responsible for calling `writer.close()` after writing.
-    async fn open_writer(&self, _object: &str) -> Result<Writer, Error> {
-        Err(Error::fatal("Write not supported by this backend"))
-    }
-
     /// Write an entire buffer to an object.
     /// Only supported by writable backends (filesystem and cloud object stores).
     async fn write(&self, object: &str, data: Buffer) -> Result<(), Error> {
@@ -305,15 +298,10 @@ pub trait Storage: Send + Sync {
         false
     }
 
-    /// Get the base filesystem path if this is a filesystem backend
+    /// Get the base filesystem path if this is a filesystem backend.
+    /// Introspection only — production write paths never consult this.
     fn get_base_path(&self) -> Option<&std::path::Path> {
         None
-    }
-
-    /// Check if this backend uses atomic writes (temp file + rename).
-    /// When true, failed writes don't leave partial files at the destination.
-    fn uses_atomic_writes(&self) -> bool {
-        false
     }
 }
 
@@ -848,37 +836,12 @@ impl Storage for OpendalStore {
         }
     }
 
-    async fn open_writer(&self, object: &str) -> Result<Writer, Error> {
-        if !self.writable {
-            return Err(Error::fatal("Write not supported by this backend"));
-        }
-
-        let key = self.object_to_key(object);
-
-        // Use writer_with to enable buffered/chunked writing for better performance
-        // All backends write through OpenDAL, which applies ConcurrentLimitLayer
-        // Filesystem backends use atomic_write_dir for atomic writes (temp file + rename)
-        let writer = self.operator.writer_with(&key).await.map_err(|e| {
-            let class = classify_opendal_error(&e);
-            Error {
-                class,
-                message: format!("Failed to open writer for {key}: {e}"),
-            }
-        })?;
-
-        Ok(writer)
-    }
-
     fn supports_writes(&self) -> bool {
         self.writable
     }
 
     fn get_base_path(&self) -> Option<&Path> {
         self.root_path.as_deref()
-    }
-
-    fn uses_atomic_writes(&self) -> bool {
-        self.atomic_writes
     }
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -8,7 +8,6 @@
 //! - Request logging
 
 use async_trait::async_trait;
-use futures_util::SinkExt;
 use futures_util::StreamExt;
 use normalize_path::NormalizePath;
 use opendal::{layers, Buffer, ErrorKind, Operator, Reader, Writer};
@@ -63,32 +62,166 @@ impl Error {
 
 pub type StorageRef = Arc<dyn Storage + Send + Sync>;
 
-/// Stream all bytes from `reader` into `writer`, returning the number of bytes
-/// copied. Each chunk is parked into the sink with `feed` (start_send under
-/// poll_ready backpressure) without an intermediate flush; the single `close()`
-/// then flushes the buffered data and finalizes the write (uploads the final
-/// part / fsync+rename). This matches `Sink::send_all`'s deferred-flush
-/// behavior — avoiding a flush per chunk — while exposing the byte count.
-async fn copy_reader_to_writer(reader: Reader, writer: Writer, object: &str) -> Result<u64, Error> {
-    let mut stream = reader
-        .into_stream(..)
-        .await
-        .map_err(|e| from_opendal_error(e, &format!("Failed to create stream for {object}")))?;
+/// A write whose visibility at the final object path is controlled by the
+/// caller: nothing is visible at the destination until `commit()` succeeds,
+/// and `abort()` (or dropping without commit) guarantees nothing remains at
+/// the final path.
+pub struct StagedWriter {
+    inner: StagedInner,
+    /// Final object path (archive-relative), for error messages.
+    object: String,
+    bytes_written: u64,
+}
 
-    let mut copied_bytes = 0u64;
-    let mut sink = writer.into_sink();
-    while let Some(result) = stream.next().await {
-        let buffer = result
-            .map_err(|e| from_opendal_error(e, &format!("Failed to read data for {object}")))?;
-        copied_bytes += buffer.len() as u64;
-        sink.feed(buffer)
-            .await
-            .map_err(|e| from_opendal_error(e, &format!("Failed to write data to {object}")))?;
+enum StagedInner {
+    /// Backend commits atomically on `close()` — object stores and fs with
+    /// `atomic_write_dir`. commit = close; abort = best-effort backend abort.
+    AtomicOnClose { writer: Writer },
+    /// Plain filesystem: direct `tokio::fs` writes to a `.tmp` sibling; commit
+    /// = flush + rename; abort = remove the `.tmp`. No fsync or `OpenDAL`
+    /// write buffering.
+    FsStaged {
+        file: tokio::fs::File,
+        tmp_path: PathBuf,
+        final_path: PathBuf,
+    },
+}
+
+impl StagedWriter {
+    fn atomic_on_close(writer: Writer, object: &str) -> Self {
+        Self {
+            inner: StagedInner::AtomicOnClose { writer },
+            object: object.to_string(),
+            bytes_written: 0,
+        }
     }
-    sink.close()
-        .await
-        .map_err(|e| from_opendal_error(e, &format!("Failed to close writer for {object}")))?;
-    Ok(copied_bytes)
+
+    /// Stage at `<root>/<object>.tmp`, creating parent directories.
+    async fn fs_staged(root: &Path, object: &str) -> Result<Self, Error> {
+        let object_rel = object.trim_start_matches('/');
+        let final_path = root.join(object_rel);
+        let tmp_path = final_path.with_added_extension("tmp");
+
+        if let Some(parent) = final_path.parent() {
+            tokio::fs::create_dir_all(parent).await.map_err(|e| {
+                from_io_error(
+                    e,
+                    &format!("Failed to create directory {}", parent.display()),
+                )
+            })?;
+        }
+        let file = tokio::fs::File::create(&tmp_path).await.map_err(|e| {
+            from_io_error(
+                e,
+                &format!("Failed to create temp file {}", tmp_path.display()),
+            )
+        })?;
+
+        Ok(Self {
+            inner: StagedInner::FsStaged {
+                file,
+                tmp_path,
+                final_path,
+            },
+            object: object.to_string(),
+            bytes_written: 0,
+        })
+    }
+
+    /// Append a chunk. Nothing becomes visible at the final path. On `Err` the
+    /// caller must `abort()` (or drop) the writer.
+    pub async fn write(&mut self, buffer: Buffer) -> Result<(), Error> {
+        self.bytes_written += buffer.len() as u64;
+        match &mut self.inner {
+            StagedInner::AtomicOnClose { writer } => writer.write(buffer).await.map_err(|e| {
+                from_opendal_error(e, &format!("Failed to write data to {}", self.object))
+            }),
+            StagedInner::FsStaged { file, tmp_path, .. } => {
+                for bytes in buffer {
+                    file.write_all(&bytes).await.map_err(|e| {
+                        from_io_error(e, &format!("Failed to write to {}", tmp_path.display()))
+                    })?;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    /// Make the staged data visible at the final path. Returns bytes written.
+    pub async fn commit(self) -> Result<u64, Error> {
+        match self.inner {
+            StagedInner::AtomicOnClose { mut writer } => {
+                if let Err(e) = writer.close().await {
+                    // Best-effort backend abort; always return the original
+                    // close error.
+                    if let Err(abort_err) = writer.abort().await {
+                        tracing::warn!(
+                            "failed to abort staged upload for {} after a failed close: {}",
+                            self.object,
+                            abort_err
+                        );
+                    }
+                    return Err(from_opendal_error(
+                        e,
+                        &format!("Failed to close writer for {}", self.object),
+                    ));
+                }
+            }
+            StagedInner::FsStaged {
+                mut file,
+                tmp_path,
+                final_path,
+            } => {
+                let flushed = file.flush().await.map_err(|e| {
+                    from_io_error(e, &format!("Failed to flush {}", tmp_path.display()))
+                });
+                drop(file); // close the handle before renaming
+                if let Err(e) = flushed {
+                    let _ = tokio::fs::remove_file(&tmp_path).await;
+                    return Err(e);
+                }
+                if let Err(e) = tokio::fs::rename(&tmp_path, &final_path).await {
+                    let _ = tokio::fs::remove_file(&tmp_path).await;
+                    return Err(from_io_error(
+                        e,
+                        &format!(
+                            "Failed to rename {} to {}",
+                            tmp_path.display(),
+                            final_path.display()
+                        ),
+                    ));
+                }
+            }
+        }
+        Ok(self.bytes_written)
+    }
+
+    /// Guarantee nothing is visible at the final path. Best-effort, infallible.
+    pub async fn abort(self) {
+        match self.inner {
+            StagedInner::AtomicOnClose { mut writer } => {
+                if let Err(e) = writer.abort().await {
+                    tracing::warn!(
+                        "failed to discard staged upload for {} on abort: {}",
+                        self.object,
+                        e
+                    );
+                }
+            }
+            StagedInner::FsStaged { file, tmp_path, .. } => {
+                drop(file);
+                if let Err(e) = tokio::fs::remove_file(&tmp_path).await {
+                    if e.kind() != std::io::ErrorKind::NotFound {
+                        tracing::warn!(
+                            "failed to remove staged temp {} after abort: {}",
+                            tmp_path.display(),
+                            e
+                        );
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Core unified storage trait for all backends
@@ -102,6 +235,12 @@ pub trait Storage: Send + Sync {
     /// Note: No automatic retries - retries are handled at the pipeline level.
     async fn exists(&self, object: &str) -> Result<bool, Error>;
 
+    /// Open a staged write to `object`: bytes become visible at the final
+    /// path only on `commit()`. Only supported by writable backends.
+    async fn open_staged_writer(&self, _object: &str) -> Result<StagedWriter, Error> {
+        Err(Error::fatal("Write not supported by this backend"))
+    }
+
     /// Open an `OpenDAL` writer for the object with buffering enabled.
     /// Only supported by writable backends (filesystem and cloud object stores).
     /// Caller is responsible for calling `writer.close()` after writing.
@@ -110,28 +249,53 @@ pub trait Storage: Send + Sync {
     }
 
     /// Write an entire buffer to an object.
-    /// This is a convenience method that opens a writer, writes, and closes.
     /// Only supported by writable backends (filesystem and cloud object stores).
     async fn write(&self, object: &str, data: Buffer) -> Result<(), Error> {
-        let mut writer = self.open_writer(object).await?;
-        writer
-            .write(data)
-            .await
-            .map_err(|e| from_opendal_error(e, &format!("Failed to write to {object}")))?;
-        writer
-            .close()
-            .await
-            .map_err(|e| from_opendal_error(e, &format!("Failed to close writer for {object}")))?;
+        let mut writer = self.open_staged_writer(object).await?;
+        if let Err(e) = writer.write(data).await {
+            writer.abort().await;
+            return Err(e);
+        }
+        writer.commit().await?;
         Ok(())
     }
 
-    /// Copy data from a source reader to a destination object.
-    /// Streams data in chunks without buffering the entire file in memory.
+    /// Copy data from a source reader to a destination object, streaming in
+    /// chunks. Nothing is visible at the destination on failure.
     /// Only supported by writable backends (filesystem and cloud object stores).
     async fn copy_from_reader(&self, object: &str, reader: Reader) -> Result<(), Error> {
         let copy_phase = crate::phase!(crate::metrics::Phase::Copy);
-        let writer = self.open_writer(object).await?;
-        let copied_bytes = copy_reader_to_writer(reader, writer, object).await?;
+        let mut writer = self.open_staged_writer(object).await?;
+
+        let mut stream = match reader.into_stream(..).await {
+            Ok(s) => s,
+            Err(e) => {
+                writer.abort().await;
+                return Err(from_opendal_error(
+                    e,
+                    &format!("Failed to create stream for {object}"),
+                ));
+            }
+        };
+
+        while let Some(result) = stream.next().await {
+            let buffer = match result {
+                Ok(b) => b,
+                Err(e) => {
+                    writer.abort().await;
+                    return Err(from_opendal_error(
+                        e,
+                        &format!("Failed to read data for {object}"),
+                    ));
+                }
+            };
+            if let Err(e) = writer.write(buffer).await {
+                writer.abort().await;
+                return Err(e);
+            }
+        }
+
+        let copied_bytes = writer.commit().await?;
         copy_phase.record_file(copied_bytes);
         Ok(())
     }
@@ -300,87 +464,6 @@ impl OpendalStore {
             let prefix = self.prefix.trim_end_matches('/');
             format!("{prefix}/{object}")
         }
-    }
-
-    /// Direct file write that bypasses `OpenDAL`'s writer layer. This avoids
-    /// the `WriteGenerator` buffering and the fsync in `close()`.
-    ///
-    /// Writes to a `.tmp` file first, then renames to the final path. This
-    /// prevents partial files from being visible at the final path if the
-    /// process is killed mid-write (SIGKILL, OOM etc.). Without this, a resumed
-    /// mirror would see the partial file via `pre_check()` and skip
-    /// re-downloading it.
-    async fn copy_from_reader_direct(
-        &self,
-        root_path: &Path,
-        object: &str,
-        reader: Reader,
-    ) -> Result<u64, Error> {
-        let object = object.trim_start_matches('/');
-        let file_path = root_path.join(object);
-        let tmp_path = file_path.with_added_extension("tmp");
-
-        if let Some(parent) = file_path.parent() {
-            tokio::fs::create_dir_all(parent).await.map_err(|e| {
-                from_io_error(
-                    e,
-                    &format!("Failed to create directory {}", parent.display()),
-                )
-            })?;
-        }
-
-        let mut file = tokio::fs::File::create(&tmp_path).await.map_err(|e| {
-            from_io_error(
-                e,
-                &format!("Failed to create temp file {}", tmp_path.display()),
-            )
-        })?;
-
-        let mut stream = reader
-            .into_stream(..)
-            .await
-            .map_err(|e| from_opendal_error(e, &format!("Failed to create stream for {object}")))?;
-
-        let write_result: Result<u64, Error> = async {
-            let mut copied_bytes = 0u64;
-            while let Some(result) = stream.next().await {
-                let buffer =
-                    result.map_err(|e| from_opendal_error(e, "Failed to read from source"))?;
-                copied_bytes += buffer.len() as u64;
-                for bytes in buffer {
-                    file.write_all(&bytes).await.map_err(|e| {
-                        from_io_error(e, &format!("Failed to write to {}", tmp_path.display()))
-                    })?;
-                }
-            }
-            file.flush().await.map_err(|e| {
-                from_io_error(e, &format!("Failed to flush {}", tmp_path.display()))
-            })?;
-            Ok(copied_bytes)
-        }
-        .await;
-
-        let copied_bytes = match write_result {
-            Ok(copied_bytes) => copied_bytes,
-            Err(e) => {
-                let _ = tokio::fs::remove_file(&tmp_path).await;
-                return Err(e);
-            }
-        };
-
-        if let Err(e) = tokio::fs::rename(&tmp_path, &file_path).await {
-            let _ = tokio::fs::remove_file(&tmp_path).await;
-            return Err(from_io_error(
-                e,
-                &format!(
-                    "Failed to rename {} to {}",
-                    tmp_path.display(),
-                    file_path.display()
-                ),
-            ));
-        }
-
-        Ok(copied_bytes)
     }
 
     // ===== Filesystem Backend =====
@@ -742,6 +825,29 @@ impl Storage for OpendalStore {
         }
     }
 
+    async fn open_staged_writer(&self, object: &str) -> Result<StagedWriter, Error> {
+        if !self.writable {
+            return Err(Error::fatal("Write not supported by this backend"));
+        }
+        if self.atomic_writes {
+            let key = self.object_to_key(object);
+            let writer = self.operator.writer_with(&key).await.map_err(|e| {
+                let class = classify_opendal_error(&e);
+                Error {
+                    class,
+                    message: format!("Failed to open writer for {key}: {e}"),
+                }
+            })?;
+            Ok(StagedWriter::atomic_on_close(writer, object))
+        } else {
+            // Plain fs is the only non-atomic writable backend; it always has a root.
+            let root = self.root_path.as_ref().ok_or_else(|| {
+                Error::fatal("Non-atomic backend without a filesystem root cannot stage writes")
+            })?;
+            StagedWriter::fs_staged(root, object).await
+        }
+    }
+
     async fn open_writer(&self, object: &str) -> Result<Writer, Error> {
         if !self.writable {
             return Err(Error::fatal("Write not supported by this backend"));
@@ -761,27 +867,6 @@ impl Storage for OpendalStore {
         })?;
 
         Ok(writer)
-    }
-
-    async fn copy_from_reader(&self, object: &str, reader: Reader) -> Result<(), Error> {
-        let copy_phase = crate::phase!(crate::metrics::Phase::Copy);
-        // If we have a filesystem root and atomic writes are disabled, use direct tokio::fs writes
-        // to bypass OpenDAL's WriteGenerator buffering and avoid the fsync in close().
-        if let Some(root_path) = &self.root_path {
-            if !self.atomic_writes {
-                let copied_bytes = self
-                    .copy_from_reader_direct(root_path, object, reader)
-                    .await?;
-                copy_phase.record_file(copied_bytes);
-                return Ok(());
-            }
-        }
-
-        // Otherwise use OpenDAL's writer (required for non-filesystem backends or when atomic writes are enabled)
-        let writer = self.open_writer(object).await?;
-        let copied_bytes = copy_reader_to_writer(reader, writer, object).await?;
-        copy_phase.record_file(copied_bytes);
-        Ok(())
     }
 
     fn supports_writes(&self) -> bool {
@@ -1074,44 +1159,4 @@ pub async fn download_buffer(store: &StorageRef, path: &str) -> Result<opendal::
         .await
         .map_err(|e| from_opendal_error(e, "Read error"))?;
     Ok(chunks.into_iter().flatten().collect())
-}
-
-/// Write `buffer` to `store` at `path`. On write failure, attempt to clean up
-/// any partial file left behind (logging but not propagating cleanup errors)
-/// and return the original write error.
-pub async fn write_buffer_with_cleanup(
-    store: &StorageRef,
-    path: &str,
-    buffer: opendal::Buffer,
-) -> Result<(), Error> {
-    match store.write(path, buffer).await {
-        Ok(()) => Ok(()),
-        Err(e) => {
-            if let Err(cleanup_err) = cleanup_partial_file(store, path).await {
-                tracing::error!("Failed to cleanup partial file {}: {}", path, cleanup_err);
-            }
-            Err(e)
-        }
-    }
-}
-
-/// Clean up a partial file on the destination after a write failure.
-/// No-op on atomic-write backends (temp file is discarded automatically).
-pub async fn cleanup_partial_file(store: &StorageRef, path: &str) -> Result<(), Error> {
-    if store.uses_atomic_writes() {
-        return Ok(());
-    }
-    if let Some(base_path) = store.get_base_path() {
-        let file_path = base_path.join(path);
-        if tokio::fs::try_exists(&file_path).await.unwrap_or(false) {
-            tokio::fs::remove_file(&file_path).await.map_err(|e| {
-                Error::fatal(format!(
-                    "Failed to remove partial file {}: {}",
-                    file_path.display(),
-                    e
-                ))
-            })?;
-        }
-    }
-    Ok(())
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -103,7 +103,7 @@ pub trait Storage: Send + Sync {
     async fn exists(&self, object: &str) -> Result<bool, Error>;
 
     /// Open an `OpenDAL` writer for the object with buffering enabled.
-    /// Only supported by writable backends (e.g., filesystem).
+    /// Only supported by writable backends (filesystem and cloud object stores).
     /// Caller is responsible for calling `writer.close()` after writing.
     async fn open_writer(&self, _object: &str) -> Result<Writer, Error> {
         Err(Error::fatal("Write not supported by this backend"))
@@ -111,7 +111,7 @@ pub trait Storage: Send + Sync {
 
     /// Write an entire buffer to an object.
     /// This is a convenience method that opens a writer, writes, and closes.
-    /// Only supported by writable backends (e.g., filesystem).
+    /// Only supported by writable backends (filesystem and cloud object stores).
     async fn write(&self, object: &str, data: Buffer) -> Result<(), Error> {
         let mut writer = self.open_writer(object).await?;
         writer
@@ -127,7 +127,7 @@ pub trait Storage: Send + Sync {
 
     /// Copy data from a source reader to a destination object.
     /// Streams data in chunks without buffering the entire file in memory.
-    /// Only supported by writable backends (e.g., filesystem).
+    /// Only supported by writable backends (filesystem and cloud object stores).
     async fn copy_from_reader(&self, object: &str, reader: Reader) -> Result<(), Error> {
         let copy_phase = crate::phase!(crate::metrics::Phase::Copy);
         let writer = self.open_writer(object).await?;
@@ -213,25 +213,27 @@ pub struct OpendalStore {
     root_path: Option<PathBuf>,
     /// Whether this backend supports writes
     writable: bool,
-    /// Whether to use atomic file writes (`OpenDAL` with fsync) vs direct writes (`tokio::fs` bypass)
-    atomic_file_writes: bool,
+    /// Whether writes are atomic (a failed write leaves nothing at the
+    /// destination path): true for object stores and for filesystem stores
+    /// using `atomic_write_dir`.
+    atomic_writes: bool,
 }
 
 impl OpendalStore {
     /// Create a new `OpendalStore` from a configured operator
-    fn from_operator(
+    pub(crate) fn from_operator(
         operator: Operator,
         prefix: impl Into<String>,
         root_path: Option<PathBuf>,
         writable: bool,
-        atomic_file_writes: bool,
+        atomic_writes: bool,
     ) -> Self {
         Self {
             operator,
             prefix: prefix.into(),
             root_path,
             writable,
-            atomic_file_writes,
+            atomic_writes,
         }
     }
 
@@ -496,7 +498,7 @@ impl OpendalStore {
         }
 
         let operator = Self::apply_layers(builder, config)?;
-        Ok(Self::from_operator(operator, prefix, None, false, false))
+        Ok(Self::from_operator(operator, prefix, None, true, true))
     }
 
     /// Create a Google Cloud Storage backend
@@ -519,7 +521,7 @@ impl OpendalStore {
         }
 
         let operator = Self::apply_layers(builder, config)?;
-        Ok(Self::from_operator(operator, prefix, None, false, false))
+        Ok(Self::from_operator(operator, prefix, None, true, true))
     }
 
     /// Create an Azure Blob Storage backend
@@ -546,7 +548,7 @@ impl OpendalStore {
         }
 
         let operator = Self::apply_layers(builder, config)?;
-        Ok(Self::from_operator(operator, prefix, None, false, false))
+        Ok(Self::from_operator(operator, prefix, None, true, true))
     }
 
     /// Create a Backblaze B2 storage backend
@@ -568,7 +570,7 @@ impl OpendalStore {
             .application_key(application_key);
 
         let operator = Self::apply_layers(builder, config)?;
-        Ok(Self::from_operator(operator, prefix, None, false, false))
+        Ok(Self::from_operator(operator, prefix, None, true, true))
     }
 
     /// Create an SFTP storage backend
@@ -615,7 +617,7 @@ impl OpendalStore {
         }
 
         let operator = Self::apply_layers(builder, config)?;
-        Ok(Self::from_operator(operator, prefix, None, false, false))
+        Ok(Self::from_operator(operator, prefix, None, true, true))
     }
 }
 
@@ -766,7 +768,7 @@ impl Storage for OpendalStore {
         // If we have a filesystem root and atomic writes are disabled, use direct tokio::fs writes
         // to bypass OpenDAL's WriteGenerator buffering and avoid the fsync in close().
         if let Some(root_path) = &self.root_path {
-            if !self.atomic_file_writes {
+            if !self.atomic_writes {
                 let copied_bytes = self
                     .copy_from_reader_direct(root_path, object, reader)
                     .await?;
@@ -791,7 +793,7 @@ impl Storage for OpendalStore {
     }
 
     fn uses_atomic_writes(&self) -> bool {
-        self.atomic_file_writes
+        self.atomic_writes
     }
 }
 

--- a/src/tests/cli_validation_test.rs
+++ b/src/tests/cli_validation_test.rs
@@ -5,20 +5,6 @@ use crate::test_helpers::{run_mirror as cmd_mirror_run, MirrorConfig};
 use rstest::rstest;
 
 #[rstest]
-#[case::http("http://example.com/archive", "HTTP destinations are read-only")]
-#[case::https("https://example.com/archive", "HTTPS destinations are read-only")]
-#[case::s3(
-    "s3://my-bucket/archive",
-    "S3 destinations are not currently supported for writing"
-)]
-#[tokio::test]
-async fn test_mirror_rejects_readonly_destination(#[case] dst: &str, #[case] _reason: &str) {
-    let config = MirrorConfig::new("file:///tmp/test-source", dst);
-    let result = cmd_mirror_run(config).await;
-    assert!(result.is_err());
-}
-
-#[rstest]
 #[case::not_a_url("not-a-url")]
 #[case::missing_scheme("://missing-scheme")]
 #[case::missing_slash("file:/missing-slash")]

--- a/src/tests/mirror_op_test.rs
+++ b/src/tests/mirror_op_test.rs
@@ -632,10 +632,10 @@ async fn test_mirror_replaces_empty_files() {
 /// partial files at the final path, preventing silent corruption on resume.
 ///
 /// Two cases cover the two distinct write paths in `MirrorOperation::process_object`:
-/// - `no_verify`: ledger files go through `OpendalStore::copy_from_reader_direct`
-///   (storage.rs) — pure tokio::fs temp+rename.
-/// - `verify`: ledger files go through `xdr_verify::verify_and_write_xdr` —
-///   OpenDAL writer/sink + tokio::fs::rename at commit.
+/// - `no_verify`: ledger files go through `Storage::copy_from_reader` — a
+///   `StagedWriter` on the fs-staged path, i.e. tokio::fs temp+rename.
+/// - `verify`: ledger files go through `xdr_verify::verify_and_write_xdr` — the
+///   same fs-staged `StagedWriter`, committed only after the parse succeeds.
 ///
 /// Scenario: mirror checkpoints 63 and 127, simulate a crash on a ledger file
 /// at checkpoint 127 by deleting the final file and leaving a truncated `.tmp`

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -21,6 +21,8 @@ mod report_test;
 #[cfg(test)]
 mod scan_op_test;
 #[cfg(test)]
+mod staged_writer_test;
+#[cfg(test)]
 pub(crate) mod utils;
 #[cfg(test)]
 mod verify_test;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -7,6 +7,8 @@ mod http_retry_test;
 #[cfg(test)]
 mod mirror_op_test;
 #[cfg(test)]
+mod object_store_write_test;
+#[cfg(test)]
 mod path_normalization_test;
 #[cfg(test)]
 mod pipeline_test;

--- a/src/tests/object_store_write_test.rs
+++ b/src/tests/object_store_write_test.rs
@@ -6,9 +6,16 @@
 //! The backing directory doubles as an inspection window: after operations
 //! complete, the "bucket" contents can be checked as plain files.
 
-use super::utils::{file_url_from_path, mock_object_store, testnet_small_archive_path};
+use super::utils::{
+    delete_first_file, file_url_from_path, mock_object_store, testnet_small_archive_path,
+};
+use crate::history_format::ROOT_WELL_KNOWN_PATH;
+use crate::mirror_operation::MirrorOperation;
+use crate::pipeline::{Pipeline, PipelineConfig};
+use crate::repair_operation::RepairOperation;
 use crate::storage::{OpendalStore, Storage, StorageRef};
-use crate::test_helpers::{run_mirror, test_storage_config, MirrorConfig};
+use crate::test_helpers::{run_mirror, run_scan, test_storage_config, MirrorConfig, ScanConfig};
+use crate::utils::{stamp_network_passphrase, update_well_known_from_history};
 use crate::verify::verify_and_write_bucket;
 use flate2::write::GzEncoder;
 use flate2::Compression;
@@ -17,6 +24,7 @@ use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
 use tempfile::TempDir;
+use walkdir::WalkDir;
 
 #[tokio::test]
 async fn mock_object_store_has_object_store_semantics() {
@@ -116,6 +124,171 @@ async fn s3_store_is_writable_and_atomic() {
     assert!(store.supports_writes());
     assert!(store.uses_atomic_writes());
     assert!(store.get_base_path().is_none());
+}
+
+#[test]
+fn stamp_passphrase_inserts_when_missing() {
+    let out = stamp_network_passphrase(
+        br#"{"currentLedger": 1023}"#.to_vec(),
+        Some("Test SDF Network ; September 2015"),
+    )
+    .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(
+        json["networkPassphrase"],
+        "Test SDF Network ; September 2015"
+    );
+    assert_eq!(json["currentLedger"], 1023);
+}
+
+#[test]
+fn stamp_passphrase_is_identity_when_already_present_or_absent() {
+    let with = br#"{"currentLedger": 1023, "networkPassphrase": "P"}"#.to_vec();
+    assert_eq!(
+        stamp_network_passphrase(with.clone(), Some("P")).unwrap(),
+        with
+    );
+    let none = br#"{"currentLedger": 1023}"#.to_vec();
+    assert_eq!(stamp_network_passphrase(none.clone(), None).unwrap(), none);
+}
+
+#[test]
+fn stamp_passphrase_rejects_non_object_json() {
+    assert!(stamp_network_passphrase(b"[1,2,3]".to_vec(), Some("P")).is_err());
+}
+
+#[tokio::test]
+async fn update_well_known_writes_through_the_storage_trait() {
+    let dir = TempDir::new().unwrap();
+    let store = mock_object_store(dir.path());
+    let history_path = crate::history_format::checkpoint_path("history", 1023);
+
+    // Plant the history file *through the store* (no fs paths).
+    crate::storage::write_buffer_with_cleanup(
+        &store,
+        &history_path,
+        br#"{"currentLedger": 1023}"#.to_vec().into(),
+    )
+    .await
+    .unwrap();
+
+    update_well_known_from_history(&store, &history_path, Some("P"))
+        .await
+        .expect("update .well-known via store");
+
+    let got = crate::storage::download_buffer(&store, ROOT_WELL_KNOWN_PATH)
+        .await
+        .unwrap()
+        .to_vec();
+    let json: serde_json::Value = serde_json::from_slice(&got).unwrap();
+    assert_eq!(json["networkPassphrase"], "P");
+    assert_eq!(json["currentLedger"], 1023);
+}
+
+/// Assert no `*.tmp` file exists anywhere under `root`. Valid only after
+/// operations that completed successfully (a failed verified write may
+/// legitimately leave OpenDAL's own abandoned staging file behind, the analog
+/// of an S3 incomplete multipart upload).
+fn assert_no_tmp_files(root: &Path) {
+    for entry in WalkDir::new(root).into_iter().filter_map(Result::ok) {
+        if entry.file_type().is_file() {
+            assert!(
+                entry.path().extension().is_none_or(|ext| ext != "tmp"),
+                "stranded temp file: {}",
+                entry.path().display()
+            );
+        }
+    }
+}
+
+/// Mirror `src_url` into a pre-built destination store. The mock object store
+/// has no URL form, so this drives `MirrorOperation` directly — the same steps
+/// `test_helpers::run_mirror` performs for URL destinations.
+async fn mirror_url_to_store(src_url: &str, dst: &StorageRef) {
+    let config = test_storage_config();
+    let src_store =
+        crate::storage::from_url_with_config(src_url, &config).expect("create source backend");
+    let pipeline_config = PipelineConfig::new(4, false, false, false, config, &src_store).await;
+    let operation = MirrorOperation::new(
+        src_store,
+        dst.clone(),
+        /*overwrite=*/ false,
+        None,
+        None,
+        /*allow_mirror_gaps=*/ false,
+        pipeline_config.clone(),
+        /*update_well_known=*/ true,
+    );
+    Pipeline::new(operation, pipeline_config, None)
+        .run()
+        .await
+        .expect("mirror to object store should succeed");
+}
+
+#[tokio::test]
+async fn mirror_to_object_store_end_to_end() {
+    let src_url = file_url_from_path(&testnet_small_archive_path());
+    let dst_dir = TempDir::new().unwrap();
+    let dst = mock_object_store(dst_dir.path());
+
+    mirror_url_to_store(&src_url, &dst).await;
+
+    // .well-known was created through the Storage trait
+    assert!(dst.exists(ROOT_WELL_KNOWN_PATH).await.unwrap());
+
+    // Everything landed at final paths — no stranded temp objects
+    assert_no_tmp_files(dst_dir.path());
+
+    // The backing dir now holds the complete archive; verify it wholesale
+    run_scan(ScanConfig::new(file_url_from_path(dst_dir.path())).verify())
+        .await
+        .expect("mirrored object-store archive should pass a verify scan");
+}
+
+#[tokio::test]
+async fn repair_object_store_restores_deleted_bucket_and_well_known() {
+    // Seed the "bucket" by mirroring the fixture into it
+    let src_url = file_url_from_path(&testnet_small_archive_path());
+    let dst_dir = TempDir::new().unwrap();
+    mirror_url_to_store(&src_url, &mock_object_store(dst_dir.path())).await;
+
+    // Break the archive behind the store's back: drop a bucket file and .well-known
+    let deleted_bucket = delete_first_file(dst_dir.path(), "/bucket-");
+    std::fs::remove_file(dst_dir.path().join(ROOT_WELL_KNOWN_PATH)).unwrap();
+
+    // Repair through a fresh mock store, driving RepairOperation directly —
+    // the same steps `test_helpers::run_repair` performs for URL destinations.
+    let dst = mock_object_store(dst_dir.path());
+    let config = test_storage_config();
+    let src_store =
+        crate::storage::from_url_with_config(&src_url, &config).expect("create source backend");
+    let pipeline_config = PipelineConfig::new(4, false, false, false, config, &src_store).await;
+    let operation = RepairOperation::new(
+        src_store,
+        dst.clone(),
+        None,
+        None,
+        /*dry_run=*/ false,
+        pipeline_config.clone(),
+    );
+    Pipeline::new(operation, pipeline_config, None)
+        .run()
+        .await
+        .expect("repair to object store should succeed");
+
+    assert!(
+        dst.exists(&deleted_bucket).await.unwrap(),
+        "deleted bucket file restored"
+    );
+    assert!(
+        dst.exists(ROOT_WELL_KNOWN_PATH).await.unwrap(),
+        ".well-known restored through the Storage trait"
+    );
+    assert_no_tmp_files(dst_dir.path());
+
+    run_scan(ScanConfig::new(file_url_from_path(dst_dir.path())).verify())
+        .await
+        .expect("repaired archive should pass a verify scan");
 }
 
 #[tokio::test]

--- a/src/tests/object_store_write_test.rs
+++ b/src/tests/object_store_write_test.rs
@@ -27,11 +27,10 @@ use tempfile::TempDir;
 use walkdir::WalkDir;
 
 #[tokio::test]
-async fn mock_object_store_has_object_store_semantics() {
+async fn mock_object_store_is_writable_with_no_base_path() {
     let dir = TempDir::new().unwrap();
     let store = mock_object_store(dir.path());
     assert!(store.supports_writes());
-    assert!(store.uses_atomic_writes());
     assert!(store.get_base_path().is_none());
 }
 
@@ -110,7 +109,7 @@ async fn verified_write_of_corrupt_bucket_leaves_nothing_at_final_path() {
 
 #[cfg(feature = "opendal-s3")]
 #[tokio::test]
-async fn s3_store_is_writable_and_atomic() {
+async fn s3_store_is_writable_with_no_base_path() {
     let store = OpendalStore::s3(
         "test-bucket",
         Some("us-east-1"),
@@ -122,7 +121,6 @@ async fn s3_store_is_writable_and_atomic() {
     )
     .expect("construct S3 store");
     assert!(store.supports_writes());
-    assert!(store.uses_atomic_writes());
     assert!(store.get_base_path().is_none());
 }
 

--- a/src/tests/object_store_write_test.rs
+++ b/src/tests/object_store_write_test.rs
@@ -164,13 +164,10 @@ async fn update_well_known_writes_through_the_storage_trait() {
     let history_path = crate::history_format::checkpoint_path("history", 1023);
 
     // Plant the history file *through the store* (no fs paths).
-    crate::storage::write_buffer_with_cleanup(
-        &store,
-        &history_path,
-        br#"{"currentLedger": 1023}"#.to_vec().into(),
-    )
-    .await
-    .unwrap();
+    store
+        .write(&history_path, br#"{"currentLedger": 1023}"#.to_vec().into())
+        .await
+        .unwrap();
 
     update_well_known_from_history(&store, &history_path, Some("P"))
         .await

--- a/src/tests/object_store_write_test.rs
+++ b/src/tests/object_store_write_test.rs
@@ -1,0 +1,129 @@
+//! Tests for writable object-store (S3/GCS/Azure/B2/Swift) destinations.
+//!
+//! Most tests use `mock_object_store` (see `tests::utils`) — a local-fs-backed
+//! store that presents exactly what a cloud object store presents to the rest
+//! of the code: writable, atomic commit-on-close, and NO filesystem base path.
+//! The backing directory doubles as an inspection window: after operations
+//! complete, the "bucket" contents can be checked as plain files.
+
+use super::utils::{file_url_from_path, mock_object_store, testnet_small_archive_path};
+use crate::storage::{OpendalStore, Storage, StorageRef};
+use crate::test_helpers::{run_mirror, test_storage_config, MirrorConfig};
+use crate::verify::verify_and_write_bucket;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use sha2::{Digest, Sha256};
+use std::io::Write;
+use std::path::Path;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn mock_object_store_has_object_store_semantics() {
+    let dir = TempDir::new().unwrap();
+    let store = mock_object_store(dir.path());
+    assert!(store.supports_writes());
+    assert!(store.uses_atomic_writes());
+    assert!(store.get_base_path().is_none());
+}
+
+/// Gzip `content` into a valid bucket file: the returned archive path embeds
+/// the sha256 of the *decompressed* content, as real bucket files do.
+fn make_bucket(content: &[u8]) -> (String, Vec<u8>) {
+    let hash = hex::encode(Sha256::digest(content));
+    let path = crate::history_format::bucket_path(&hash).unwrap();
+    let mut enc = GzEncoder::new(Vec::new(), Compression::default());
+    enc.write_all(content).unwrap();
+    (path, enc.finish().unwrap())
+}
+
+/// Put `bytes` at `path` inside `dir` so a filesystem source store can serve it.
+fn plant_file(dir: &Path, path: &str, bytes: &[u8]) {
+    let full = dir.join(path);
+    std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+    std::fs::write(&full, bytes).unwrap();
+}
+
+fn fs_store(root: &Path) -> StorageRef {
+    Arc::new(OpendalStore::filesystem(root, &test_storage_config()).expect("create fs store"))
+}
+
+#[tokio::test]
+async fn verified_write_commits_good_bucket_at_final_path_on_object_store() {
+    let src_dir = TempDir::new().unwrap();
+    let dst_dir = TempDir::new().unwrap();
+    let (path, gz) = make_bucket(b"verified bucket content");
+    plant_file(src_dir.path(), &path, &gz);
+
+    let src = fs_store(src_dir.path());
+    let dst = mock_object_store(dst_dir.path());
+    let reader = src.open_reader(&path).await.unwrap();
+
+    verify_and_write_bucket(&path, reader, &dst)
+        .await
+        .expect("verified write should succeed");
+
+    assert!(dst.exists(&path).await.unwrap(), "object at final path");
+    assert!(
+        !dst_dir.path().join(format!("{path}.tmp")).exists(),
+        "no stranded sibling .tmp object"
+    );
+}
+
+#[tokio::test]
+async fn verified_write_of_corrupt_bucket_leaves_nothing_at_final_path() {
+    let src_dir = TempDir::new().unwrap();
+    let dst_dir = TempDir::new().unwrap();
+
+    // Path claims the hash of one content, bytes decompress to another:
+    // valid gzip, wrong hash — must fail verification.
+    let (path, _) = make_bucket(b"content the path claims");
+    let (_, wrong_gz) = make_bucket(b"content actually delivered");
+    plant_file(src_dir.path(), &path, &wrong_gz);
+
+    let src = fs_store(src_dir.path());
+    let dst = mock_object_store(dst_dir.path());
+    let reader = src.open_reader(&path).await.unwrap();
+
+    let err = verify_and_write_bucket(&path, reader, &dst)
+        .await
+        .expect_err("hash mismatch must fail");
+    assert!(err.to_string().contains("Hash mismatch"), "got: {err}");
+
+    assert!(
+        !dst.exists(&path).await.unwrap(),
+        "corrupt data must not be visible at the final path"
+    );
+    assert!(
+        !dst_dir.path().join(format!("{path}.tmp")).exists(),
+        "no stranded sibling .tmp object"
+    );
+}
+
+#[cfg(feature = "opendal-s3")]
+#[tokio::test]
+async fn s3_store_is_writable_and_atomic() {
+    let store = OpendalStore::s3(
+        "test-bucket",
+        Some("us-east-1"),
+        Some("http://127.0.0.1:9"), // never contacted; construction only
+        Some("test-access-key"),
+        Some("test-secret-key"),
+        "some/prefix",
+        &test_storage_config(),
+    )
+    .expect("construct S3 store");
+    assert!(store.supports_writes());
+    assert!(store.uses_atomic_writes());
+    assert!(store.get_base_path().is_none());
+}
+
+#[tokio::test]
+async fn http_destination_is_still_rejected() {
+    let src_url = file_url_from_path(&testnet_small_archive_path());
+    let err = run_mirror(MirrorConfig::new(&src_url, "https://example.org/archive"))
+        .await
+        .expect_err("HTTP destinations must be rejected");
+    let msg = err.to_string();
+    assert!(msg.contains("does not support writes"), "got: {msg}");
+}

--- a/src/tests/repair_op_test.rs
+++ b/src/tests/repair_op_test.rs
@@ -4,8 +4,8 @@
 //! manual mode, dry run, error handling, idempotency, and CLI validation.
 
 use super::utils::{
-    copy_testnet_small_archive, corrupt_ledger_cross_file_hash, file_url_from_path,
-    get_files_by_pattern, start_http_server, testnet_small_archive_path,
+    copy_testnet_small_archive, corrupt_ledger_cross_file_hash, delete_first_file,
+    file_url_from_path, get_files_by_pattern, start_http_server, testnet_small_archive_path,
 };
 use crate::history_format;
 use crate::test_helpers::{
@@ -34,20 +34,6 @@ async fn mirror_testnet_small() -> (String, TempDir, String) {
         .expect("Mirror setup should succeed");
 
     (src_url, dest_dir, dest_url)
-}
-
-/// Delete a specific file pattern from the archive, returns the deleted file path (relative)
-fn delete_first_file(archive_path: &Path, pattern: &str) -> String {
-    let files = get_files_by_pattern(archive_path, pattern);
-    assert!(!files.is_empty(), "No files matching pattern '{pattern}'");
-    let file = &files[0];
-    let relative = file
-        .strip_prefix(archive_path)
-        .unwrap()
-        .to_string_lossy()
-        .replace('\\', "/");
-    std::fs::remove_file(file).expect("Failed to delete file");
-    relative
 }
 
 /// Corrupt a bucket file with garbage bytes (invalid gzip)

--- a/src/tests/staged_writer_test.rs
+++ b/src/tests/staged_writer_test.rs
@@ -1,0 +1,126 @@
+//! Unit tests for the StagedWriter commit/abort contract, per backend flavor.
+//!
+//! Three flavors are exercised through their public constructors:
+//! - mock object store (atomic commit-on-close, no base path)
+//! - plain filesystem (fs-staged: `.tmp` sibling + rename)
+//! - filesystem with atomic_file_writes (OpenDAL atomic_write_dir)
+
+use super::utils::mock_object_store;
+use crate::storage::{OpendalStore, StorageConfig, StorageRef};
+use crate::test_helpers::test_storage_config;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::TempDir;
+
+// mock_object_store (tests/utils.rs) already returns a StorageRef.
+
+fn plain_fs_store(root: &Path) -> StorageRef {
+    // test_storage_config() has atomic_file_writes = false
+    Arc::new(OpendalStore::filesystem(root, &test_storage_config()).unwrap())
+}
+
+fn atomic_fs_store(root: &Path) -> StorageRef {
+    let config = StorageConfig::new(
+        3,
+        Duration::from_millis(100),
+        Duration::from_secs(30),
+        64,
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+        0,
+        true, // atomic_file_writes
+    );
+    Arc::new(OpendalStore::filesystem(root, &config).unwrap())
+}
+
+const OBJ: &str = "bucket/ab/cd/ef/bucket-test.xdr.gz";
+
+/// Every regular file under `root`, whatever it is named. Used to catch staged
+/// data an abort failed to clean up, without depending on how a backend names
+/// its temp files.
+fn files_under(root: &Path) -> Vec<PathBuf> {
+    walkdir::WalkDir::new(root)
+        .into_iter()
+        .map(Result::unwrap)
+        .filter(|e| e.file_type().is_file())
+        .map(|e| e.path().to_path_buf())
+        .collect()
+}
+
+async fn write_and_commit(store: &StorageRef) -> u64 {
+    let mut w = store.open_staged_writer(OBJ).await.unwrap();
+    w.write(b"hello ".to_vec().into()).await.unwrap();
+    w.write(b"world".to_vec().into()).await.unwrap();
+    w.commit().await.unwrap()
+}
+
+#[tokio::test]
+async fn commit_makes_data_visible_on_all_writable_flavors() {
+    for store_fn in [mock_object_store, plain_fs_store, atomic_fs_store] {
+        let dir = TempDir::new().unwrap();
+        let store = store_fn(dir.path());
+        let bytes = write_and_commit(&store).await;
+        assert_eq!(bytes, 11, "commit returns bytes written");
+        let got = crate::storage::download_buffer(&store, OBJ)
+            .await
+            .unwrap()
+            .to_vec();
+        assert_eq!(got, b"hello world");
+        assert!(
+            !dir.path().join(format!("{OBJ}.tmp")).exists(),
+            "no stranded .tmp sibling after commit"
+        );
+    }
+}
+
+#[tokio::test]
+async fn abort_leaves_nothing_at_final_path_on_all_writable_flavors() {
+    for store_fn in [mock_object_store, plain_fs_store, atomic_fs_store] {
+        let dir = TempDir::new().unwrap();
+        let store = store_fn(dir.path());
+        let mut w = store.open_staged_writer(OBJ).await.unwrap();
+        w.write(b"partial garbage".to_vec().into()).await.unwrap();
+        w.abort().await;
+        assert!(
+            !store.exists(OBJ).await.unwrap(),
+            "nothing visible after abort"
+        );
+        assert!(
+            !dir.path().join(format!("{OBJ}.tmp")).exists(),
+            "fs-staged abort removes the .tmp sibling"
+        );
+        assert_eq!(
+            files_under(dir.path()),
+            Vec::<PathBuf>::new(),
+            "abort leaves no staged data behind anywhere under the root"
+        );
+    }
+}
+
+#[tokio::test]
+async fn drop_without_commit_leaves_nothing_at_final_path() {
+    for store_fn in [mock_object_store, plain_fs_store, atomic_fs_store] {
+        let dir = TempDir::new().unwrap();
+        let store = store_fn(dir.path());
+        {
+            let mut w = store.open_staged_writer(OBJ).await.unwrap();
+            w.write(b"never committed".to_vec().into()).await.unwrap();
+            // dropped here without commit()
+        }
+        assert!(!store.exists(OBJ).await.unwrap());
+    }
+}
+
+#[tokio::test]
+async fn read_only_backend_rejects_staged_writer() {
+    let store =
+        crate::storage::from_url_with_config("https://example.org/archive", &test_storage_config())
+            .unwrap();
+    // StagedWriter is not Debug (it wraps an OpenDAL Writer), so match instead
+    // of expect_err().
+    let Err(err) = store.open_staged_writer(OBJ).await else {
+        panic!("HTTP must reject writes");
+    };
+    assert!(err.to_string().contains("not supported"), "got: {err}");
+}

--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -155,6 +155,20 @@ pub fn set_network_passphrase(archive_dir: &Path, passphrase: &str) {
     .expect("write .well-known");
 }
 
+/// Delete a specific file pattern from the archive, returns the deleted file path (relative)
+pub(crate) fn delete_first_file(archive_path: &Path, pattern: &str) -> String {
+    let files = get_files_by_pattern(archive_path, pattern);
+    assert!(!files.is_empty(), "No files matching pattern '{pattern}'");
+    let file = &files[0];
+    let relative = file
+        .strip_prefix(archive_path)
+        .unwrap()
+        .to_string_lossy()
+        .replace('\\', "/");
+    std::fs::remove_file(file).expect("Failed to delete file");
+    relative
+}
+
 /// Get all files of a specific type from the archive
 pub fn get_files_by_pattern(archive_path: &Path, pattern: &str) -> Vec<PathBuf> {
     let mut files = Vec::new();

--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -9,7 +9,8 @@
 
 #![allow(dead_code)] // Test utilities may not all be used in every test run
 
-use crate::storage::Error as StorageError;
+use crate::history_format::{CHECKPOINT_FREQUENCY, FIRST_SCP_CHECKPOINT};
+use crate::storage::{Error as StorageError, OpendalStore, StorageRef};
 use crate::utils::{NON_STANDARD_RETRYABLE_HTTP_ERRORS, STANDARD_RETRYABLE_HTTP_ERRORS};
 use crate::xdr_verify::{
     parse_ledger_header_entries_for_checkpoint, parse_result_entries_for_checkpoint,
@@ -17,9 +18,9 @@ use crate::xdr_verify::{
 };
 use axum::{routing::get_service, Router};
 use normalize_path::NormalizePath;
+use opendal::{services::Fs, Operator};
 use path_slash::PathExt;
-use std::collections::BTreeMap;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -29,6 +30,28 @@ use tokio::net::TcpListener;
 use tower_http::services::ServeDir;
 use url::Url;
 use walkdir::WalkDir;
+
+//=============================================================================
+// Mock Storage Backends
+//=============================================================================
+
+/// Build a mock cloud object store: writable, atomic commit-on-close, and no
+/// filesystem base path exposed — the exact surface S3/GCS present to the
+/// rest of the code. Backed by a bare local fs operator with
+/// `atomic_write_dir` (no layer stack — mocks don't need timeouts or
+/// concurrency limits), so the backing directory doubles as an inspection
+/// window: tests can read, delete, or corrupt the "bucket" contents as plain
+/// files behind the store's back.
+pub(crate) fn mock_object_store(root: &Path) -> StorageRef {
+    let root_str = root.normalize().to_string_lossy().to_string();
+    let builder = Fs::default().root(&root_str).atomic_write_dir(&root_str);
+    let operator = Operator::new(builder)
+        .expect("build mock object store operator")
+        .finish();
+    Arc::new(OpendalStore::from_operator(
+        operator, "", None, /*writable=*/ true, /*atomic_writes=*/ true,
+    ))
+}
 
 //=============================================================================
 // Test Archive Helpers
@@ -51,7 +74,6 @@ pub fn testnet_small_archive_path() -> PathBuf {
 // The fixture straddles the SCP boundary (`FIRST_SCP_CHECKPOINT`, the first
 // pubnet checkpoint that archives an scp): four checkpoints below it (in the
 // gap, no scp) and four at/above it (scp present).
-use crate::history_format::{CHECKPOINT_FREQUENCY, FIRST_SCP_CHECKPOINT};
 
 /// Lowest checkpoint in the fixture — four checkpoints below the boundary.
 pub const PUBNET_SCP_BOUNDARY_LOW: u32 = FIRST_SCP_CHECKPOINT - 4 * CHECKPOINT_FREQUENCY;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -671,12 +671,9 @@ pub async fn update_well_known_from_history(
             "Failed to stamp network passphrase into {history_path}: {e}"
         ))
     })?;
-    crate::storage::write_buffer_with_cleanup(
-        store,
-        crate::history_format::ROOT_WELL_KNOWN_PATH,
-        contents.into(),
-    )
-    .await
+    store
+        .write(crate::history_format::ROOT_WELL_KNOWN_PATH, contents.into())
+        .await
 }
 
 /// Compute checkpoint bounds using a pre-fetched source checkpoint

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -622,45 +622,61 @@ pub async fn fetch_source_network_passphrase(
     }
 }
 
-/// Write `src_history_file` (a per-checkpoint history file) to `dst_well_known`,
-/// stamping in `network_passphrase` when `Some` so the mirrored/repaired archive
-/// root carries the network identity that per-checkpoint history files omit
-/// (only the archive root `.well-known` does). When `None` (the source archive
-/// itself had no passphrase) the file is copied verbatim. The caller is
-/// responsible for ensuring the destination parent directory exists.
-pub async fn write_well_known_from_history(
-    src_history_file: &std::path::Path,
-    dst_well_known: &std::path::Path,
+/// Stamp `network_passphrase` into history-file JSON bytes when needed, so a
+/// mirrored/repaired archive root carries the network identity that
+/// per-checkpoint history files omit (only the archive root `.well-known`
+/// does). Returns the bytes unchanged when no passphrase is given or the same
+/// value is already present; errors when the bytes are not a JSON object.
+pub(crate) fn stamp_network_passphrase(
+    contents: Vec<u8>,
     network_passphrase: Option<&str>,
-) -> std::io::Result<()> {
-    // Start from the source bytes; only replace them when the passphrase
-    // actually needs stamping (source has one and the history file lacks it or
-    // carries a different value).
-    let mut contents = tokio::fs::read(src_history_file).await?;
-
-    if let Some(passphrase) = network_passphrase {
-        let mut value: serde_json::Value = serde_json::from_slice(&contents)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-        let already_present =
-            value.get("networkPassphrase").and_then(|v| v.as_str()) == Some(passphrase);
-        if !already_present {
-            let obj = value.as_object_mut().ok_or_else(|| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    "history file is not a JSON object",
-                )
-            })?;
-            obj.insert(
-                "networkPassphrase".to_string(),
-                serde_json::Value::String(passphrase.to_string()),
-            );
-            contents = serde_json::to_vec_pretty(&value)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-            contents.push(b'\n');
-        }
+) -> std::io::Result<Vec<u8>> {
+    let Some(passphrase) = network_passphrase else {
+        return Ok(contents);
+    };
+    let mut value: serde_json::Value = serde_json::from_slice(&contents)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let already_present =
+        value.get("networkPassphrase").and_then(|v| v.as_str()) == Some(passphrase);
+    if already_present {
+        return Ok(contents);
     }
+    let obj = value.as_object_mut().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "history file is not a JSON object",
+        )
+    })?;
+    obj.insert(
+        "networkPassphrase".to_string(),
+        serde_json::Value::String(passphrase.to_string()),
+    );
+    let mut out = serde_json::to_vec_pretty(&value)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    out.push(b'\n');
+    Ok(out)
+}
 
-    tokio::fs::write(dst_well_known, contents).await
+/// Copy `history_path` (already present on `store`) to
+/// `.well-known/stellar-history.json` on the same store, stamping the network
+/// passphrase when provided. Works on any writable backend.
+pub async fn update_well_known_from_history(
+    store: &crate::storage::StorageRef,
+    history_path: &str,
+    network_passphrase: Option<&str>,
+) -> Result<(), crate::storage::Error> {
+    let buffer = crate::storage::download_buffer(store, history_path).await?;
+    let contents = stamp_network_passphrase(buffer.to_vec(), network_passphrase).map_err(|e| {
+        crate::storage::Error::fatal(format!(
+            "Failed to stamp network passphrase into {history_path}: {e}"
+        ))
+    })?;
+    crate::storage::write_buffer_with_cleanup(
+        store,
+        crate::history_format::ROOT_WELL_KNOWN_PATH,
+        contents.into(),
+    )
+    .await
 }
 
 /// Compute checkpoint bounds using a pre-fetched source checkpoint

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -4,11 +4,11 @@
 //! filename and verified against the decompressed content.
 
 use crate::history_format::bucket_hash_from_path;
-use crate::storage::{from_opendal_error, Error as StorageError, StorageRef};
+use crate::storage::{from_opendal_error, Error as StorageError, StagedWriter, StorageRef};
 use async_compression::tokio::bufread::GzipDecoder;
 use bytes::Bytes;
 use futures_util::StreamExt;
-use opendal::{Reader, Writer};
+use opendal::Reader;
 use sha2::{Digest, Sha256};
 use tokio::io::{AsyncReadExt, BufReader};
 use tracing::debug;
@@ -16,16 +16,16 @@ use tracing::debug;
 const HASH_BUFFER_SIZE: usize = 64 * 1024;
 const CHANNEL_CAPACITY: usize = 64;
 
-/// Decompress and hash the given reader's content and verify it against the expected hash.
-/// If `writer` is provided, compressed bytes are written to it while verifying.
+/// Decompress and hash the given reader's content and verify it against the expected hash,
+/// returning the number of decompressed bytes.
+///
+/// If `staged` is provided, compressed bytes are streamed into it while verifying; the
+/// staged write is not committed or aborted here — that is the caller's decision.
 async fn verify_bucket_maybe_write(
     path: &str,
     reader: Reader,
-    writer: Option<Writer>,
-) -> Result<(), StorageError> {
-    let bucket_phase = crate::phase!(crate::metrics::Phase::BucketStream);
-    use futures_util::SinkExt;
-
+    mut staged: Option<&mut StagedWriter>,
+) -> Result<u64, StorageError> {
     let expected = bucket_hash_from_path(path)
         .ok_or_else(|| StorageError::fatal(format!("Invalid bucket path: {}", path)))?;
 
@@ -61,19 +61,15 @@ async fn verify_bucket_maybe_write(
     });
 
     futures_util::pin_mut!(stream);
-    let mut sink = writer.map(|w| w.into_sink());
     let mut streaming_error: Option<StorageError> = None;
 
     while let Some(result) = stream.next().await {
         match result {
             Ok(buffer) => {
                 // Write to destination if provided
-                if let Some(ref mut s) = sink {
-                    if let Err(e) = s.send(buffer.clone()).await {
-                        streaming_error = Some(from_opendal_error(
-                            e,
-                            &format!("Failed to write to {}", path),
-                        ));
+                if let Some(w) = staged.as_deref_mut() {
+                    if let Err(e) = w.write(buffer.clone()).await {
+                        streaming_error = Some(e);
                         break;
                     }
                 }
@@ -112,57 +108,48 @@ async fn verify_bucket_maybe_write(
         .map_err(|e| StorageError::retry(format!("Failed to decompress {}: {}", path, e)))?;
 
     if actual != expected {
-        // Don't close sink - avoids committing corrupt data on atomic backends
+        // Don't commit — caller aborts the staged write.
         return Err(StorageError::fatal(format!(
             "Hash mismatch for {}: expected {}, got {}",
             path, expected, actual
         )));
     }
 
-    if let Some(mut s) = sink {
-        s.close()
-            .await
-            .map_err(|e| from_opendal_error(e, &format!("Failed to close {}", path)))?;
-    }
+    Ok(decompressed_bytes)
+}
 
+/// Verify a bucket file's hash (scan operation) — stream + hash, no write.
+pub async fn verify_bucket_stream(path: &str, reader: Reader) -> Result<(), StorageError> {
+    debug!("Verifying bucket hash for {}", path);
+    let bucket_phase = crate::phase!(crate::metrics::Phase::BucketStream);
+    let decompressed_bytes = verify_bucket_maybe_write(path, reader, None).await?;
     bucket_phase.record_file(decompressed_bytes);
-
     Ok(())
 }
 
-/// Verify a bucket file's hash (scan operation).
-///
-/// Delegates to the production async streaming path
-/// ([`verify_bucket_maybe_write`] with no writer), the shipped decode used by
-/// scan-verify.
-pub async fn verify_bucket_stream(path: &str, reader: Reader) -> Result<(), StorageError> {
-    debug!("Verifying bucket hash for {}", path);
-    verify_bucket_maybe_write(path, reader, None).await
-}
-
-/// Verify and write a bucket file (mirror operation).
-/// Hash is verified before committing the write.
-///
-/// On non-atomic backends the compressed stream is written to a `.tmp`
-/// sibling and renamed to `path` only after the hash verifies — the same
-/// scheme as `verify_and_write_xdr` — so a failed or interrupted write never
-/// disturbs a pre-existing file at `path`. Atomic backends commit on
-/// `close()` internally.
+/// Verify and write a bucket file (mirror/repair). The staged write is
+/// committed only after the hash verifies; on any failure it is aborted,
+/// so nothing becomes visible at the destination path.
 pub async fn verify_and_write_bucket(
     path: &str,
     reader: Reader,
     dst_store: &StorageRef,
 ) -> Result<(), StorageError> {
     debug!("Verifying and writing bucket {}", path);
-    let write_path: String = if dst_store.uses_atomic_writes() {
-        path.to_string()
-    } else {
-        format!("{path}.tmp")
-    };
-    let writer = dst_store.open_writer(&write_path).await?;
-    if let Err(e) = verify_bucket_maybe_write(path, reader, Some(writer)).await {
-        crate::xdr_verify::cleanup_non_atomic_partial_write(&write_path, dst_store).await;
-        return Err(e);
+    // Opening the destination is not part of the streaming phase.
+    let mut staged = dst_store.open_staged_writer(path).await?;
+    // The phase spans streaming and the commit that makes the bytes visible;
+    // the file is counted only once both have succeeded.
+    let bucket_phase = crate::phase!(crate::metrics::Phase::BucketStream);
+    match verify_bucket_maybe_write(path, reader, Some(&mut staged)).await {
+        Ok(decompressed_bytes) => {
+            staged.commit().await?;
+            bucket_phase.record_file(decompressed_bytes);
+            Ok(())
+        }
+        Err(e) => {
+            staged.abort().await;
+            Err(e)
+        }
     }
-    crate::xdr_verify::commit_non_atomic_write(dst_store, &write_path, path).await
 }

--- a/src/xdr_verify.rs
+++ b/src/xdr_verify.rs
@@ -17,11 +17,11 @@
 //! - Cross-checkpoint hash chain: first ledger's `previous_ledger_hash` matches prior checkpoint's last hash
 
 use crate::history_format::{self, CHECKPOINT_FREQUENCY, GENESIS_CHECKPOINT_LEDGER};
-use crate::storage::{from_opendal_error, Error as StorageError, StorageRef};
+use crate::storage::{from_opendal_error, Error as StorageError, StagedWriter, StorageRef};
 use async_compression::tokio::bufread::GzipDecoder;
 use bytes::Bytes;
 use futures_util::StreamExt;
-use opendal::{Reader, Writer};
+use opendal::Reader;
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap};
 use std::io::Cursor;
@@ -1072,11 +1072,10 @@ pub async fn parse_ledger_header_stream(
     reader: Reader,
 ) -> Result<BTreeMap<u32, LedgerHeaderVerificationData>, StorageError> {
     let cp = history_format::checkpoint_from_path(path);
-    Ok(decompress_then(path, reader, None, move |b| {
+    decompress_then(path, reader, None, move |b| {
         parse_ledger_header_entries_for_checkpoint(b, cp)
     })
-    .await?
-    .0)
+    .await
 }
 
 /// Decompress a gzipped result file from a reader and parse it.
@@ -1086,11 +1085,10 @@ pub async fn parse_results_stream(
     reader: Reader,
 ) -> Result<BTreeMap<u32, Hash>, StorageError> {
     let cp = history_format::checkpoint_from_path(path);
-    Ok(decompress_then(path, reader, None, move |b| {
+    decompress_then(path, reader, None, move |b| {
         parse_result_entries_for_checkpoint(b, cp)
     })
-    .await?
-    .0)
+    .await
 }
 
 /// Parse decompressed transaction XDR data, computing content hashes per ledger.
@@ -1176,18 +1174,15 @@ pub async fn parse_transactions_stream(
     reader: Reader,
 ) -> Result<BTreeMap<u32, Hash>, StorageError> {
     let cp = history_format::checkpoint_from_path(path);
-    Ok(decompress_then(path, reader, None, move |b| {
+    decompress_then(path, reader, None, move |b| {
         parse_transaction_entries_for_checkpoint(b, cp)
     })
-    .await?
-    .0)
+    .await
 }
 
 /// Decompress a gzipped SCP file from a reader and validate its frame structure.
 pub async fn parse_scp_stream(path: &str, reader: Reader) -> Result<(), StorageError> {
-    decompress_then(path, reader, None, parse_scp_entries)
-        .await
-        .map(|(parsed, _sink)| parsed)
+    decompress_then(path, reader, None, parse_scp_entries).await
 }
 
 /// Result of parsing an XDR archive file during a verified mirror write.
@@ -1201,28 +1196,26 @@ pub enum XdrParseResult {
 }
 
 /// Streaming core for every XDR file: read gzipped bytes from `reader`,
-/// optionally tee the still-compressed bytes to `writer`, gzip-decode to a
+/// optionally tee the still-compressed bytes into `staged`, gzip-decode to a
 /// buffer, and run `parse` on it ALL inside one spawned task (gzip decode AND
 /// the XDR parse/hash leave the orchestration task; the caller only feeds
-/// chunks). Returns the parse result alongside the **unclosed** sink (`None`
-/// when `writer` is `None`); the caller commits a write only after `parse`
-/// succeeds (parse-before-commit), so a parse failure never leaves committed
-/// corrupt data.
+/// chunks). The staged write is never committed or aborted here; the caller
+/// commits only after `parse` succeeds.
 ///
 /// Error classes (the pipeline retries only `ErrorClass::Retry`): gzip framing
 /// → `retry`; XDR parse/hash → whatever `parse` returns (`fatal` in practice);
-/// storage I/O → opendal-classified; channel-closed or task panic → `fatal`.
+/// source reads → opendal-classified; destination staging I/O →
+/// backend-classified; channel-closed or task panic → `fatal`.
 async fn decompress_then<T>(
     path: &str,
     reader: Reader,
-    writer: Option<Writer>,
+    mut staged: Option<&mut StagedWriter>,
     parse: impl FnOnce(&[u8]) -> Result<T, StorageError> + Send + 'static,
-) -> Result<(T, Option<opendal::BufferSink>), StorageError>
+) -> Result<T, StorageError>
 where
     T: Send + 'static,
 {
     let decompress_phase = crate::phase!(crate::metrics::Phase::XdrDecompress);
-    use futures_util::SinkExt;
 
     let stream = reader
         .into_stream(..)
@@ -1257,18 +1250,14 @@ where
     });
 
     futures_util::pin_mut!(stream);
-    let mut sink = writer.map(|w| w.into_sink());
     let mut streaming_error: Option<StorageError> = None;
 
     while let Some(result) = stream.next().await {
         match result {
             Ok(buffer) => {
-                if let Some(ref mut s) = sink {
-                    if let Err(e) = s.send(buffer.clone()).await {
-                        streaming_error = Some(from_opendal_error(
-                            e,
-                            &format!("failed to write to {}", path),
-                        ));
+                if let Some(w) = staged.as_deref_mut() {
+                    if let Err(e) = w.write(buffer.clone()).await {
+                        streaming_error = Some(e);
                         break;
                     }
                 }
@@ -1298,7 +1287,7 @@ where
 
     if let Some(err) = streaming_error {
         task.abort();
-        return Err(err); // sink dropped here unclosed — caller cleans up
+        return Err(err); // caller aborts the staged write
     }
 
     let (parsed, len) = task.await.map_err(|e| {
@@ -1310,66 +1299,7 @@ where
 
     decompress_phase.record_file(len);
 
-    Ok((parsed, sink))
-}
-
-/// Remove a partially-written file after a verified-write fails.
-///
-/// - **Atomic backends**: no-op — dropping the sink without `close()` already
-///   prevents the temp-to-target rename, so nothing landed at `path`.
-/// - **Non-atomic backends**: data sent via `sink.send()` is written directly
-///   to `path`, so the abandoned partial file is `tokio::fs::remove_file`'d.
-///   `NotFound` is silently tolerated; other errors are warned but not raised.
-///
-/// Safe to call on backends without a base path (e.g. HTTP) — does nothing.
-pub(crate) async fn cleanup_non_atomic_partial_write(path: &str, dst_store: &StorageRef) {
-    if dst_store.uses_atomic_writes() {
-        return;
-    }
-    if let Some(base_path) = dst_store.get_base_path() {
-        let file_path = base_path.join(path);
-        if let Err(remove_err) = tokio::fs::remove_file(&file_path).await {
-            if remove_err.kind() != std::io::ErrorKind::NotFound {
-                warn!(
-                    "failed to remove partially written file {} after error: {}",
-                    file_path.display(),
-                    remove_err
-                );
-            }
-        }
-    }
-}
-
-/// Commit a verified write performed at `write_path` to its final `path`.
-///
-/// - **Atomic backends**: `write_path == path` (the backend already committed
-///   via its own temp-to-target rename on `close()`) — no-op.
-/// - **Non-atomic backends**: rename the `.tmp` sibling to the final path.
-///   The temp is removed on rename failure to avoid leaking `.tmp` files;
-///   the pre-existing file at `path` (if any) is only replaced by the rename,
-///   never deleted on failure.
-pub(crate) async fn commit_non_atomic_write(
-    dst_store: &StorageRef,
-    write_path: &str,
-    path: &str,
-) -> Result<(), StorageError> {
-    if write_path == path {
-        return Ok(());
-    }
-    if let Some(base) = dst_store.get_base_path() {
-        let tmp_full = base.join(write_path);
-        let final_full = base.join(path);
-        if let Err(e) = tokio::fs::rename(&tmp_full, &final_full).await {
-            let _ = tokio::fs::remove_file(&tmp_full).await;
-            return Err(StorageError::fatal(format!(
-                "failed to rename {} to {}: {}",
-                tmp_full.display(),
-                final_full.display(),
-                e
-            )));
-        }
-    }
-    Ok(())
+    Ok(parsed)
 }
 
 /// Decompress, verify XDR structure, and write to destination in a single
@@ -1382,11 +1312,6 @@ pub(crate) async fn commit_non_atomic_write(
 /// - **scp** → `XdrParseResult::None` (frame structure validated, no hashes)
 /// - other → `XdrParseResult::None`
 ///
-/// Atomicity: the sink is closed (committing the write) only after the
-/// in-memory decompressed payload parses successfully. On parse or
-/// decompression failure the sink is dropped without close; for non-atomic
-/// backends the partial file is additionally removed on disk.
-///
 /// Caller passes the returned hashes to
 /// [`XdrVerificationManager::record_*`](XdrVerificationManager) for
 /// cross-file verification.
@@ -1395,25 +1320,11 @@ pub async fn verify_and_write_xdr(
     reader: Reader,
     dst_store: &StorageRef,
 ) -> Result<XdrParseResult, StorageError> {
-    use futures_util::SinkExt;
-
-    // For non-atomic backends, write to a `.tmp` sibling first and rename to
-    // `path` only after parsing succeeds. This prevents a partial file from
-    // being visible at the final path if the process is killed mid-stream
-    // (SIGKILL, OOM), which would otherwise cause `pre_check()` to skip
-    // re-downloading on resume. Atomic backends handle this internally.
-    let write_path: String = if dst_store.uses_atomic_writes() {
-        path.to_string()
-    } else {
-        format!("{path}.tmp")
-    };
-
-    let writer = dst_store.open_writer(&write_path).await?;
+    let mut staged = dst_store.open_staged_writer(path).await?;
 
     // Decode + parse run together in the spawned task. The closure captures
-    // only owned data (the logical `path` for file-type detection and `cp`) so
-    // it is `Send + 'static`. Classify on `path`, NOT `write_path`, so a `.tmp`
-    // sibling is never misread as an unrecognized type.
+    // only owned data (the logical `path` for file-type detection and `cp`)
+    // so it is `Send + 'static`.
     let cp = history_format::checkpoint_from_path(path);
     let path_owned = path.to_string();
     let parse = move |b: &[u8]| -> Result<XdrParseResult, StorageError> {
@@ -1430,23 +1341,14 @@ pub async fn verify_and_write_xdr(
         }
     };
 
-    match decompress_then(&write_path, reader, Some(writer), parse).await {
-        Ok((result, sink)) => {
-            // Parse passed — close the sink to commit the write.
-            if let Some(mut s) = sink {
-                s.close().await.map_err(|e| {
-                    from_opendal_error(e, &format!("failed to close {}", write_path))
-                })?;
-            }
-            // Non-atomic FS backend: rename the temp to the final path.
-            commit_non_atomic_write(dst_store, &write_path, path).await?;
+    match decompress_then(path, reader, Some(&mut staged), parse).await {
+        Ok(result) => {
+            staged.commit().await?;
             Ok(result)
         }
         Err(e) => {
-            // Decode or parse failed — `decompress_then` dropped the sink unclosed
-            // (no commit on atomic backends). On non-atomic backends partial data
-            // may be on disk via send(), so remove it.
-            cleanup_non_atomic_partial_write(&write_path, dst_store).await;
+            // Decode/parse/stream failure — nothing may remain visible.
+            staged.abort().await;
             Err(e)
         }
     }
@@ -1462,13 +1364,6 @@ pub async fn verify_and_write_xdr(
 /// - xdr per-cp file + manager → [`verify_and_write_xdr`] + record into manager
 /// - everything else (and the manager-off path) → plain
 ///   [`crate::storage::Storage::copy_from_reader`]
-///
-/// Every branch writes via a temp artifact (`.tmp` sibling on non-atomic
-/// backends, the backend's own temp-to-target rename on atomic ones) and
-/// cleans up after itself on failure — a failed fetch never disturbs a
-/// pre-existing file at `path`. Repair's failed-list mode relies on this:
-/// it force-fetches listed files that may still be valid on dst, and a
-/// transient src failure must not destroy that copy.
 pub async fn fetch_verify_and_write(
     src_store: &StorageRef,
     dst_store: &StorageRef,


### PR DESCRIPTION
**What**

- Enable the cloud object-store backends (`s3://`, `gcs://` etc.) as writable destinations for `mirror` and `repair`; previously they were read-only and any write attempt failed with "Destination does not support writes".
- Restore and update `.well-known/stellar-history.json` through the `Storage` trait instead of local-filesystem paths, so it works against any writable backend.
- Consolidate every archive write behind a new `StagedWriter` primitive owned by `OpendalStore`, with explicit `commit()`/`abort()`. Object stores and fs-with-`atomic_write_dir` commit on close; plain fs stages at a `.tmp` sibling and renames. Verified writes (bucket hash, XDR parse) commit only after verification passes.
- Retire the old write surface: `open_writer`, `uses_atomic_writes`, `write_buffer_with_cleanup`, `cleanup_partial_file`, and the caller-side `.tmp` commit/cleanup helpers in `verify.rs`/`xdr_verify.rs`.

**Why**

- Repair and mirror archives hosted directly in S3.
- Flipping the writable flag alone wasn't enough — two write paths silently assumed a local filesystem: the caller-side `.tmp`+rename scheme for verified writes, and `.well-known` handling via `get_base_path()` + `tokio::fs`. Both no-op'd or misbehaved on object stores.
- The writing path previously was fragmented, having one interface inside store  makes "nothing visible until commit" hold on every backend, and is a nice clean up.